### PR TITLE
test: fix flaky IPC connection tests (broken pipe race)

### DIFF
--- a/internal/ipc/server_coverage_test.go
+++ b/internal/ipc/server_coverage_test.go
@@ -132,17 +132,20 @@ func TestServerConnectionWithMalformedJSON(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Send malformed JSON
-	_, err = conn.Write([]byte("{invalid json"))
-	if err != nil {
-		t.Fatalf("Failed to write malformed JSON: %v", err)
+	// Send malformed JSON. The server may reject the connection on peer
+	// credential verification (non-root peer) and close it before we finish
+	// writing, which surfaces as a broken pipe — that is an acceptable outcome,
+	// so only assert on the response if the write succeeded.
+	if _, err = conn.Write([]byte("{invalid json")); err != nil {
+		return
 	}
 
 	// Read response
 	buffer := make([]byte, 4096)
 	n, err := conn.Read(buffer)
 	if err != nil {
-		t.Fatalf("Failed to read response: %v", err)
+		// A server-side rejection close (EOF/broken pipe) is acceptable here.
+		return
 	}
 
 	var response Response
@@ -192,11 +195,10 @@ func TestServerConnectionWithEmptyData(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Send empty data
-	_, err = conn.Write([]byte(""))
-	if err != nil {
-		t.Fatalf("Failed to write empty data: %v", err)
-	}
+	// Send empty data. As above, the server may reject and close the connection
+	// first (broken pipe), which is an acceptable outcome — the assertion is
+	// simply that the server handles this without crashing.
+	_, _ = conn.Write([]byte(""))
 
 	// Server should handle empty data gracefully
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
## Problem

`TestServerConnectionWithMalformedJSON` and `TestServerConnectionWithEmptyData` intermittently fail main CI with:

```
server_coverage_test.go: Failed to write ...: write unix @->/tmp/ipc-test-*/test.sock: write: broken pipe
```

## Root cause

On Linux the IPC server verifies peer credentials in `handleConnection`, finds the test client is not root, sends `PERMISSION_DENIED`, and closes the connection (deferred `conn.Close()`). This races the client's `conn.Write`, so the write occasionally lands after the server has closed → `EPIPE`. The tests treated that write error as fatal.

This is a **test bug, not a product bug** — server-side rejection of a non-root peer is correct, intended behavior (the test already accepts `PERMISSION_DENIED` as a valid response code).

## Fix

Treat write/read errors as an acceptable rejection outcome instead of `t.Fatalf`. Response assertions still run whenever the server replies before closing.

Verified locally: both tests pass 5/5 with `-count=5`, full `internal/ipc` package passes `-count=3`.