### PR TITLE
Enforce rate limiting for IPC server and broker

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -71,7 +71,7 @@ func main() {
 	}
 
 	// Create IPC server for PAM communication
-	ipcServer, err := ipc.NewServer(cfg.Server.SocketPath, broker, cfg.Server.SocketMode, cfg.Server.SocketGroup, cfg.Server.RequirePeerAuth)
+	ipcServer, err := ipc.NewServer(cfg.Server.SocketPath, broker, cfg.Server.SocketMode, cfg.Server.SocketGroup, cfg.Server.RequirePeerAuth, cfg.Security.RateLimiting.MaxRequestsPerMinute, cfg.Security.RateLimiting.MaxConcurrentAuths)
 	if err != nil {
 		log.Fatal().
 			Err(err).

--- a/internal/ipc/errors.go
+++ b/internal/ipc/errors.go
@@ -31,6 +31,12 @@ func clientErrorMessage(code string) string {
 		return "Authentication provider not available"
 	case "REFRESH_FAILED":
 		return "Token refresh failed"
+	case "RATE_LIMIT_EXCEEDED":
+		return "Too many requests, please try again later"
+	case "TOO_MANY_CONCURRENT_AUTHS":
+		return "Too many concurrent authentication requests"
+	case "TOO_MANY_SESSIONS":
+		return "Maximum concurrent sessions reached"
 	default:
 		return "An error occurred"
 	}

--- a/internal/ipc/ratelimit.go
+++ b/internal/ipc/ratelimit.go
@@ -1,0 +1,163 @@
+package ipc
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// bucket tracks tokens for a single UID using a token-bucket algorithm.
+type bucket struct {
+	tokens     float64
+	lastRefill time.Time
+}
+
+// RateLimiter enforces per-UID request rate limits and a global concurrent
+// authentication limit. It is safe for concurrent use.
+type RateLimiter struct {
+	// Per-UID token bucket parameters
+	maxTokens  float64 // burst size (== MaxRequestsPerMinute)
+	refillRate float64 // tokens per second
+
+	mu      sync.Mutex
+	buckets map[uint32]*bucket
+
+	// Concurrent auth semaphore
+	maxConcurrentAuths int32
+	concurrentAuths    atomic.Int32
+
+	// Cleanup goroutine lifecycle
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewRateLimiter creates a RateLimiter. If maxRequestsPerMinute or
+// maxConcurrentAuths is <= 0, that particular limit is disabled (always
+// allows). A background goroutine evicts stale UID entries every 5 minutes.
+func NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths int) *RateLimiter {
+	rl := &RateLimiter{
+		maxTokens:          float64(maxRequestsPerMinute),
+		refillRate:         float64(maxRequestsPerMinute) / 60.0,
+		buckets:            make(map[uint32]*bucket),
+		maxConcurrentAuths: int32(maxConcurrentAuths),
+		stopChan:           make(chan struct{}),
+	}
+
+	rl.wg.Add(1)
+	go rl.cleanupLoop()
+
+	return rl
+}
+
+// AllowRequest consumes one token from the bucket for uid. Returns false if
+// the bucket is empty (rate limit exceeded). If rate limiting is disabled
+// (maxTokens <= 0), it always returns true.
+func (rl *RateLimiter) AllowRequest(uid uint32) bool {
+	if rl.maxTokens <= 0 {
+		return true
+	}
+
+	now := time.Now()
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	b, ok := rl.buckets[uid]
+	if !ok {
+		// First request from this UID — create a full bucket minus one token.
+		rl.buckets[uid] = &bucket{
+			tokens:     rl.maxTokens - 1,
+			lastRefill: now,
+		}
+		return true
+	}
+
+	// Refill tokens based on elapsed time.
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	b.tokens += elapsed * rl.refillRate
+	if b.tokens > rl.maxTokens {
+		b.tokens = rl.maxTokens
+	}
+	b.lastRefill = now
+
+	if b.tokens < 1 {
+		return false
+	}
+
+	b.tokens--
+	return true
+}
+
+// AcquireAuth attempts to increment the concurrent auth counter. Returns false
+// if the limit would be exceeded. If the limit is disabled (<= 0), always
+// returns true.
+func (rl *RateLimiter) AcquireAuth() bool {
+	if rl.maxConcurrentAuths <= 0 {
+		return true
+	}
+
+	for {
+		current := rl.concurrentAuths.Load()
+		if current >= rl.maxConcurrentAuths {
+			return false
+		}
+		if rl.concurrentAuths.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+// ReleaseAuth decrements the concurrent auth counter. Must be called after a
+// successful AcquireAuth when the authentication request completes.
+func (rl *RateLimiter) ReleaseAuth() {
+	rl.concurrentAuths.Add(-1)
+}
+
+// Stop terminates the background cleanup goroutine and waits for it to exit.
+func (rl *RateLimiter) Stop() {
+	close(rl.stopChan)
+	rl.wg.Wait()
+}
+
+// cleanupLoop periodically evicts UID buckets that have been idle for more
+// than 5 minutes (fully refilled and unused).
+func (rl *RateLimiter) cleanupLoop() {
+	defer rl.wg.Done()
+
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-rl.stopChan:
+			return
+		case <-ticker.C:
+			rl.evictStale()
+		}
+	}
+}
+
+// evictStale removes buckets that have not been used in more than 5 minutes.
+func (rl *RateLimiter) evictStale() {
+	cutoff := time.Now().Add(-5 * time.Minute)
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	before := len(rl.buckets)
+	for uid, b := range rl.buckets {
+		if b.lastRefill.Before(cutoff) {
+			delete(rl.buckets, uid)
+		}
+	}
+	after := len(rl.buckets)
+
+	if evicted := before - after; evicted > 0 {
+		log.Debug().
+			Int("evicted", evicted).
+			Int("remaining", after).
+			Msg("Evicted stale rate-limit buckets")
+	}
+}

--- a/internal/ipc/ratelimit_test.go
+++ b/internal/ipc/ratelimit_test.go
@@ -1,0 +1,211 @@
+package ipc
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAllowRequest(t *testing.T) {
+	// 6 requests/minute = 1 token every 10 seconds, burst of 6
+	rl := NewRateLimiter(6, 0)
+	defer rl.Stop()
+
+	uid := uint32(1000)
+
+	// Should allow 6 requests (full burst)
+	for i := 0; i < 6; i++ {
+		if !rl.AllowRequest(uid) {
+			t.Fatalf("request %d should have been allowed", i+1)
+		}
+	}
+
+	// 7th should be denied
+	if rl.AllowRequest(uid) {
+		t.Fatal("request should have been denied after burst exhausted")
+	}
+}
+
+func TestAllowRequestRefill(t *testing.T) {
+	// 60 requests/minute = 1 token/second
+	rl := NewRateLimiter(60, 0)
+	defer rl.Stop()
+
+	uid := uint32(1000)
+
+	// Exhaust all tokens
+	for i := 0; i < 60; i++ {
+		rl.AllowRequest(uid)
+	}
+	if rl.AllowRequest(uid) {
+		t.Fatal("should be denied when exhausted")
+	}
+
+	// Manually advance the bucket's lastRefill to simulate time passing.
+	rl.mu.Lock()
+	b := rl.buckets[uid]
+	b.lastRefill = b.lastRefill.Add(-2 * time.Second)
+	rl.mu.Unlock()
+
+	// Should now have ~2 tokens refilled
+	if !rl.AllowRequest(uid) {
+		t.Fatal("should be allowed after refill")
+	}
+}
+
+func TestAllowRequestPerUID(t *testing.T) {
+	rl := NewRateLimiter(2, 0)
+	defer rl.Stop()
+
+	uid1 := uint32(1000)
+	uid2 := uint32(2000)
+
+	// Exhaust UID 1
+	rl.AllowRequest(uid1)
+	rl.AllowRequest(uid1)
+	if rl.AllowRequest(uid1) {
+		t.Fatal("uid1 should be denied")
+	}
+
+	// UID 2 should still be fine
+	if !rl.AllowRequest(uid2) {
+		t.Fatal("uid2 should be allowed (independent bucket)")
+	}
+}
+
+func TestAllowRequestDisabled(t *testing.T) {
+	rl := NewRateLimiter(0, 0)
+	defer rl.Stop()
+
+	// Should always allow when disabled
+	for i := 0; i < 100; i++ {
+		if !rl.AllowRequest(uint32(1000)) {
+			t.Fatal("should always allow when rate limiting is disabled")
+		}
+	}
+}
+
+func TestConcurrentAuthLimit(t *testing.T) {
+	rl := NewRateLimiter(0, 3)
+	defer rl.Stop()
+
+	// Acquire 3 (max)
+	for i := 0; i < 3; i++ {
+		if !rl.AcquireAuth() {
+			t.Fatalf("acquire %d should have succeeded", i+1)
+		}
+	}
+
+	// 4th should fail
+	if rl.AcquireAuth() {
+		t.Fatal("should not exceed max concurrent auths")
+	}
+
+	// Release one
+	rl.ReleaseAuth()
+
+	// Now should succeed again
+	if !rl.AcquireAuth() {
+		t.Fatal("should succeed after release")
+	}
+}
+
+func TestConcurrentAuthDisabled(t *testing.T) {
+	rl := NewRateLimiter(0, 0)
+	defer rl.Stop()
+
+	// Should always allow when disabled
+	for i := 0; i < 100; i++ {
+		if !rl.AcquireAuth() {
+			t.Fatal("should always allow when limit is disabled")
+		}
+	}
+}
+
+func TestConcurrentAuthConcurrency(t *testing.T) {
+	rl := NewRateLimiter(0, 5)
+	defer rl.Stop()
+
+	// Use many goroutines to test for races
+	var wg sync.WaitGroup
+	acquired := make(chan struct{}, 100)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if rl.AcquireAuth() {
+				acquired <- struct{}{}
+				time.Sleep(10 * time.Millisecond)
+				rl.ReleaseAuth()
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(acquired)
+
+	count := 0
+	for range acquired {
+		count++
+	}
+	if count == 0 {
+		t.Fatal("at least some acquires should have succeeded")
+	}
+}
+
+func TestRateLimiterCleanup(t *testing.T) {
+	rl := NewRateLimiter(10, 0)
+	defer rl.Stop()
+
+	// Add some entries
+	rl.AllowRequest(1000)
+	rl.AllowRequest(2000)
+	rl.AllowRequest(3000)
+
+	// Manually age the buckets
+	rl.mu.Lock()
+	staleTime := time.Now().Add(-10 * time.Minute)
+	for _, b := range rl.buckets {
+		b.lastRefill = staleTime
+	}
+	rl.mu.Unlock()
+
+	// Run eviction directly
+	rl.evictStale()
+
+	rl.mu.Lock()
+	remaining := len(rl.buckets)
+	rl.mu.Unlock()
+
+	if remaining != 0 {
+		t.Fatalf("expected 0 buckets after eviction, got %d", remaining)
+	}
+}
+
+func TestRateLimiterCleanupKeepsFresh(t *testing.T) {
+	rl := NewRateLimiter(10, 0)
+	defer rl.Stop()
+
+	rl.AllowRequest(1000) // fresh
+	rl.AllowRequest(2000) // will be aged
+
+	// Age only UID 2000
+	rl.mu.Lock()
+	rl.buckets[2000].lastRefill = time.Now().Add(-10 * time.Minute)
+	rl.mu.Unlock()
+
+	rl.evictStale()
+
+	rl.mu.Lock()
+	_, has1000 := rl.buckets[1000]
+	_, has2000 := rl.buckets[2000]
+	rl.mu.Unlock()
+
+	if !has1000 {
+		t.Fatal("fresh bucket for UID 1000 should not be evicted")
+	}
+	if has2000 {
+		t.Fatal("stale bucket for UID 2000 should be evicted")
+	}
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	socketGroup     string
 	requirePeerAuth bool
 	broker          *auth.Broker
+	rateLimiter     *RateLimiter
 	listener        net.Listener
 	stopChan        chan struct{}
 	wg              sync.WaitGroup
@@ -64,14 +65,17 @@ type Response struct {
 	Metadata         map[string]interface{} `json:"metadata"`
 }
 
-// NewServer creates a new IPC server
-func NewServer(socketPath string, broker *auth.Broker, socketMode os.FileMode, socketGroup string, requirePeerAuth bool) (*Server, error) {
+// NewServer creates a new IPC server. maxRequestsPerMinute and
+// maxConcurrentAuths configure per-UID rate limiting and the global
+// concurrent auth cap respectively. Values <= 0 disable that limit.
+func NewServer(socketPath string, broker *auth.Broker, socketMode os.FileMode, socketGroup string, requirePeerAuth bool, maxRequestsPerMinute, maxConcurrentAuths int) (*Server, error) {
 	return &Server{
 		socketPath:      socketPath,
 		socketMode:      socketMode,
 		socketGroup:     socketGroup,
 		requirePeerAuth: requirePeerAuth,
 		broker:          broker,
+		rateLimiter:     NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths),
 		stopChan:        make(chan struct{}),
 	}, nil
 }
@@ -148,6 +152,11 @@ func (s *Server) Stop() error {
 		// Wait for goroutines to finish
 		s.wg.Wait()
 
+		// Stop rate limiter cleanup goroutine
+		if s.rateLimiter != nil {
+			s.rateLimiter.Stop()
+		}
+
 		// Remove socket file
 		if err := os.RemoveAll(s.socketPath); err != nil {
 			log.Warn().
@@ -212,6 +221,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Verify peer credentials if required
+	var peerUID uint32
 	if s.requirePeerAuth {
 		uid, gid, err := getPeerCredentials(conn)
 		if err != nil {
@@ -229,10 +239,20 @@ func (s *Server) handleConnection(conn net.Conn) {
 			s.sendErrorResponse(conn, "PEER_AUTH_DENIED", "Only root processes are allowed to connect")
 			return
 		}
+		peerUID = uid
 		log.Debug().
 			Uint32("uid", uid).
 			Uint32("gid", gid).
 			Msg("Peer credentials verified")
+	}
+
+	// Apply per-UID rate limiting
+	if !s.rateLimiter.AllowRequest(peerUID) {
+		log.Warn().
+			Uint32("uid", peerUID).
+			Msg("Rate limit exceeded for UID")
+		s.sendErrorResponse(conn, "RATE_LIMIT_EXCEEDED", clientErrorMessage("RATE_LIMIT_EXCEEDED"))
+		return
 	}
 
 	log.Debug().
@@ -284,6 +304,15 @@ func (s *Server) handleConnection(conn net.Conn) {
 func (s *Server) handleRequest(request *Request) *Response {
 	switch request.Type {
 	case "authenticate":
+		if !s.rateLimiter.AcquireAuth() {
+			log.Warn().Msg("Concurrent auth limit reached")
+			return &Response{
+				Success:      false,
+				ErrorCode:    "TOO_MANY_CONCURRENT_AUTHS",
+				ErrorMessage: clientErrorMessage("TOO_MANY_CONCURRENT_AUTHS"),
+			}
+		}
+		defer s.rateLimiter.ReleaseAuth()
 		return s.handleAuthenticate(request)
 	case "check_session":
 		return s.handleCheckSession(request)

--- a/internal/ipc/server_coverage_test.go
+++ b/internal/ipc/server_coverage_test.go
@@ -24,7 +24,7 @@ func TestServerHandleRequestTypes(t *testing.T) {
 	socketPath := filepath.Join(tempDir, "test.sock")
 
 	// Create a broker (will be nil, but that's expected for these tests)
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestServerFormatInstructionsExtended(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestServerConnectionWithMalformedJSON(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestServerConnectionWithEmptyData(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestServerStartStopEdgeCases(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestServerWithValidRequestStructure(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestServerConcurrentConnections(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, nil, 0660, "", false)
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestServerWithRealBrokerConfig(t *testing.T) {
 	}
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -28,7 +28,7 @@ func TestNewServer(t *testing.T) {
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
 
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestServerLifecycle(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestServerConnection(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestServerMultipleConnections(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestServerInvalidSocketPath(t *testing.T) {
 	// Test with invalid socket path
 	invalidPath := "/invalid/path/that/does/not/exist/test.sock"
 	broker := createTestBroker(t)
-	server, err := NewServer(invalidPath, broker, 0660, "", false)
+	server, err := NewServer(invalidPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestServerStopBeforeStart(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestServerDoubleStop(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestServerConnectionHandling(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestServerHandleRequest(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestServerHandleRequestUnknownTypeDoesNotEcho(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestServerHandleAuthenticate(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestServerHandleCheckSession(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestServerHandleRefreshSession(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestServerHandleRevokeSession(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -491,7 +491,7 @@ func TestServerRejectsPathTraversal(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -554,7 +554,7 @@ func TestServerFormatInstructions(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test.sock")
 	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false)
+	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -233,6 +233,20 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		b.removeSession(req.SessionID)
 	}
 
+	// Check per-user session limit
+	maxSessions := b.config.Authentication.MaxConcurrentSessions
+	if maxSessions > 0 && b.countUserSessions(req.UserID) >= maxSessions {
+		log.Warn().
+			Str("user_id", req.UserID).
+			Int("max_sessions", maxSessions).
+			Msg("Maximum concurrent sessions reached for user")
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "TOO_MANY_SESSIONS",
+			ErrorMessage: "Maximum concurrent sessions reached",
+		}, nil
+	}
+
 	// Apply policy checks
 	policyResult, err := b.policyEngine.EvaluateRequest(req)
 	if err != nil {
@@ -479,6 +493,20 @@ func (b *Broker) removeSession(sessionID string) {
 	b.sessionMutex.Lock()
 	defer b.sessionMutex.Unlock()
 	delete(b.sessions, sessionID)
+}
+
+// countUserSessions returns the number of active sessions for the given user.
+func (b *Broker) countUserSessions(userID string) int {
+	b.sessionMutex.RLock()
+	defer b.sessionMutex.RUnlock()
+
+	count := 0
+	for _, session := range b.sessions {
+		if session.UserID == userID {
+			count++
+		}
+	}
+	return count
 }
 
 func (b *Broker) createSuccessResponse(session *Session) *AuthResponse {

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -96,14 +96,8 @@ func (pe *PolicyEngine) applyGlobalPolicies(req *AuthRequest, result *PolicyResu
 		result.RequiredGroups = pe.config.Authentication.RequireGroups
 	}
 
-	// Check max concurrent sessions
-	if pe.config.Authentication.MaxConcurrentSessions > 0 {
-		// This would check against active sessions
-		// For now, we'll just log
-		log.Debug().
-			Int("max_sessions", pe.config.Authentication.MaxConcurrentSessions).
-			Msg("Checking concurrent session limit")
-	}
+	// Note: MaxConcurrentSessions is enforced in Broker.Authenticate() which
+	// has access to the session map. The policy engine does not own sessions.
 
 	return nil
 }

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -137,7 +137,7 @@ func (s *IntegrationTestSuite) TestIPCServerSetup() error {
 	}
 
 	// Create IPC server
-	ipcServer, err := ipc.NewServer(s.config.Server.SocketPath, s.broker, s.config.Server.SocketMode, s.config.Server.SocketGroup, s.config.Server.RequirePeerAuth)
+	ipcServer, err := ipc.NewServer(s.config.Server.SocketPath, s.broker, s.config.Server.SocketMode, s.config.Server.SocketGroup, s.config.Server.RequirePeerAuth, s.config.Security.RateLimiting.MaxRequestsPerMinute, s.config.Security.RateLimiting.MaxConcurrentAuths)
 	if err != nil {
 		return fmt.Errorf("failed to create IPC server: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes #25

- Add per-UID request rate limiting (token bucket) in the IPC server, rejecting requests before they reach the broker
- Add concurrent authentication semaphore to cap in-flight auth requests
- Add per-user session limit enforcement in the broker before creating new sessions
- Add `RATE_LIMIT_EXCEEDED`, `TOO_MANY_CONCURRENT_AUTHS`, and `TOO_MANY_SESSIONS` error codes

These limits were configured (`RateLimiting.MaxRequestsPerMinute`, `RateLimiting.MaxConcurrentAuths`, `Authentication.MaxConcurrentSessions`) but never enforced, leaving the system vulnerable to brute force, DoS, and resource exhaustion.

## Test plan

- [x] `go build ./internal/ipc/... ./pkg/auth/... ./cmd/broker/...`
- [x] `go test -race ./internal/ipc/...` — includes new rate limiter tests (token depletion/refill, per-UID isolation, concurrent auth limit, stale bucket eviction)
- [x] `go test -race ./pkg/auth/...`
- [x] `go vet ./internal/ipc/... ./pkg/auth/...`