### PR TITLE
Fix environment variable override bypassing security settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -268,9 +269,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	v.SetConfigFile(configPath)
 	v.SetConfigType("yaml")
 
-	// Enable environment variable support
+	// Enable environment variable support for safe settings only
 	v.SetEnvPrefix("OIDC_AUTH")
-	v.AutomaticEnv()
+	bindSafeEnvironmentVariables(v)
 
 	// Check config file permissions
 	if info, err := os.Stat(configPath); err == nil {
@@ -291,6 +292,10 @@ func LoadConfig(configPath string) (*Config, error) {
 	var config Config
 	if err := v.Unmarshal(&config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	if err := validateSecurityConfig(&config); err != nil {
+		return nil, err
 	}
 
 	return &config, nil
@@ -328,6 +333,10 @@ func loadFromEnvironment(v *viper.Viper) (*Config, error) {
 				EnabledForLogin: true,
 			},
 		}
+	}
+
+	if err := validateSecurityConfig(&config); err != nil {
+		return nil, err
 	}
 
 	return &config, nil
@@ -423,6 +432,107 @@ func (c *Config) Validate() error {
 	}
 	if c.Authentication.MaxConcurrentSessions <= 0 {
 		return fmt.Errorf("authentication.max_concurrent_sessions must be positive")
+	}
+
+	return nil
+}
+
+// isDevelopmentMode checks if development mode is enabled via OIDC_AUTH_DEV environment variable.
+func isDevelopmentMode() bool {
+	val := strings.ToLower(os.Getenv("OIDC_AUTH_DEV"))
+	return val == "true" || val == "1" || val == "yes"
+}
+
+// bindSafeEnvironmentVariables binds only non-security-critical config keys to environment variables.
+// Security booleans (secure_token_storage, verify_audience, require_pkce, skip_tls_verify) are NOT
+// bound in production mode — they can only come from the config file or defaults.
+func bindSafeEnvironmentVariables(v *viper.Viper) {
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+	// Server settings (safe)
+	safeKeys := []string{
+		"server.socket_path",
+		"server.log_level",
+		"server.audit_log",
+		"server.socket_group",
+		"server.read_timeout",
+		"server.write_timeout",
+
+		// Authentication settings (safe)
+		"authentication.token_lifetime",
+		"authentication.refresh_threshold",
+		"authentication.max_concurrent_sessions",
+
+		// Cloud settings (safe)
+		"cloud.provider",
+		"cloud.auto_discovery",
+
+		// Audit settings (safe)
+		"audit.format",
+		"audit.retention_period",
+
+		// Security settings (safe subset)
+		"security.token_encryption_key",
+		"security.rate_limiting.max_requests_per_minute",
+		"security.rate_limiting.max_concurrent_auths",
+	}
+
+	for _, key := range safeKeys {
+		_ = v.BindEnv(key)
+	}
+
+	// In development mode, also bind security-critical settings with a warning
+	if isDevelopmentMode() {
+		log.Printf("WARNING: Development mode enabled (OIDC_AUTH_DEV=true). Security settings can be overridden via environment variables. DO NOT use in production.")
+
+		securityKeys := []string{
+			"security.secure_token_storage",
+			"security.verify_audience",
+			"security.require_pkce",
+			"security.tls_verification.skip_tls_verify",
+		}
+
+		for _, key := range securityKeys {
+			_ = v.BindEnv(key)
+		}
+	}
+}
+
+// validateSecurityConfig validates that security-critical settings are not weakened.
+// In development mode, weakened settings produce warnings instead of errors.
+func validateSecurityConfig(cfg *Config) error {
+	devMode := isDevelopmentMode()
+
+	if !cfg.Security.SecureTokenStorage {
+		if devMode {
+			log.Printf("WARNING: secure_token_storage is disabled (development mode)")
+		} else {
+			return fmt.Errorf("security.secure_token_storage must be enabled; set OIDC_AUTH_DEV=true to override for development")
+		}
+	}
+
+	if !cfg.Security.VerifyAudience {
+		if devMode {
+			log.Printf("WARNING: verify_audience is disabled (development mode)")
+		} else {
+			return fmt.Errorf("security.verify_audience must be enabled; set OIDC_AUTH_DEV=true to override for development")
+		}
+	}
+
+	if !cfg.Security.RequirePKCE {
+		if devMode {
+			log.Printf("WARNING: require_pkce is disabled (development mode)")
+		} else {
+			return fmt.Errorf("security.require_pkce must be enabled; set OIDC_AUTH_DEV=true to override for development")
+		}
+	}
+
+	if cfg.Security.TLSVerification.SkipTLSVerify {
+		if devMode {
+			log.Printf("WARNING: skip_tls_verify is enabled (development mode)")
+		} else {
+			return fmt.Errorf("security.tls_verification.skip_tls_verify must be disabled; set OIDC_AUTH_DEV=true to override for development")
+		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -431,3 +431,232 @@ oidc:
 		t.Errorf("Expected default max sessions 10, got: %d", cfg.Authentication.MaxConcurrentSessions)
 	}
 }
+
+func TestSecurityConfigValidation(t *testing.T) {
+	// Ensure dev mode is off for these tests
+	t.Setenv("OIDC_AUTH_DEV", "")
+
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "secure defaults pass",
+			config: &Config{
+				Security: SecurityConfig{
+					SecureTokenStorage: true,
+					VerifyAudience:     true,
+					RequirePKCE:        true,
+					TLSVerification:    TLSVerification{SkipTLSVerify: false},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "secure_token_storage disabled fails",
+			config: &Config{
+				Security: SecurityConfig{
+					SecureTokenStorage: false,
+					VerifyAudience:     true,
+					RequirePKCE:        true,
+					TLSVerification:    TLSVerification{SkipTLSVerify: false},
+				},
+			},
+			expectError: true,
+			errorMsg:    "secure_token_storage must be enabled",
+		},
+		{
+			name: "verify_audience disabled fails",
+			config: &Config{
+				Security: SecurityConfig{
+					SecureTokenStorage: true,
+					VerifyAudience:     false,
+					RequirePKCE:        true,
+					TLSVerification:    TLSVerification{SkipTLSVerify: false},
+				},
+			},
+			expectError: true,
+			errorMsg:    "verify_audience must be enabled",
+		},
+		{
+			name: "require_pkce disabled fails",
+			config: &Config{
+				Security: SecurityConfig{
+					SecureTokenStorage: true,
+					VerifyAudience:     true,
+					RequirePKCE:        false,
+					TLSVerification:    TLSVerification{SkipTLSVerify: false},
+				},
+			},
+			expectError: true,
+			errorMsg:    "require_pkce must be enabled",
+		},
+		{
+			name: "skip_tls_verify enabled fails",
+			config: &Config{
+				Security: SecurityConfig{
+					SecureTokenStorage: true,
+					VerifyAudience:     true,
+					RequirePKCE:        true,
+					TLSVerification:    TLSVerification{SkipTLSVerify: true},
+				},
+			},
+			expectError: true,
+			errorMsg:    "skip_tls_verify must be disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSecurityConfig(tt.config)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				} else if !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error containing %q, got: %v", tt.errorMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityConfigValidationDevMode(t *testing.T) {
+	t.Setenv("OIDC_AUTH_DEV", "true")
+
+	// All weakened settings should pass in dev mode (warnings only, no errors)
+	cfg := &Config{
+		Security: SecurityConfig{
+			SecureTokenStorage: false,
+			VerifyAudience:     false,
+			RequirePKCE:        false,
+			TLSVerification:    TLSVerification{SkipTLSVerify: true},
+		},
+	}
+
+	if err := validateSecurityConfig(cfg); err != nil {
+		t.Errorf("Expected no error in dev mode, got: %v", err)
+	}
+}
+
+func TestEnvironmentVariableOverrides(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "config-env-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	configPath := filepath.Join(tempDir, "test.yaml")
+	configContent := `
+server:
+  socket_path: "/tmp/test.sock"
+  log_level: "info"
+oidc:
+  providers:
+    - name: "test"
+      issuer: "https://test.example.com"
+      client_id: "test-client"
+      scopes: ["openid", "profile"]
+authentication:
+  token_lifetime: "1h"
+  refresh_threshold: "5m"
+  max_concurrent_sessions: 10
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	t.Run("safe env vars work", func(t *testing.T) {
+		t.Setenv("OIDC_AUTH_DEV", "")
+		t.Setenv("OIDC_AUTH_SERVER_LOG_LEVEL", "debug")
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+
+		if cfg.Server.LogLevel != "debug" {
+			t.Errorf("Expected log_level 'debug' from env override, got %q", cfg.Server.LogLevel)
+		}
+	})
+
+	t.Run("security env vars ignored in production", func(t *testing.T) {
+		t.Setenv("OIDC_AUTH_DEV", "")
+		t.Setenv("OIDC_AUTH_SECURITY_SECURE_TOKEN_STORAGE", "false")
+		t.Setenv("OIDC_AUTH_SECURITY_VERIFY_AUDIENCE", "false")
+		t.Setenv("OIDC_AUTH_SECURITY_REQUIRE_PKCE", "false")
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+
+		// Security settings should retain their defaults (true), not the env override
+		if !cfg.Security.SecureTokenStorage {
+			t.Error("secure_token_storage should not be overridden by env var in production")
+		}
+		if !cfg.Security.VerifyAudience {
+			t.Error("verify_audience should not be overridden by env var in production")
+		}
+		if !cfg.Security.RequirePKCE {
+			t.Error("require_pkce should not be overridden by env var in production")
+		}
+	})
+
+	t.Run("security env vars allowed in dev mode", func(t *testing.T) {
+		t.Setenv("OIDC_AUTH_DEV", "true")
+		t.Setenv("OIDC_AUTH_SECURITY_SECURE_TOKEN_STORAGE", "false")
+		t.Setenv("OIDC_AUTH_SECURITY_VERIFY_AUDIENCE", "false")
+		t.Setenv("OIDC_AUTH_SECURITY_REQUIRE_PKCE", "false")
+
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+
+		// In dev mode, security env vars should take effect
+		if cfg.Security.SecureTokenStorage {
+			t.Error("secure_token_storage should be overridden by env var in dev mode")
+		}
+		if cfg.Security.VerifyAudience {
+			t.Error("verify_audience should be overridden by env var in dev mode")
+		}
+		if cfg.Security.RequirePKCE {
+			t.Error("require_pkce should be overridden by env var in dev mode")
+		}
+	})
+}
+
+func TestDevelopmentModeDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{"true", "true", true},
+		{"TRUE", "TRUE", true},
+		{"True", "True", true},
+		{"1", "1", true},
+		{"yes", "yes", true},
+		{"YES", "YES", true},
+		{"false", "false", false},
+		{"0", "0", false},
+		{"no", "no", false},
+		{"empty", "", false},
+		{"random", "random", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OIDC_AUTH_DEV", tt.envValue)
+			if got := isDevelopmentMode(); got != tt.expected {
+				t.Errorf("isDevelopmentMode() with OIDC_AUTH_DEV=%q = %v, want %v", tt.envValue, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #27

- Replace `v.AutomaticEnv()` with explicit `bindSafeEnvironmentVariables()` so that security-critical settings (`secure_token_storage`, `verify_audience`, `require_pkce`, `skip_tls_verify`) cannot be weakened via `OIDC_AUTH_*` environment variables
- Add `validateSecurityConfig()` in the `LoadConfig`/`loadFromEnvironment` paths to error on weakened security settings
- Add development mode gate (`OIDC_AUTH_DEV=true`) that allows overrides with loud warnings for local development/testing

## Test plan

- [x] `go build ./pkg/config/...`
- [x] `go test -race ./pkg/config/...` (26 tests pass)
- [x] `go vet ./pkg/config/...`
- [x] `TestSecurityConfigValidation` — secure defaults pass, each weakened boolean fails
- [x] `TestSecurityConfigValidationDevMode` — weakened settings pass in dev mode
- [x] `TestEnvironmentVariableOverrides` — safe env vars work, security env vars ignored in production, allowed in dev mode
- [x] `TestDevelopmentModeDetection` — true/false/yes/1/empty values