### PR TITLE
Implement SSH key generation and revocation in broker

### DIFF
--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -10,19 +10,22 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
 	"github.com/scttfrdmn/oidc-pam/pkg/security"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
 )
 
 // Broker manages authentication requests and OIDC provider interactions
 type Broker struct {
-	config       *config.Config
-	providers    map[string]*OIDCProvider
-	tokenManager *TokenManager
-	policyEngine *PolicyEngine
-	auditLogger  *security.AuditLogger
-	sessions     map[string]*Session
-	sessionMutex sync.RWMutex
-	stopChan     chan struct{}
-	wg           sync.WaitGroup
+	config                *config.Config
+	providers             map[string]*OIDCProvider
+	tokenManager          *TokenManager
+	policyEngine          *PolicyEngine
+	auditLogger           *security.AuditLogger
+	sessions              map[string]*Session
+	sessionMutex          sync.RWMutex
+	keyManager            *sshpkg.KeyManager
+	authorizedKeysManager *sshpkg.AuthorizedKeysManager
+	stopChan              chan struct{}
+	wg                    sync.WaitGroup
 }
 
 // Session represents an active authentication session
@@ -40,6 +43,7 @@ type Session struct {
 	UserAgent        string
 	TokenFingerprint string
 	SSHKeyID         string
+	SSHPublicKey     string
 	IsActive         bool
 	RiskScore        int
 	DeviceTrusted    bool
@@ -157,13 +161,15 @@ func NewBroker(cfg *config.Config) (*Broker, error) {
 	}
 
 	broker := &Broker{
-		config:       cfg,
-		providers:    providers,
-		tokenManager: tokenManager,
-		policyEngine: policyEngine,
-		auditLogger:  auditLogger,
-		sessions:     make(map[string]*Session),
-		stopChan:     make(chan struct{}),
+		config:                cfg,
+		providers:             providers,
+		tokenManager:          tokenManager,
+		policyEngine:          policyEngine,
+		auditLogger:           auditLogger,
+		sessions:              make(map[string]*Session),
+		keyManager:            sshpkg.NewKeyManager("/var/lib/oidc-pam/ssh-keys"),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager("/home"),
+		stopChan:              make(chan struct{}),
 	}
 
 	return broker, nil
@@ -523,7 +529,7 @@ func (b *Broker) createSuccessResponse(session *Session) *AuthResponse {
 		Groups:       session.Groups,
 		SessionID:    session.ID,
 		ExpiresAt:    session.ExpiresAt,
-		SSHPublicKey: session.SSHKeyID, // This would be the actual public key
+		SSHPublicKey: session.SSHPublicKey,
 		RiskScore:    session.RiskScore,
 		Metadata: map[string]interface{}{
 			"provider":       session.Provider,
@@ -611,6 +617,7 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 						Msg("Failed to generate SSH key")
 				} else {
 					session.SSHKeyID = sshKey.ID
+					session.SSHPublicKey = sshKey.PublicKey
 				}
 			}
 
@@ -692,22 +699,78 @@ func (b *Broker) sessionCleanup(ctx context.Context) {
 }
 
 func (b *Broker) generateSSHKey(session *Session) (*SSHKey, error) {
-	// This would generate an SSH key pair and return the key info
-	// For now, return a placeholder
+	if b.keyManager == nil || b.authorizedKeysManager == nil {
+		return nil, fmt.Errorf("SSH key manager not initialized")
+	}
+
+	// Generate an RSA key pair with the username as the comment prefix
+	sshKey, err := b.keyManager.GenerateKey(session.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate SSH key pair: %w", err)
+	}
+
+	// Persist the key pair on disk, keyed by session ID so multiple
+	// concurrent sessions for the same user don't overwrite each other.
+	if err := b.keyManager.SaveKey(session.ID, sshKey); err != nil {
+		return nil, fmt.Errorf("failed to save SSH key: %w", err)
+	}
+
+	// Append the public key to the user's authorized_keys file
+	if err := b.authorizedKeysManager.AddPublicKey(session.UserID, sshKey.PublicKey); err != nil {
+		// Best-effort cleanup: remove the stored key if we couldn't authorize it
+		_ = b.keyManager.DeleteKey(session.ID)
+		return nil, fmt.Errorf("failed to add public key to authorized_keys: %w", err)
+	}
+
+	log.Info().
+		Str("session_id", session.ID).
+		Str("user_id", session.UserID).
+		Time("expires_at", sshKey.ExpiresAt).
+		Msg("SSH key generated and authorized")
+
 	return &SSHKey{
-		ID:        fmt.Sprintf("ssh-key-%s", session.ID),
-		PublicKey: "ssh-rsa AAAAB3NzaC1yc2E...",
-		ExpiresAt: session.ExpiresAt,
+		ID:        session.ID,
+		PublicKey: string(sshKey.PublicKey),
+		ExpiresAt: sshKey.ExpiresAt,
 	}, nil
 }
 
 func (b *Broker) revokeSSHKey(session *Session) error {
-	// This would revoke the SSH key
-	// For now, just log
+	if b.keyManager == nil || b.authorizedKeysManager == nil {
+		return nil
+	}
+
+	// Load the stored key to obtain the public key bytes needed for removal
+	sshKey, err := b.keyManager.LoadKey(session.SSHKeyID)
+	if err != nil {
+		// Key may have already been deleted; treat as success
+		log.Debug().
+			Err(err).
+			Str("session_id", session.ID).
+			Str("ssh_key_id", session.SSHKeyID).
+			Msg("SSH key not found during revocation (may already be deleted)")
+		return nil
+	}
+
+	// Remove from authorized_keys (best effort — do not abort on failure)
+	if err := b.authorizedKeysManager.RemovePublicKey(session.UserID, sshKey.PublicKey); err != nil {
+		log.Warn().
+			Err(err).
+			Str("session_id", session.ID).
+			Str("user_id", session.UserID).
+			Msg("Failed to remove public key from authorized_keys during revocation")
+	}
+
+	// Delete the key files from disk
+	if err := b.keyManager.DeleteKey(session.SSHKeyID); err != nil {
+		return fmt.Errorf("failed to delete SSH key files: %w", err)
+	}
+
 	log.Info().
 		Str("session_id", session.ID).
 		Str("ssh_key_id", session.SSHKeyID).
-		Msg("Revoking SSH key")
+		Msg("SSH key revoked")
+
 	return nil
 }
 

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -2,11 +2,14 @@ package auth
 
 import (
 	"context"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
 )
 
 func TestBrokerInternalMethods(t *testing.T) {
@@ -301,45 +304,89 @@ func TestBrokerProviderSelection(t *testing.T) {
 }
 
 func TestBrokerSSHKeyMethods(t *testing.T) {
-	// Test SSH key methods without requiring full broker initialization
+	// Use real temp directories for key storage and home dirs.
+	keyDir := t.TempDir()
+	homeDir := t.TempDir()
 
-	// Create broker with minimal config
 	broker := &Broker{
 		config: &config.Config{
 			Security: config.SecurityConfig{
 				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
 			},
 		},
+		keyManager:            sshpkg.NewKeyManager(keyDir),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir),
 	}
 
-	// Test SSH key generation with mock session
-	mockSession := &Session{
-		ID:               "test-session",
-		UserID:           "test-user",
-		Email:            "test@example.com",
+	// Use a short key size to keep the test fast.
+	broker.keyManager.SetKeySize(2048)
+
+	session := &Session{
+		ID:               "test-session-ssh",
+		UserID:           "test-user-ssh",
+		Email:            "ssh@example.com",
 		Groups:           []string{"users"},
 		Provider:         "test-provider",
 		DeviceID:         "test-device",
 		CreatedAt:        time.Now(),
 		ExpiresAt:        time.Now().Add(time.Hour),
 		LastAccessed:     time.Now(),
-		SourceIP:         "192.168.1.100",
+		SourceIP:         "192.168.1.1",
 		UserAgent:        "test-agent-ssh",
 		TokenFingerprint: "test-token-fp-ssh",
-		SSHKeyID:         "test-ssh-key-ssh",
 		IsActive:         true,
-		RiskScore:        20,
+		RiskScore:        0,
 	}
 
-	_, err := broker.generateSSHKey(mockSession)
+	// Generate an SSH key.
+	sshKey, err := broker.generateSSHKey(session)
 	if err != nil {
-		t.Logf("SSH key generation failed as expected: %v", err)
+		t.Fatalf("generateSSHKey failed: %v", err)
+	}
+	if sshKey == nil {
+		t.Fatal("Expected non-nil SSHKey")
+	}
+	if sshKey.PublicKey == "" {
+		t.Error("Expected non-empty public key")
+	}
+	if !strings.HasPrefix(sshKey.PublicKey, "ssh-rsa ") {
+		t.Errorf("Expected public key to start with 'ssh-rsa ', got: %.20s", sshKey.PublicKey)
+	}
+	if sshKey.ID != session.ID {
+		t.Errorf("Expected key ID %q, got %q", session.ID, sshKey.ID)
 	}
 
-	// Test SSH key revocation
-	err = broker.revokeSSHKey(mockSession)
+	// Verify the public key was written to authorized_keys.
+	akPath := homeDir + "/" + session.UserID + "/.ssh/authorized_keys"
+	akData, err := os.ReadFile(akPath)
 	if err != nil {
-		t.Logf("SSH key revocation failed as expected: %v", err)
+		t.Fatalf("Failed to read authorized_keys: %v", err)
+	}
+	if !strings.Contains(string(akData), strings.TrimSpace(sshKey.PublicKey)) {
+		t.Error("Public key not found in authorized_keys")
+	}
+
+	// Set the SSHKeyID on the session so revokeSSHKey can find it.
+	session.SSHKeyID = session.ID
+	session.SSHPublicKey = sshKey.PublicKey
+
+	// Revoke the SSH key.
+	if err := broker.revokeSSHKey(session); err != nil {
+		t.Fatalf("revokeSSHKey failed: %v", err)
+	}
+
+	// Verify the public key was removed from authorized_keys.
+	akData, err = os.ReadFile(akPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("Failed to read authorized_keys after revocation: %v", err)
+	}
+	if err == nil && strings.Contains(string(akData), strings.TrimSpace(sshKey.PublicKey)) {
+		t.Error("Public key still present in authorized_keys after revocation")
+	}
+
+	// Verify the key files were deleted.
+	if _, err := broker.keyManager.LoadKey(session.ID); err == nil {
+		t.Error("Expected key files to be deleted after revocation")
 	}
 }
 

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -10,11 +10,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/scttfrdmn/oidc-pam/internal/ipc"
 	"github.com/scttfrdmn/oidc-pam/pkg/auth"
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
 )
 
 func main() {
@@ -224,9 +226,92 @@ func (s *IntegrationTestSuite) TestSessionManagement() error {
 }
 
 func (s *IntegrationTestSuite) TestSSHKeyGeneration() error {
-	// Test SSH key generation functionality
-	// This would typically involve creating SSH keys and managing authorized_keys
-	log.Println("SSH key generation test passed (placeholder)")
+	// Test SSH key generation and authorized_keys management using the ssh package
+	// directly, so this test works without a running broker.
+	keyDir, err := os.MkdirTemp("", "oidc-pam-ssh-keys-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp key dir: %w", err)
+	}
+	defer os.RemoveAll(keyDir)
+
+	homeDir, err := os.MkdirTemp("", "oidc-pam-home-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp home dir: %w", err)
+	}
+	defer os.RemoveAll(homeDir)
+
+	km := sshpkg.NewKeyManager(keyDir)
+	km.SetKeySize(2048) // small key for speed
+
+	akm := sshpkg.NewAuthorizedKeysManager(homeDir)
+
+	username := "integration-test-user"
+	sessionID := "integration-test-session"
+
+	// Generate a key.
+	sshKey, err := km.GenerateKey(username)
+	if err != nil {
+		return fmt.Errorf("GenerateKey failed: %w", err)
+	}
+	if len(sshKey.PublicKey) == 0 {
+		return fmt.Errorf("generated public key is empty")
+	}
+
+	// Save the key using the session ID as the storage key.
+	if err := km.SaveKey(sessionID, sshKey); err != nil {
+		return fmt.Errorf("SaveKey failed: %w", err)
+	}
+
+	// Add to authorized_keys.
+	if err := akm.AddPublicKey(username, sshKey.PublicKey); err != nil {
+		return fmt.Errorf("AddPublicKey failed: %w", err)
+	}
+
+	// Load the key back and verify.
+	loaded, err := km.LoadKey(sessionID)
+	if err != nil {
+		return fmt.Errorf("LoadKey failed: %w", err)
+	}
+	if string(loaded.PublicKey) != string(sshKey.PublicKey) {
+		return fmt.Errorf("loaded public key does not match generated key")
+	}
+
+	// Verify the key appears in authorized_keys.
+	akPath := filepath.Join(homeDir, username, ".ssh", "authorized_keys")
+	akData, err := os.ReadFile(akPath)
+	if err != nil {
+		return fmt.Errorf("failed to read authorized_keys: %w", err)
+	}
+	pubKeyStr := strings.TrimSpace(string(sshKey.PublicKey))
+	if !strings.Contains(string(akData), pubKeyStr) {
+		return fmt.Errorf("public key not found in authorized_keys")
+	}
+
+	// Remove the public key.
+	if err := akm.RemovePublicKey(username, sshKey.PublicKey); err != nil {
+		return fmt.Errorf("RemovePublicKey failed: %w", err)
+	}
+
+	// Verify removal.
+	akData, err = os.ReadFile(akPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read authorized_keys after removal: %w", err)
+	}
+	if err == nil && strings.Contains(string(akData), pubKeyStr) {
+		return fmt.Errorf("public key still present in authorized_keys after removal")
+	}
+
+	// Delete the key files.
+	if err := km.DeleteKey(sessionID); err != nil {
+		return fmt.Errorf("DeleteKey failed: %w", err)
+	}
+
+	// Verify deletion.
+	if _, err := km.LoadKey(sessionID); err == nil {
+		return fmt.Errorf("expected key files to be deleted")
+	}
+
+	log.Println("SSH key generation test passed")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Wires up `KeyManager` and `AuthorizedKeysManager` into `Broker` struct, initialized in `NewBroker()` with system defaults (`/var/lib/oidc-pam/ssh-keys` and `/home`)
- Implements `generateSSHKey()`: generates RSA key pair, saves to disk keyed by session ID, adds public key to the user's `authorized_keys`
- Implements `revokeSSHKey()`: loads key by session ID, removes public key from `authorized_keys`, then deletes the key files
- Stores the generated public key in `Session.SSHPublicKey` so it flows through to `AuthResponse`
- nil-guards on the managers maintain backward compatibility with tests that manually construct `&Broker{}`

## Test plan

- [x] `TestBrokerSSHKeyMethods` updated to use real temp directories; asserts key generation, `authorized_keys` population, revocation, and file deletion
- [x] `TestSSHKeyGeneration` integration test updated to replace placeholder with real end-to-end `KeyManager` + `AuthorizedKeysManager` assertions
- [x] `go test -race ./pkg/auth/...` passes
- [x] `go build ./pkg/auth/...` passes

Closes #49