### PR TITLE
Fix weak cryptographic defaults

### DIFF
--- a/pkg/auth/broker_core_test.go
+++ b/pkg/auth/broker_core_test.go
@@ -205,6 +205,9 @@ func TestDeviceFlowProviderCore(t *testing.T) {
 	if fingerprint == "" {
 		t.Error("Expected non-empty fingerprint")
 	}
+	if len(fingerprint) != 64 {
+		t.Errorf("Expected 64-char hex fingerprint, got %d chars", len(fingerprint))
+	}
 
 	// Test different tokens produce different fingerprints
 	fingerprint2 := provider.generateTokenFingerprint("different-token")

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -401,12 +403,8 @@ func (p *OIDCProvider) getDeviceAuthorizationEndpoint() (string, error) {
 }
 
 func (p *OIDCProvider) generateTokenFingerprint(accessToken string) string {
-	// Generate a simple fingerprint based on the first and last 8 characters
-	// In a real implementation, this would be a proper hash
-	if len(accessToken) < 16 {
-		return accessToken
-	}
-	return accessToken[:8] + "..." + accessToken[len(accessToken)-8:]
+	hash := sha256.Sum256([]byte(accessToken))
+	return hex.EncodeToString(hash[:])
 }
 
 func (p *OIDCProvider) extractUserInfoFromClaims(claims map[string]interface{}) (*UserInfo, error) {

--- a/pkg/auth/device_flow_test.go
+++ b/pkg/auth/device_flow_test.go
@@ -88,6 +88,9 @@ func TestDeviceFlowHelperMethods(t *testing.T) {
 	if fingerprint == "" {
 		t.Error("Expected non-empty token fingerprint")
 	}
+	if len(fingerprint) != 64 {
+		t.Errorf("Expected 64-char hex fingerprint, got %d chars", len(fingerprint))
+	}
 
 	// Test multiple fingerprint generation for consistency
 	fingerprint2 := provider.generateTokenFingerprint("test-token")

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"sync"
@@ -94,7 +93,10 @@ func (tm *TokenManager) Stop() error {
 // StoreToken stores a token in the token store
 func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) error {
 	// Generate token ID
-	tokenID := tm.generateTokenID()
+	tokenID, err := tm.generateTokenID()
+	if err != nil {
+		return fmt.Errorf("failed to generate token ID: %w", err)
+	}
 
 	// Encrypt token if encryption is enabled
 	accessToken := token.AccessToken
@@ -381,17 +383,12 @@ func (tm *TokenManager) GetTokenStats() map[string]interface{} {
 
 // Helper methods
 
-func (tm *TokenManager) generateTokenID() string {
-	// Generate random bytes
+func (tm *TokenManager) generateTokenID() (string, error) {
 	randomBytes := make([]byte, 16)
 	if _, err := rand.Read(randomBytes); err != nil {
-		// Fallback to timestamp-based ID
-		return fmt.Sprintf("token_%d", time.Now().UnixNano())
+		return "", fmt.Errorf("failed to generate token ID: %w", err)
 	}
-
-	// Create hash
-	hash := sha256.Sum256(randomBytes)
-	return hex.EncodeToString(hash[:])[:16]
+	return hex.EncodeToString(randomBytes), nil
 }
 
 func (tm *TokenManager) removeToken(tokenID string) {

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -183,15 +183,24 @@ func TestTokenManagerInternalMethods(t *testing.T) {
 	}
 
 	// Test generateTokenID
-	tokenID := tm.generateTokenID()
+	tokenID, err := tm.generateTokenID()
+	if err != nil {
+		t.Fatalf("generateTokenID returned error: %v", err)
+	}
 	if tokenID == "" {
 		t.Error("Expected non-empty token ID")
+	}
+	if len(tokenID) != 32 {
+		t.Errorf("Expected 32-char hex token ID, got %d chars", len(tokenID))
 	}
 
 	// Test multiple token ID generation for uniqueness
 	ids := make(map[string]bool)
 	for i := 0; i < 10; i++ {
-		id := tm.generateTokenID()
+		id, err := tm.generateTokenID()
+		if err != nil {
+			t.Fatalf("generateTokenID returned error: %v", err)
+		}
 		if ids[id] {
 			t.Error("Generated duplicate token ID")
 		}
@@ -253,7 +262,11 @@ func TestTokenManagerConcurrency(t *testing.T) {
 			defer wg.Done()
 
 			// Generate unique token ID
-			tokenID := tm.generateTokenID()
+			tokenID, err := tm.generateTokenID()
+			if err != nil {
+				t.Errorf("generateTokenID returned error in goroutine %d: %v", i, err)
+				return
+			}
 			if tokenID == "" {
 				t.Errorf("Generated empty token ID in goroutine %d", i)
 				return

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -2,6 +2,8 @@ package security
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -219,7 +221,12 @@ func createAuditOutput(config config.AuditOutput) (AuditOutput, error) {
 }
 
 func generateEventID() string {
-	return fmt.Sprintf("audit_%d", time.Now().UnixNano())
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// This indicates a broken system; return a best-effort fallback.
+		return fmt.Sprintf("audit_%d", time.Now().UnixNano())
+	}
+	return "audit_" + hex.EncodeToString(b)
 }
 
 // FileAuditOutput implementation

--- a/pkg/security/encryption.go
+++ b/pkg/security/encryption.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+
+	"golang.org/x/crypto/pbkdf2"
 )
 
 // Encryption handles encryption and decryption of sensitive data
@@ -21,9 +23,12 @@ func NewEncryption(keyString string) (*Encryption, error) {
 		return nil, fmt.Errorf("encryption key cannot be empty")
 	}
 
-	// Generate a 32-byte key from the provided string
-	hash := sha256.Sum256([]byte(keyString))
-	key := hash[:]
+	// Derive a 32-byte key using PBKDF2 with a fixed application-level salt.
+	// The key string is expected to be a high-entropy secret (config validation
+	// requires 32+ bytes), so the static salt is acceptable — the primary benefit
+	// is computational cost against brute force.
+	salt := []byte("oidc-pam-token-encryption-v1")
+	key := pbkdf2.Key([]byte(keyString), salt, 600000, 32, sha256.New)
 
 	return &Encryption{
 		key: key,

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -37,7 +37,7 @@ type SSHKey struct {
 func NewKeyManager(baseDir string) *KeyManager {
 	return &KeyManager{
 		baseDir:    baseDir,
-		keySize:    2048,
+		keySize:    4096,
 		keyType:    "rsa",
 		expiration: 24 * time.Hour, // Default 24 hour expiration
 	}

--- a/pkg/ssh/keys_test.go
+++ b/pkg/ssh/keys_test.go
@@ -15,8 +15,8 @@ func TestNewKeyManager(t *testing.T) {
 		t.Errorf("Expected baseDir %s, got %s", baseDir, km.baseDir)
 	}
 
-	if km.keySize != 2048 {
-		t.Errorf("Expected default keySize 2048, got %d", km.keySize)
+	if km.keySize != 4096 {
+		t.Errorf("Expected default keySize 4096, got %d", km.keySize)
 	}
 
 	if km.keyType != "rsa" {


### PR DESCRIPTION
## Summary

Fixes #24. Addresses five cryptographic weaknesses in the codebase:

- **SSH key default:** Increase from RSA-2048 to RSA-4096
- **Token fingerprint:** Replace raw token truncation with SHA-256 hash (64-char hex)
- **Key derivation:** Replace raw SHA-256 with PBKDF2 (600k iterations, fixed application-level salt)
- **Token IDs:** Generate from 128-bit `crypto/rand` bytes instead of SHA-256-then-truncate with timestamp fallback
- **Audit event IDs:** Use `crypto/rand` instead of predictable `time.Now().UnixNano()`

## Test plan

- [x] `go build ./pkg/ssh/... ./pkg/auth/... ./pkg/security/...`
- [x] `go test -race ./pkg/ssh/...`
- [x] `go test -race ./pkg/auth/...`
- [x] `go test -race ./pkg/security/...`
- [x] `go vet ./pkg/ssh/... ./pkg/auth/... ./pkg/security/...`