### PR TITLE
Validate request metadata and harden HTTP client TLS configuration

### DIFF
--- a/internal/ipc/validate.go
+++ b/internal/ipc/validate.go
@@ -19,6 +19,15 @@ const (
 
 	// maxFieldLen is the maximum length for generic string fields.
 	maxFieldLen = 256
+
+	// maxMetadataKeys is the maximum number of entries in the metadata map.
+	maxMetadataKeys = 32
+
+	// maxMetadataKeyLen is the maximum length of a single metadata key.
+	maxMetadataKeyLen = 64
+
+	// maxMetadataValueLen is the maximum length of a string metadata value.
+	maxMetadataValueLen = 1024
 )
 
 // userIDRegexp matches valid Unix usernames: starts with a lowercase letter or
@@ -58,6 +67,9 @@ func validateRequest(req *Request) error {
 			if err := validateSessionID(req.SessionID); err != nil {
 				return err
 			}
+		}
+		if err := validateMetadata(req.Metadata); err != nil {
+			return err
 		}
 		return nil
 
@@ -116,6 +128,51 @@ func validateStringField(val, name string, maxLen int) error {
 	for _, r := range val {
 		if unicode.IsControl(r) {
 			return fmt.Errorf("%s contains invalid control characters", name)
+		}
+	}
+	return nil
+}
+
+// validateMetadata validates the metadata map: enforces limits on key count,
+// key length, and value types/sizes. Allowed value types are string, bool,
+// float64 (JSON number), and nil.
+func validateMetadata(m map[string]interface{}) error {
+	if len(m) == 0 {
+		return nil
+	}
+	if len(m) > maxMetadataKeys {
+		return fmt.Errorf("metadata exceeds maximum of %d keys", maxMetadataKeys)
+	}
+	for k, v := range m {
+		if len(k) == 0 {
+			return fmt.Errorf("metadata key must not be empty")
+		}
+		if len(k) > maxMetadataKeyLen {
+			return fmt.Errorf("metadata key %q exceeds maximum length of %d", k, maxMetadataKeyLen)
+		}
+		for _, r := range k {
+			if unicode.IsControl(r) {
+				return fmt.Errorf("metadata key %q contains invalid control characters", k)
+			}
+		}
+		switch val := v.(type) {
+		case nil:
+			// allowed
+		case bool:
+			// allowed
+		case float64:
+			// allowed (JSON numbers decode to float64)
+		case string:
+			if len(val) > maxMetadataValueLen {
+				return fmt.Errorf("metadata value for key %q exceeds maximum length of %d", k, maxMetadataValueLen)
+			}
+			for _, r := range val {
+				if unicode.IsControl(r) {
+					return fmt.Errorf("metadata value for key %q contains invalid control characters", k)
+				}
+			}
+		default:
+			return fmt.Errorf("metadata value for key %q has unsupported type %T (allowed: string, bool, number, null)", k, v)
 		}
 	}
 	return nil

--- a/internal/ipc/validate_test.go
+++ b/internal/ipc/validate_test.go
@@ -256,3 +256,74 @@ func TestValidateRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    map[string]interface{}
+		wantErr bool
+	}{
+		{"nil map", nil, false},
+		{"empty map", map[string]interface{}{}, false},
+		{"string value", map[string]interface{}{"k": "v"}, false},
+		{"bool value", map[string]interface{}{"flag": true}, false},
+		{"float64 value", map[string]interface{}{"score": float64(42)}, false},
+		{"nil value", map[string]interface{}{"k": nil}, false},
+		{"mixed valid types", map[string]interface{}{"a": "str", "b": true, "c": float64(1), "d": nil}, false},
+		{
+			"too many keys",
+			func() map[string]interface{} {
+				m := make(map[string]interface{})
+				for i := 0; i < maxMetadataKeys+1; i++ {
+					m[strings.Repeat("k", i+1)] = "v"
+				}
+				return m
+			}(),
+			true,
+		},
+		{"empty key", map[string]interface{}{"": "v"}, true},
+		{"key too long", map[string]interface{}{strings.Repeat("k", maxMetadataKeyLen+1): "v"}, true},
+		{"key with control char", map[string]interface{}{"key\x00bad": "v"}, true},
+		{"string value too long", map[string]interface{}{"k": strings.Repeat("x", maxMetadataValueLen+1)}, true},
+		{"string value with control char", map[string]interface{}{"k": "val\x00ue"}, true},
+		{"unsupported type slice", map[string]interface{}{"k": []string{"a"}}, true},
+		{"unsupported type map", map[string]interface{}{"k": map[string]string{"a": "b"}}, true},
+		{"unsupported type int", map[string]interface{}{"k": 42}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMetadata(tt.meta)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMetadata() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRequestMetadata(t *testing.T) {
+	// Verify metadata validation is wired into validateRequest for authenticate.
+	tests := []struct {
+		name    string
+		meta    map[string]interface{}
+		wantErr bool
+	}{
+		{"valid metadata", map[string]interface{}{"service": "sshd", "tty": "pts/0"}, false},
+		{"unsupported value type", map[string]interface{}{"nested": map[string]interface{}{"a": "b"}}, true},
+		{"value too long", map[string]interface{}{"k": strings.Repeat("x", maxMetadataValueLen+1)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &Request{
+				Type:     "authenticate",
+				UserID:   "testuser",
+				Metadata: tt.meta,
+			}
+			err := validateRequest(req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -569,8 +569,10 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 			b.removeSession(session.ID)
 			return
 		case <-ticker.C:
-			// Poll for authorization
-			token, err := provider.PollDeviceAuthorization(deviceFlow.DeviceCode)
+			// Poll for authorization using a per-attempt context with timeout.
+			pollCtx, pollCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			token, err := provider.PollDeviceAuthorization(pollCtx, deviceFlow.DeviceCode)
+			pollCancel()
 			if err != nil {
 				// Handle specific error types
 				if err.Error() == "authorization_pending" {

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -115,9 +116,14 @@ func NewOIDCProvider(providerCfg OIDCProviderConfig, secCfg config.SecurityConfi
 		RedirectURL: "", // Not used for device flow
 	}
 
-	// Create HTTP client with appropriate timeout
+	// Create HTTP client with TLS 1.2 minimum and a sensible timeout.
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+		},
 	}
 
 	return &OIDCProvider{
@@ -192,8 +198,9 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 	return deviceFlow, nil
 }
 
-// PollDeviceAuthorization polls for device authorization completion
-func (p *OIDCProvider) PollDeviceAuthorization(deviceCode string) (*Token, error) {
+// PollDeviceAuthorization polls for device authorization completion.
+// ctx is used for ID token verification so callers can apply deadlines.
+func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode string) (*Token, error) {
 	// Get token endpoint
 	tokenEndpoint := p.Provider.Endpoint().TokenURL
 
@@ -229,7 +236,7 @@ func (p *OIDCProvider) PollDeviceAuthorization(deviceCode string) (*Token, error
 	// Parse and verify ID token if present
 	var claims map[string]interface{}
 	if tokenResp.IDToken != "" {
-		idToken, err := p.Verifier.Verify(context.Background(), tokenResp.IDToken)
+		idToken, err := p.Verifier.Verify(ctx, tokenResp.IDToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify ID token: %w", err)
 		}

--- a/pkg/auth/device_flow_test.go
+++ b/pkg/auth/device_flow_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -309,7 +310,7 @@ func TestDeviceFlowPollingMethod(t *testing.T) {
 		PollingInterval: 5,
 	}
 
-	token, err := provider.PollDeviceAuthorization(deviceFlow.DeviceCode)
+	token, err := provider.PollDeviceAuthorization(context.Background(), deviceFlow.DeviceCode)
 	if err != nil {
 		t.Logf("PollDeviceAuthorization failed as expected: %v", err)
 	}


### PR DESCRIPTION
## Summary

Addresses all three items from issue #52.

### Metadata validation (`internal/ipc/validate.go`)
- New `validateMetadata()` enforces:
  - Max **32 keys** per map
  - Max **64-character** keys (no empty keys, no control characters)
  - Allowed value types: `string`, `bool`, `float64` (JSON number), `nil` — slices, nested maps, and raw `int` are rejected
  - Max **1024-character** string values (no control characters)
- Wired into `validateRequest()` for `authenticate` requests

### TLS hardening (`pkg/auth/device_flow.go`)
- HTTP client for OIDC endpoint communication now uses `&http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}`, ensuring TLS 1.2+ for all provider connections

### Context propagation (`pkg/auth/device_flow.go`, `pkg/auth/broker.go`)
- `PollDeviceAuthorization` now accepts `ctx context.Context` — passed through to `Verifier.Verify()` replacing `context.Background()`
- `broker.go` creates a `context.WithTimeout(30s)` per poll attempt so verification can't stall indefinitely

## Test plan

- [x] `TestValidateMetadata` — covers nil/empty map, all valid types, too many keys, empty key, key too long, key with control char, value too long, value with control char, unsupported types (slice, map, int)
- [x] `TestValidateRequestMetadata` — verifies metadata validation is wired into `validateRequest`
- [x] `go test -race ./internal/ipc/... ./pkg/auth/...` passes
- [x] `go build ./...` passes

Closes #52