### PR TITLE
Fix race conditions in session and token management

### DIFF
--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -613,24 +613,39 @@ func (b *Broker) sessionCleanup(ctx context.Context) {
 			return
 		case <-ticker.C:
 			now := time.Now()
-			var expiredSessions []string
 
-			b.sessionMutex.RLock()
+			// Atomically collect and remove expired sessions under a single write lock
+			// to avoid TOCTOU race between identifying and removing sessions.
+			var expiredSessions []*Session
+			b.sessionMutex.Lock()
 			for id, session := range b.sessions {
 				if session.ExpiresAt.Before(now) {
-					expiredSessions = append(expiredSessions, id)
+					expiredSessions = append(expiredSessions, session)
+					delete(b.sessions, id)
 				}
 			}
-			b.sessionMutex.RUnlock()
+			b.sessionMutex.Unlock()
 
-			// Clean up expired sessions
-			for _, sessionID := range expiredSessions {
-				if err := b.RevokeSession(sessionID); err != nil {
-					log.Error().
-						Err(err).
-						Str("session_id", sessionID).
-						Msg("Failed to revoke expired session")
+			// Perform SSH key revocation and audit logging outside the lock.
+			// Sessions are already removed from the map, so no TOCTOU risk.
+			for _, session := range expiredSessions {
+				if session.SSHKeyID != "" {
+					if err := b.revokeSSHKey(session); err != nil {
+						log.Error().
+							Err(err).
+							Str("session_id", session.ID).
+							Str("ssh_key_id", session.SSHKeyID).
+							Msg("Failed to revoke SSH key for expired session")
+					}
 				}
+
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType: "session_revoked",
+					UserID:    session.UserID,
+					SessionID: session.ID,
+					Success:   true,
+					Timestamp: time.Now(),
+				})
 			}
 
 			if len(expiredSessions) > 0 {

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -238,8 +238,8 @@ func (tm *TokenManager) GetToken(tokenID string) (*Token, error) {
 
 // ValidateToken validates a token
 func (tm *TokenManager) ValidateToken(tokenFingerprint string) (*StoredToken, error) {
-	tm.tokenStore.mutex.RLock()
-	defer tm.tokenStore.mutex.RUnlock()
+	tm.tokenStore.mutex.Lock()
+	defer tm.tokenStore.mutex.Unlock()
 
 	// Find token by fingerprint
 	for _, storedToken := range tm.tokenStore.tokens {

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -269,3 +269,56 @@ func TestTokenManagerConcurrency(t *testing.T) {
 	wg.Wait()
 	t.Log("Concurrent operations completed successfully")
 }
+
+func TestValidateTokenConcurrent(t *testing.T) {
+	// Regression test: ValidateToken mutates LastUsed. Under a read lock this
+	// would race; the fix uses a write lock. Run with -race to verify.
+
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+		},
+	}
+
+	tm, err := NewTokenManager(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create token manager: %v", err)
+	}
+
+	// Store a token so ValidateToken has something to find
+	testToken := &Token{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		IDToken:      "id",
+		TokenType:    "Bearer",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Fingerprint:  "concurrent-fp",
+		Claims:       make(map[string]interface{}),
+	}
+	if err := tm.StoreToken(testToken, "user1", "session1"); err != nil {
+		t.Fatalf("Failed to store token: %v", err)
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				storedToken, err := tm.ValidateToken("concurrent-fp")
+				if err != nil {
+					t.Errorf("ValidateToken failed: %v", err)
+					return
+				}
+				if storedToken == nil {
+					t.Error("ValidateToken returned nil token")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -7,10 +7,31 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/rs/zerolog/log"
 )
+
+// withFileLock acquires an exclusive POSIX file lock on a lockfile adjacent to
+// the authorized_keys file, runs fn, then releases the lock. This serializes
+// concurrent read-then-write operations across processes.
+func withFileLock(lockPath string, fn func() error) error {
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open lock file: %w", err)
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		_ = lockFile.Close()
+	}()
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("failed to acquire file lock: %w", err)
+	}
+
+	return fn()
+}
 
 // AuthorizedKeysManager manages authorized_keys files for users
 type AuthorizedKeysManager struct {
@@ -29,54 +50,57 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
+	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
 
 	// Create .ssh directory if it doesn't exist
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
 		return fmt.Errorf("failed to create .ssh directory: %w", err)
 	}
 
-	// Read existing authorized_keys file
-	var existingKeys []string
-	if data, err := os.ReadFile(authorizedKeysPath); err == nil {
-		existingKeys = strings.Split(string(data), "\n")
-	}
-
-	// Check if key already exists
-	newKeyLine := strings.TrimSpace(string(publicKey))
-	for _, existingKey := range existingKeys {
-		if strings.TrimSpace(existingKey) == newKeyLine {
-			log.Debug().
-				Str("username", username).
-				Msg("Public key already exists in authorized_keys")
-			return nil
+	return withFileLock(lockPath, func() error {
+		// Read existing authorized_keys file
+		var existingKeys []string
+		if data, err := os.ReadFile(authorizedKeysPath); err == nil {
+			existingKeys = strings.Split(string(data), "\n")
 		}
-	}
 
-	// Add the new key
-	file, err := os.OpenFile(authorizedKeysPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open authorized_keys file: %w", err)
-	}
-	defer func() { _ = file.Close() }()
+		// Check if key already exists
+		newKeyLine := strings.TrimSpace(string(publicKey))
+		for _, existingKey := range existingKeys {
+			if strings.TrimSpace(existingKey) == newKeyLine {
+				log.Debug().
+					Str("username", username).
+					Msg("Public key already exists in authorized_keys")
+				return nil
+			}
+		}
 
-	// Add timestamp comment
-	timestamp := time.Now().Format("2006-01-02 15:04:05")
-	comment := fmt.Sprintf("# Added by OIDC PAM on %s\n", timestamp)
+		// Add the new key
+		file, err := os.OpenFile(authorizedKeysPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return fmt.Errorf("failed to open authorized_keys file: %w", err)
+		}
+		defer func() { _ = file.Close() }()
 
-	if _, err := file.WriteString(comment); err != nil {
-		return fmt.Errorf("failed to write comment to authorized_keys: %w", err)
-	}
+		// Add timestamp comment
+		timestamp := time.Now().Format("2006-01-02 15:04:05")
+		comment := fmt.Sprintf("# Added by OIDC PAM on %s\n", timestamp)
 
-	if _, err := file.WriteString(newKeyLine + "\n"); err != nil {
-		return fmt.Errorf("failed to write key to authorized_keys: %w", err)
-	}
+		if _, err := file.WriteString(comment); err != nil {
+			return fmt.Errorf("failed to write comment to authorized_keys: %w", err)
+		}
 
-	log.Info().
-		Str("username", username).
-		Str("authorized_keys_path", authorizedKeysPath).
-		Msg("Public key added to authorized_keys")
+		if _, err := file.WriteString(newKeyLine + "\n"); err != nil {
+			return fmt.Errorf("failed to write key to authorized_keys: %w", err)
+		}
 
-	return nil
+		log.Info().
+			Str("username", username).
+			Str("authorized_keys_path", authorizedKeysPath).
+			Msg("Public key added to authorized_keys")
+
+		return nil
+	})
 }
 
 // RemovePublicKey removes a public key from a user's authorized_keys file
@@ -84,105 +108,46 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
+	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
 
-	// Read existing authorized_keys file
-	data, err := os.ReadFile(authorizedKeysPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // File doesn't exist, nothing to remove
-		}
-		return fmt.Errorf("failed to read authorized_keys file: %w", err)
-	}
-
-	// Parse existing keys
-	lines := strings.Split(string(data), "\n")
-	keyToRemove := strings.TrimSpace(string(publicKey))
-
-	var filteredLines []string
-	removed := false
-
-	for _, line := range lines {
-		trimmedLine := strings.TrimSpace(line)
-		if trimmedLine == keyToRemove {
-			removed = true
-			continue
-		}
-		filteredLines = append(filteredLines, line)
-	}
-
-	if !removed {
-		log.Debug().
-			Str("username", username).
-			Msg("Public key not found in authorized_keys")
+	// Check if .ssh directory exists; if not, nothing to remove
+	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
 		return nil
 	}
 
-	// Write filtered content back
-	newContent := strings.Join(filteredLines, "\n")
-	if err := os.WriteFile(authorizedKeysPath, []byte(newContent), 0600); err != nil {
-		return fmt.Errorf("failed to write authorized_keys file: %w", err)
-	}
-
-	log.Info().
-		Str("username", username).
-		Str("authorized_keys_path", authorizedKeysPath).
-		Msg("Public key removed from authorized_keys")
-
-	return nil
-}
-
-// RemoveExpiredKeys removes expired OIDC PAM keys from authorized_keys
-func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-
-	// Read existing authorized_keys file
-	file, err := os.Open(authorizedKeysPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // File doesn't exist, nothing to clean
-		}
-		return fmt.Errorf("failed to open authorized_keys file: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	var filteredLines []string
-	var removedCount int
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Check if this is an OIDC PAM key
-		if strings.Contains(line, "@oidc-pam-") {
-			// Extract timestamp from comment
-			parts := strings.Fields(line)
-			if len(parts) >= 3 {
-				comment := parts[2]
-				if strings.Contains(comment, "@oidc-pam-") {
-					// Extract timestamp
-					timestampStr := strings.Split(comment, "@oidc-pam-")[1]
-					if timestamp, err := strconv.ParseInt(timestampStr, 10, 64); err == nil {
-						keyTime := time.Unix(timestamp, 0)
-						// Check if key is older than 24 hours (default expiration)
-						if time.Since(keyTime) > 24*time.Hour {
-							removedCount++
-							continue // Skip this line (remove the key)
-						}
-					}
-				}
+	return withFileLock(lockPath, func() error {
+		// Read existing authorized_keys file
+		data, err := os.ReadFile(authorizedKeysPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // File doesn't exist, nothing to remove
 			}
+			return fmt.Errorf("failed to read authorized_keys file: %w", err)
 		}
 
-		filteredLines = append(filteredLines, line)
-	}
+		// Parse existing keys
+		lines := strings.Split(string(data), "\n")
+		keyToRemove := strings.TrimSpace(string(publicKey))
 
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to scan authorized_keys file: %w", err)
-	}
+		var filteredLines []string
+		removed := false
 
-	if removedCount > 0 {
+		for _, line := range lines {
+			trimmedLine := strings.TrimSpace(line)
+			if trimmedLine == keyToRemove {
+				removed = true
+				continue
+			}
+			filteredLines = append(filteredLines, line)
+		}
+
+		if !removed {
+			log.Debug().
+				Str("username", username).
+				Msg("Public key not found in authorized_keys")
+			return nil
+		}
+
 		// Write filtered content back
 		newContent := strings.Join(filteredLines, "\n")
 		if err := os.WriteFile(authorizedKeysPath, []byte(newContent), 0600); err != nil {
@@ -191,11 +156,86 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 
 		log.Info().
 			Str("username", username).
-			Int("removed_count", removedCount).
-			Msg("Removed expired OIDC PAM keys from authorized_keys")
+			Str("authorized_keys_path", authorizedKeysPath).
+			Msg("Public key removed from authorized_keys")
+
+		return nil
+	})
+}
+
+// RemoveExpiredKeys removes expired OIDC PAM keys from authorized_keys
+func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
+	userHomeDir := filepath.Join(akm.baseDir, username)
+	sshDir := filepath.Join(userHomeDir, ".ssh")
+	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
+	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
+
+	// Check if .ssh directory exists; if not, nothing to clean
+	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
+		return nil
 	}
 
-	return nil
+	return withFileLock(lockPath, func() error {
+		// Read existing authorized_keys file
+		file, err := os.Open(authorizedKeysPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // File doesn't exist, nothing to clean
+			}
+			return fmt.Errorf("failed to open authorized_keys file: %w", err)
+		}
+		defer func() { _ = file.Close() }()
+
+		var filteredLines []string
+		var removedCount int
+		scanner := bufio.NewScanner(file)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Check if this is an OIDC PAM key
+			if strings.Contains(line, "@oidc-pam-") {
+				// Extract timestamp from comment
+				parts := strings.Fields(line)
+				if len(parts) >= 3 {
+					comment := parts[2]
+					if strings.Contains(comment, "@oidc-pam-") {
+						// Extract timestamp
+						timestampStr := strings.Split(comment, "@oidc-pam-")[1]
+						if timestamp, err := strconv.ParseInt(timestampStr, 10, 64); err == nil {
+							keyTime := time.Unix(timestamp, 0)
+							// Check if key is older than 24 hours (default expiration)
+							if time.Since(keyTime) > 24*time.Hour {
+								removedCount++
+								continue // Skip this line (remove the key)
+							}
+						}
+					}
+				}
+			}
+
+			filteredLines = append(filteredLines, line)
+		}
+
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("failed to scan authorized_keys file: %w", err)
+		}
+
+		if removedCount > 0 {
+			// Write filtered content back
+			newContent := strings.Join(filteredLines, "\n")
+			if err := os.WriteFile(authorizedKeysPath, []byte(newContent), 0600); err != nil {
+				return fmt.Errorf("failed to write authorized_keys file: %w", err)
+			}
+
+			log.Info().
+				Str("username", username).
+				Int("removed_count", removedCount).
+				Msg("Removed expired OIDC PAM keys from authorized_keys")
+		}
+
+		return nil
+	})
 }
 
 // ListOIDCKeys lists all OIDC PAM keys in a user's authorized_keys file

--- a/pkg/ssh/authorized_keys_test.go
+++ b/pkg/ssh/authorized_keys_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -516,6 +517,52 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@oidc-pam-%d
 	// Expired OIDC key should be removed
 	if strings.Contains(updatedContent, fmt.Sprintf("user@oidc-pam-%d", expiredTimestamp)) {
 		t.Error("Expired OIDC key should have been removed")
+	}
+}
+
+func TestAddPublicKeyConcurrent(t *testing.T) {
+	// Regression test: without file locking, concurrent AddPublicKey calls
+	// can produce duplicate keys. Run with -race to verify.
+	tmpDir, err := os.MkdirTemp("", "test-auth-keys-concurrent")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	akm := NewAuthorizedKeysManager(tmpDir)
+	username := "testuser"
+
+	const goroutines = 20
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest concurrent@test")
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := akm.AddPublicKey(username, key); err != nil {
+				t.Errorf("AddPublicKey failed: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Verify: the key should appear exactly once
+	authorizedKeysPath := filepath.Join(tmpDir, username, ".ssh", "authorized_keys")
+	data, err := os.ReadFile(authorizedKeysPath)
+	if err != nil {
+		t.Fatalf("Failed to read authorized_keys: %v", err)
+	}
+
+	keyLine := strings.TrimSpace(string(key))
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == keyLine {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Expected key to appear exactly once, found %d occurrences", count)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **ValidateToken write-under-read-lock**: Changed `RLock`/`RUnlock` to `Lock`/`Unlock` since `ValidateToken` mutates `storedToken.LastUsed`, which would race under concurrent read locks.
- **Session cleanup TOCTOU**: Restructured `sessionCleanup` to atomically collect and delete expired sessions under a single write lock, then perform SSH key revocation and audit logging outside the lock.
- **authorized_keys TOCTOU**: Added `withFileLock` helper using `syscall.Flock` (POSIX exclusive file lock) to serialize read-then-write operations in `AddPublicKey`, `RemovePublicKey`, and `RemoveExpiredKeys`.
- **Concurrent regression tests**: Added `TestValidateTokenConcurrent` and `TestAddPublicKeyConcurrent` to catch these races under `-race`.

Closes #22

## Test plan

- [x] `go build ./pkg/auth/... ./pkg/ssh/...`
- [x] `go test -race ./pkg/auth/...`
- [x] `go test -race ./pkg/ssh/...`
- [x] `go vet ./pkg/auth/... ./pkg/ssh/...`