### PR TITLE
Sanitize error messages returned to IPC clients

### DIFF
--- a/internal/ipc/errors.go
+++ b/internal/ipc/errors.go
@@ -1,0 +1,37 @@
+package ipc
+
+// clientErrorMessage returns a generic, client-safe error message for the given
+// error code. Internal details are never exposed to IPC clients — they are
+// logged server-side via zerolog instead.
+func clientErrorMessage(code string) string {
+	switch code {
+	case "INVALID_REQUEST":
+		return "Invalid request"
+	case "INVALID_REQUEST_TYPE":
+		return "Invalid request type"
+	case "AUTHENTICATION_FAILED":
+		return "Authentication failed"
+	case "SESSION_CHECK_FAILED":
+		return "Session check failed"
+	case "SESSION_REFRESH_FAILED":
+		return "Session refresh failed"
+	case "SESSION_REVOCATION_FAILED":
+		return "Session revocation failed"
+	case "POLICY_DENIED":
+		return "Access denied by policy"
+	case "NO_PROVIDER":
+		return "No suitable authentication provider found"
+	case "DEVICE_FLOW_FAILED":
+		return "Device authorization flow failed"
+	case "SESSION_NOT_FOUND":
+		return "Session not found"
+	case "SESSION_EXPIRED":
+		return "Session has expired"
+	case "PROVIDER_NOT_FOUND":
+		return "Authentication provider not available"
+	case "REFRESH_FAILED":
+		return "Token refresh failed"
+	default:
+		return "An error occurred"
+	}
+}

--- a/internal/ipc/errors_test.go
+++ b/internal/ipc/errors_test.go
@@ -1,0 +1,45 @@
+package ipc
+
+import "testing"
+
+func TestClientErrorMessageKnownCodes(t *testing.T) {
+	tests := []struct {
+		code     string
+		expected string
+	}{
+		{"INVALID_REQUEST", "Invalid request"},
+		{"INVALID_REQUEST_TYPE", "Invalid request type"},
+		{"AUTHENTICATION_FAILED", "Authentication failed"},
+		{"SESSION_CHECK_FAILED", "Session check failed"},
+		{"SESSION_REFRESH_FAILED", "Session refresh failed"},
+		{"SESSION_REVOCATION_FAILED", "Session revocation failed"},
+		{"POLICY_DENIED", "Access denied by policy"},
+		{"NO_PROVIDER", "No suitable authentication provider found"},
+		{"DEVICE_FLOW_FAILED", "Device authorization flow failed"},
+		{"SESSION_NOT_FOUND", "Session not found"},
+		{"SESSION_EXPIRED", "Session has expired"},
+		{"PROVIDER_NOT_FOUND", "Authentication provider not available"},
+		{"REFRESH_FAILED", "Token refresh failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			got := clientErrorMessage(tt.code)
+			if got != tt.expected {
+				t.Errorf("clientErrorMessage(%q) = %q, want %q", tt.code, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClientErrorMessageUnknownCode(t *testing.T) {
+	unknownCodes := []string{"", "UNKNOWN", "something_random", "invalid_request"}
+	for _, code := range unknownCodes {
+		t.Run(code, func(t *testing.T) {
+			got := clientErrorMessage(code)
+			if got != "An error occurred" {
+				t.Errorf("clientErrorMessage(%q) = %q, want %q", code, got, "An error occurred")
+			}
+		})
+	}
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -257,7 +257,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 			Err(err).
 			Str("request_type", request.Type).
 			Msg("Invalid IPC request")
-		s.sendErrorResponse(conn, "INVALID_REQUEST", err.Error())
+		s.sendErrorResponse(conn, "INVALID_REQUEST", clientErrorMessage("INVALID_REQUEST"))
 		return
 	}
 
@@ -292,10 +292,13 @@ func (s *Server) handleRequest(request *Request) *Response {
 	case "revoke_session":
 		return s.handleRevokeSession(request)
 	default:
+		log.Warn().
+			Str("request_type", request.Type).
+			Msg("Unknown request type")
 		return &Response{
 			Success:      false,
 			ErrorCode:    "INVALID_REQUEST_TYPE",
-			ErrorMessage: fmt.Sprintf("Unknown request type: %s", request.Type),
+			ErrorMessage: clientErrorMessage("INVALID_REQUEST_TYPE"),
 		}
 	}
 }
@@ -326,7 +329,7 @@ func (s *Server) handleAuthenticate(request *Request) *Response {
 		return &Response{
 			Success:      false,
 			ErrorCode:    "AUTHENTICATION_FAILED",
-			ErrorMessage: err.Error(),
+			ErrorMessage: clientErrorMessage("AUTHENTICATION_FAILED"),
 		}
 	}
 
@@ -370,7 +373,7 @@ func (s *Server) handleCheckSession(request *Request) *Response {
 		return &Response{
 			Success:      false,
 			ErrorCode:    "SESSION_CHECK_FAILED",
-			ErrorMessage: err.Error(),
+			ErrorMessage: clientErrorMessage("SESSION_CHECK_FAILED"),
 		}
 	}
 
@@ -403,7 +406,7 @@ func (s *Server) handleRefreshSession(request *Request) *Response {
 		return &Response{
 			Success:      false,
 			ErrorCode:    "SESSION_REFRESH_FAILED",
-			ErrorMessage: err.Error(),
+			ErrorMessage: clientErrorMessage("SESSION_REFRESH_FAILED"),
 		}
 	}
 
@@ -434,7 +437,7 @@ func (s *Server) handleRevokeSession(request *Request) *Response {
 		return &Response{
 			Success:      false,
 			ErrorCode:    "SESSION_REVOCATION_FAILED",
-			ErrorMessage: err.Error(),
+			ErrorMessage: clientErrorMessage("SESSION_REVOCATION_FAILED"),
 		}
 	}
 

--- a/internal/ipc/server_coverage_test.go
+++ b/internal/ipc/server_coverage_test.go
@@ -42,8 +42,8 @@ func TestServerHandleRequestTypes(t *testing.T) {
 	if response.ErrorCode != "INVALID_REQUEST_TYPE" {
 		t.Errorf("Expected INVALID_REQUEST_TYPE, got %s", response.ErrorCode)
 	}
-	if !strings.Contains(response.ErrorMessage, "Unknown request type") {
-		t.Errorf("Expected error message to contain 'Unknown request type', got %s", response.ErrorMessage)
+	if response.ErrorMessage != "Invalid request type" {
+		t.Errorf("Expected generic error message 'Invalid request type', got %s", response.ErrorMessage)
 	}
 }
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -320,6 +320,41 @@ func TestServerHandleRequest(t *testing.T) {
 	}
 }
 
+func TestServerHandleRequestUnknownTypeDoesNotEcho(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "ipc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	socketPath := filepath.Join(tempDir, "test.sock")
+	broker := createTestBroker(t)
+	server, err := NewServer(socketPath, broker, 0660, "", false)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+
+	// Test that unknown request type is not echoed back in the response
+	request := &Request{
+		Type:   "secret_internal_type",
+		UserID: "test-user",
+	}
+
+	response := server.handleRequest(request)
+	if response.Success {
+		t.Error("Expected failure for unknown request type")
+	}
+	if response.ErrorCode != "INVALID_REQUEST_TYPE" {
+		t.Errorf("Expected error code INVALID_REQUEST_TYPE, got %s", response.ErrorCode)
+	}
+	if strings.Contains(response.ErrorMessage, "secret_internal_type") {
+		t.Errorf("Response should not echo back the unknown request type, got: %s", response.ErrorMessage)
+	}
+	if response.ErrorMessage != "Invalid request type" {
+		t.Errorf("Expected generic error message 'Invalid request type', got: %s", response.ErrorMessage)
+	}
+}
+
 func TestServerHandleAuthenticate(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "ipc-test-*")
 	if err != nil {
@@ -498,8 +533,15 @@ func TestServerRejectsPathTraversal(t *testing.T) {
 	if !strings.Contains(response, "INVALID_REQUEST") {
 		t.Errorf("Expected INVALID_REQUEST error code in response, got: %s", response)
 	}
-	if !strings.Contains(response, "invalid characters") {
-		t.Errorf("Expected 'invalid characters' in error message, got: %s", response)
+	// Verify generic message is returned, not internal validation details
+	if !strings.Contains(response, "Invalid request") {
+		t.Errorf("Expected generic 'Invalid request' message, got: %s", response)
+	}
+	if strings.Contains(response, "invalid characters") {
+		t.Errorf("Response should not contain internal validation details, got: %s", response)
+	}
+	if strings.Contains(response, "../../root") {
+		t.Errorf("Response should not echo back the malicious input, got: %s", response)
 	}
 }
 

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -250,10 +250,15 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 			Timestamp:    time.Now(),
 		})
 
+		log.Warn().
+			Str("user_id", req.UserID).
+			Str("reason", policyResult.Reason).
+			Msg("Authentication denied by policy")
+
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "POLICY_DENIED",
-			ErrorMessage: policyResult.Reason,
+			ErrorMessage: "Access denied by policy",
 		}, nil
 	}
 
@@ -283,7 +288,7 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "DEVICE_FLOW_FAILED",
-			ErrorMessage: err.Error(),
+			ErrorMessage: "Device authorization flow failed",
 		}, nil
 	}
 
@@ -409,7 +414,7 @@ func (b *Broker) RefreshSession(sessionID string) (*AuthResponse, error) {
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "REFRESH_FAILED",
-			ErrorMessage: err.Error(),
+			ErrorMessage: "Token refresh failed",
 		}, nil
 	}
 


### PR DESCRIPTION
## Summary

- Replace internal error details (`err.Error()`, policy denial reasons, provider errors) in client-facing `ErrorMessage` fields with generic, safe messages to prevent leaking file paths, configuration details, and policy rules
- Add `clientErrorMessage()` mapping function for error codes to client-safe messages
- Internal details continue to be logged server-side via zerolog

## Test plan

- [x] All existing tests pass with updated assertions
- [x] New `errors_test.go` covers all known error codes and unknown/default fallback
- [x] `TestServerRejectsPathTraversal` verifies generic message, not validation details
- [x] `TestServerHandleRequestUnknownTypeDoesNotEcho` verifies request type is not echoed back
- [x] `go vet` passes on all affected packages

Closes #29