### PR TITLE
Add nonce validation for authorization code flow

### DIFF
--- a/pkg/auth/auth_code_flow.go
+++ b/pkg/auth/auth_code_flow.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/rs/zerolog/log"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+	"golang.org/x/oauth2"
+)
+
+// AuthCodeFlowState holds the state needed to complete an authorization code flow.
+type AuthCodeFlowState struct {
+	AuthURL string
+	State   string
+	Nonce   string
+}
+
+// StartAuthCodeFlow initiates an authorization code flow with CSRF state and
+// nonce parameters for replay-attack protection.
+func (p *OIDCProvider) StartAuthCodeFlow(redirectURL string) (*AuthCodeFlowState, error) {
+	nonce, err := security.GenerateNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	state, err := security.GenerateNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	// Temporarily set redirect URL for this flow
+	cfg := *p.OAuth2Config
+	cfg.RedirectURL = redirectURL
+
+	authURL := cfg.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("nonce", nonce),
+	)
+
+	log.Debug().
+		Str("provider", p.Name).
+		Str("redirect_url", redirectURL).
+		Msg("Authorization code flow initiated")
+
+	return &AuthCodeFlowState{
+		AuthURL: authURL,
+		State:   state,
+		Nonce:   nonce,
+	}, nil
+}
+
+// ExchangeCodeForToken exchanges an authorization code for tokens and verifies
+// that the ID token nonce matches expectedNonce.
+func (p *OIDCProvider) ExchangeCodeForToken(ctx context.Context, code, expectedNonce string) (*Token, error) {
+	if expectedNonce == "" {
+		return nil, fmt.Errorf("expected nonce must not be empty")
+	}
+
+	oauth2Token, err := p.OAuth2Config.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange authorization code: %w", err)
+	}
+
+	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return nil, fmt.Errorf("no id_token in token response")
+	}
+
+	// Create a per-request verifier for signature and standard claim checks.
+	verifier := p.Provider.Verifier(&oidc.Config{
+		ClientID:             p.Config.ClientID,
+		SupportedSigningAlgs: []string{"RS256", "ES256"},
+	})
+
+	idToken, err := verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify ID token: %w", err)
+	}
+
+	// The go-oidc library exposes the nonce but does not verify it.
+	// We must check it ourselves to prevent replay attacks.
+	if idToken.Nonce != expectedNonce {
+		return nil, fmt.Errorf("ID token nonce mismatch: expected %q, got %q", expectedNonce, idToken.Nonce)
+	}
+
+	var claims map[string]interface{}
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("failed to parse ID token claims: %w", err)
+	}
+
+	if err := p.validateIDTokenClaims(claims); err != nil {
+		return nil, fmt.Errorf("ID token claim validation failed: %w", err)
+	}
+
+	token := &Token{
+		AccessToken:  oauth2Token.AccessToken,
+		RefreshToken: oauth2Token.RefreshToken,
+		IDToken:      rawIDToken,
+		TokenType:    oauth2Token.TokenType,
+		ExpiresAt:    oauth2Token.Expiry,
+		Fingerprint:  p.generateTokenFingerprint(oauth2Token.AccessToken),
+		Claims:       claims,
+	}
+
+	log.Debug().
+		Str("provider", p.Name).
+		Str("token_type", token.TokenType).
+		Time("expires_at", token.ExpiresAt).
+		Msg("Authorization code exchange completed")
+
+	return token, nil
+}

--- a/pkg/auth/auth_code_flow_test.go
+++ b/pkg/auth/auth_code_flow_test.go
@@ -1,0 +1,347 @@
+package auth
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"golang.org/x/oauth2"
+)
+
+func TestStartAuthCodeFlow(t *testing.T) {
+	provider := &OIDCProvider{
+		Name: "test-provider",
+		Config: config.OIDCProvider{
+			Name:     "test-provider",
+			Issuer:   "https://example.com",
+			ClientID: "test-client",
+			Scopes:   []string{"openid", "profile"},
+		},
+		OAuth2Config: &oauth2.Config{
+			ClientID: "test-client",
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://example.com/authorize",
+				TokenURL: "https://example.com/token",
+			},
+			Scopes: []string{"openid", "profile"},
+		},
+	}
+
+	redirectURL := "http://localhost:8080/callback"
+	flowState, err := provider.StartAuthCodeFlow(redirectURL)
+	if err != nil {
+		t.Fatalf("StartAuthCodeFlow failed: %v", err)
+	}
+
+	// Verify all fields are populated
+	if flowState.AuthURL == "" {
+		t.Error("AuthURL should not be empty")
+	}
+	if flowState.State == "" {
+		t.Error("State should not be empty")
+	}
+	if flowState.Nonce == "" {
+		t.Error("Nonce should not be empty")
+	}
+
+	// Verify AuthURL contains nonce and state params
+	if !strings.Contains(flowState.AuthURL, "nonce=") {
+		t.Error("AuthURL should contain nonce parameter")
+	}
+	if !strings.Contains(flowState.AuthURL, "state=") {
+		t.Error("AuthURL should contain state parameter")
+	}
+	if !strings.Contains(flowState.AuthURL, "redirect_uri=") {
+		t.Error("AuthURL should contain redirect_uri parameter")
+	}
+
+	// Verify uniqueness across calls
+	flowState2, err := provider.StartAuthCodeFlow(redirectURL)
+	if err != nil {
+		t.Fatalf("second StartAuthCodeFlow failed: %v", err)
+	}
+	if flowState.State == flowState2.State {
+		t.Error("State should be unique across calls")
+	}
+	if flowState.Nonce == flowState2.Nonce {
+		t.Error("Nonce should be unique across calls")
+	}
+}
+
+// testOIDCServer sets up an httptest server that serves OIDC discovery, JWKS,
+// and token endpoints. It returns the server and the RSA key used for signing.
+func testOIDCServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey) {
+	t.Helper()
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		// We need the server URL which is set after creation, so we
+		// read the Host header to reconstruct it.
+		scheme := "http"
+		baseURL := scheme + "://" + r.Host
+		disc := map[string]interface{}{
+			"issuer":                 baseURL,
+			"authorization_endpoint": baseURL + "/authorize",
+			"token_endpoint":         baseURL + "/token",
+			"jwks_uri":               baseURL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(disc)
+	})
+
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		jwks := jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{
+				{
+					Key:       &rsaKey.PublicKey,
+					KeyID:     "test-key-1",
+					Algorithm: "RS256",
+					Use:       "sig",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	})
+
+	server := httptest.NewServer(mux)
+	return server, rsaKey
+}
+
+// signIDToken creates a signed JWT with the given claims using the provided RSA key.
+func signIDToken(t *testing.T, key *rsa.PrivateKey, claims map[string]interface{}) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithHeader("kid", "test-key-1").WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("failed to marshal claims: %v", err)
+	}
+
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("failed to serialize token: %v", err)
+	}
+
+	return compact
+}
+
+func TestExchangeCodeForToken_NonceValidation(t *testing.T) {
+	oidcServer, rsaKey := testOIDCServer(t)
+	defer oidcServer.Close()
+
+	correctNonce := "correct-nonce-value"
+	wrongNonce := "wrong-nonce-value"
+
+	// Create an OIDC provider using the test server
+	ctx := context.Background()
+	oidcProvider, err := oidc.NewProvider(ctx, oidcServer.URL)
+	if err != nil {
+		t.Fatalf("failed to create oidc provider: %v", err)
+	}
+
+	now := time.Now()
+	baseClaims := map[string]interface{}{
+		"iss":   oidcServer.URL,
+		"sub":   "user-123",
+		"aud":   "test-client",
+		"exp":   now.Add(time.Hour).Unix(),
+		"iat":   now.Unix(),
+		"nonce": correctNonce,
+	}
+
+	t.Run("correct nonce succeeds", func(t *testing.T) {
+		idToken := signIDToken(t, rsaKey, baseClaims)
+
+		// Set up token endpoint on the OIDC server
+		tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := map[string]interface{}{
+				"access_token":  "test-access-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"refresh_token": "test-refresh-token",
+				"id_token":      idToken,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer tokenServer.Close()
+
+		provider := &OIDCProvider{
+			Name: "test",
+			Config: config.OIDCProvider{
+				ClientID: "test-client",
+			},
+			Provider: oidcProvider,
+			OAuth2Config: &oauth2.Config{
+				ClientID: "test-client",
+				Endpoint: oauth2.Endpoint{
+					TokenURL: tokenServer.URL,
+				},
+			},
+			securityConfig: config.SecurityConfig{},
+		}
+
+		token, err := provider.ExchangeCodeForToken(ctx, "test-code", correctNonce)
+		if err != nil {
+			t.Fatalf("expected success with correct nonce, got error: %v", err)
+		}
+		if token.AccessToken != "test-access-token" {
+			t.Errorf("unexpected access token: %s", token.AccessToken)
+		}
+		if token.Claims["sub"] != "user-123" {
+			t.Errorf("unexpected subject claim: %v", token.Claims["sub"])
+		}
+	})
+
+	t.Run("wrong nonce fails", func(t *testing.T) {
+		idToken := signIDToken(t, rsaKey, baseClaims)
+
+		tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := map[string]interface{}{
+				"access_token": "test-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+				"id_token":     idToken,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer tokenServer.Close()
+
+		provider := &OIDCProvider{
+			Name: "test",
+			Config: config.OIDCProvider{
+				ClientID: "test-client",
+			},
+			Provider: oidcProvider,
+			OAuth2Config: &oauth2.Config{
+				ClientID: "test-client",
+				Endpoint: oauth2.Endpoint{
+					TokenURL: tokenServer.URL,
+				},
+			},
+			securityConfig: config.SecurityConfig{},
+		}
+
+		_, err := provider.ExchangeCodeForToken(ctx, "test-code", wrongNonce)
+		if err == nil {
+			t.Fatal("expected error with wrong nonce, got nil")
+		}
+		if !strings.Contains(err.Error(), "nonce") {
+			t.Errorf("error should mention nonce, got: %v", err)
+		}
+	})
+}
+
+func TestExchangeCodeForToken_MissingNonce(t *testing.T) {
+	oidcServer, rsaKey := testOIDCServer(t)
+	defer oidcServer.Close()
+
+	ctx := context.Background()
+	oidcProvider, err := oidc.NewProvider(ctx, oidcServer.URL)
+	if err != nil {
+		t.Fatalf("failed to create oidc provider: %v", err)
+	}
+
+	now := time.Now()
+	// ID token with no nonce claim
+	claimsWithoutNonce := map[string]interface{}{
+		"iss": oidcServer.URL,
+		"sub": "user-123",
+		"aud": "test-client",
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+	}
+
+	idToken := signIDToken(t, rsaKey, claimsWithoutNonce)
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"id_token":     idToken,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer tokenServer.Close()
+
+	provider := &OIDCProvider{
+		Name: "test",
+		Config: config.OIDCProvider{
+			ClientID: "test-client",
+		},
+		Provider: oidcProvider,
+		OAuth2Config: &oauth2.Config{
+			ClientID: "test-client",
+			Endpoint: oauth2.Endpoint{
+				TokenURL: tokenServer.URL,
+			},
+		},
+		securityConfig: config.SecurityConfig{},
+	}
+
+	_, err = provider.ExchangeCodeForToken(ctx, "test-code", "expected-nonce")
+	if err == nil {
+		t.Fatal("expected error when nonce is missing from ID token")
+	}
+	if !strings.Contains(err.Error(), "nonce") {
+		t.Errorf("error should mention nonce, got: %v", err)
+	}
+}
+
+func TestExchangeCodeForToken_EmptyExpectedNonce(t *testing.T) {
+	provider := &OIDCProvider{
+		Name: "test",
+		Config: config.OIDCProvider{
+			ClientID: "test-client",
+		},
+	}
+
+	_, err := provider.ExchangeCodeForToken(context.Background(), "test-code", "")
+	if err == nil {
+		t.Fatal("expected error when expected nonce is empty")
+	}
+	if !strings.Contains(err.Error(), "expected nonce must not be empty") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// Ensure go-jose types are used (prevent import pruning)
+var _ crypto.Signer = (*rsa.PrivateKey)(nil)
+var _ = jose.RS256
+var _ = jwt.Claims{}
+var _ = big.NewInt

--- a/pkg/security/encryption.go
+++ b/pkg/security/encryption.go
@@ -174,6 +174,16 @@ func (e *Encryption) DecryptBytes(ciphertext []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
+// GenerateNonce generates a cryptographically random URL-safe nonce string.
+// Returns 32 random bytes, base64url-encoded (no padding).
+func GenerateNonce() (string, error) {
+	b := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
 // GenerateKey generates a new encryption key
 func GenerateKey() (string, error) {
 	key := make([]byte, 32)

--- a/pkg/security/encryption_test.go
+++ b/pkg/security/encryption_test.go
@@ -215,6 +215,43 @@ func TestDecryptBytesInvalidData(t *testing.T) {
 	}
 }
 
+func TestGenerateNonce(t *testing.T) {
+	nonces := make(map[string]bool)
+	for i := 0; i < 10; i++ {
+		nonce, err := GenerateNonce()
+		if err != nil {
+			t.Fatalf("Failed to generate nonce: %v", err)
+		}
+
+		if nonce == "" {
+			t.Error("Generated nonce should not be empty")
+		}
+
+		// Verify URL-safe: only base64url characters (no +, /, or =)
+		for _, c := range nonce {
+			if c == '+' || c == '/' || c == '=' {
+				t.Errorf("Nonce contains non-URL-safe character %q: %s", c, nonce)
+				break
+			}
+		}
+
+		// Verify uniqueness
+		if nonces[nonce] {
+			t.Error("Generated nonce should be unique")
+		}
+		nonces[nonce] = true
+
+		// Verify base64url-decodable and correct length (32 bytes)
+		decoded, err := base64.RawURLEncoding.DecodeString(nonce)
+		if err != nil {
+			t.Errorf("Generated nonce should be valid base64url: %v", err)
+		}
+		if len(decoded) != 32 {
+			t.Errorf("Generated nonce should decode to 32 bytes, got %d", len(decoded))
+		}
+	}
+}
+
 func TestGenerateKey(t *testing.T) {
 	// Generate multiple keys
 	keys := make(map[string]bool)


### PR DESCRIPTION
## Summary
- Add `GenerateNonce()` utility to `pkg/security/encryption.go` for cryptographically random URL-safe nonce generation (32 bytes, base64url-encoded)
- Create authorization code flow (`pkg/auth/auth_code_flow.go`) with `StartAuthCodeFlow` and `ExchangeCodeForToken` methods that generate and validate nonces to prevent CSRF and replay attacks
- Add comprehensive tests for nonce generation, correct/wrong/missing nonce scenarios using httptest and real JWT signing

Closes #37

## Test plan
- [x] `go build ./pkg/security/... ./pkg/auth/...` passes
- [x] `go test -race ./pkg/security/... ./pkg/auth/...` passes
- [x] `go vet ./pkg/security/... ./pkg/auth/...` passes
- [x] Correct nonce in ID token — exchange succeeds
- [x] Wrong nonce in ID token — exchange returns nonce mismatch error
- [x] Missing nonce in ID token — exchange returns nonce mismatch error
- [x] Empty expected nonce — returns clear error before exchange
- [x] Generated nonces are unique, URL-safe, and correct length