### PR TITLE
Fix file permissions too permissive (#26)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -270,6 +271,13 @@ func LoadConfig(configPath string) (*Config, error) {
 	// Enable environment variable support
 	v.SetEnvPrefix("OIDC_AUTH")
 	v.AutomaticEnv()
+
+	// Check config file permissions
+	if info, err := os.Stat(configPath); err == nil {
+		if mode := info.Mode().Perm(); mode&0137 != 0 {
+			log.Printf("WARNING: config file %s has permissions %04o, which are more permissive than recommended 0640", configPath, mode)
+		}
+	}
 
 	// Try to read config file
 	if err := v.ReadInConfig(); err != nil {

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -232,7 +232,7 @@ func generateEventID() string {
 // FileAuditOutput implementation
 
 func NewFileAuditOutput(config config.AuditOutput) (*FileAuditOutput, error) {
-	file, err := os.OpenFile(config.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(config.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open audit file: %w", err)
 	}

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -137,7 +137,7 @@ func (km *KeyManager) SaveKey(username string, key *SSHKey) error {
 		key.CreatedAt.Unix(),
 		key.ExpiresAt.Unix(),
 		key.Comment)
-	if err := os.WriteFile(metadataPath, []byte(metadata), 0644); err != nil {
+	if err := os.WriteFile(metadataPath, []byte(metadata), 0600); err != nil {
 		return fmt.Errorf("failed to save key metadata: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Restrict audit log file permissions from 0644 to 0600 (owner read/write only)
- Restrict SSH key metadata file permissions from 0644 to 0600 (owner read/write only)
- Add warning log when config file permissions are more permissive than 0640

Fixes #26

## Test plan
- [ ] Verify `go build ./pkg/security/... ./pkg/ssh/... ./pkg/config/...` passes
- [ ] Verify `go test -race ./pkg/security/... ./pkg/ssh/... ./pkg/config/...` passes
- [ ] Verify `go vet ./pkg/security/... ./pkg/ssh/... ./pkg/config/...` passes
- [ ] Confirm newly created audit log files have 0600 permissions
- [ ] Confirm newly written key metadata files have 0600 permissions
- [ ] Confirm a warning is logged when config file permissions exceed 0640