### PR TITLE
fix(security): bind OIDC identity to local user + harden authorized_keys (C-1, C-2, H-1, M-7, M-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Critical (#90):** Bind the authenticated OIDC identity to the requested local username via `username_claim` before activating a session; previously any IdP user could log in as any local account (including root). Fails closed when `username_claim` is unset.
+- **Critical (#91):** Harden authorized_keys writes against symlink/TOCTOU attacks — the root broker now refuses symlinked `.ssh`/`authorized_keys`, opens files with `O_NOFOLLOW`, and replaces files atomically (temp+rename) instead of following/truncating user-planted links.
+- **High (#92):** Enforce `require_groups` — required group membership is now checked against the authenticated user's groups instead of being silently ignored.
+- **(#95) M-7:** `validateUsername` is now a strict POSIX login-name allowlist and is applied in `RemoveExpiredKeys` (previously skipped).
+- **(#95) M-8:** Reject SSH public keys containing embedded newlines (authorized_keys injection); `ValidateKeyFormat` now enforces this and is wired into `AddPublicKey`.
+
 ### Added
 - DEPLOYMENT.md: "Identity vs. Authentication" guidance explaining that oidc-pam is an authentication layer (use SSSD/a directory for NSS identity and consistent cluster UIDs), why no `libnss_oidc.so` module is shipped, and the provision-on-first-login pattern for directory-less environments
 

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -728,6 +728,60 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 				return
 			}
 
+			// SECURITY (C-1): bind the authenticated OIDC identity to the local
+			// username this login was requested for. Without this, any IdP user
+			// could authenticate as any local account (including root). Fail
+			// closed on any mismatch or misconfiguration.
+			if err := b.verifyIdentityBinding(provider, userInfo, session.UserID); err != nil {
+				log.Warn().
+					Err(err).
+					Str("session_id", session.ID).
+					Str("requested_user", session.UserID).
+					Str("oidc_subject", userInfo.Subject).
+					Msg("Rejected authentication: OIDC identity does not match requested local user")
+				if b.metrics != nil {
+					b.metrics.RecordAuth(provider.Name, "failure", "IDENTITY_MISMATCH")
+				}
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType:    "authentication_denied",
+					UserID:       session.UserID,
+					Email:        userInfo.Email,
+					SessionID:    session.ID,
+					Success:      false,
+					ErrorCode:    "IDENTITY_MISMATCH",
+					ErrorMessage: err.Error(),
+					Timestamp:    time.Now(),
+				})
+				b.removeSession(session.ID)
+				return
+			}
+
+			// SECURITY (H-1): enforce required group membership. RequiredGroups
+			// was previously collected by the policy engine but never checked.
+			if err := b.verifyRequiredGroups(userInfo.Groups); err != nil {
+				log.Warn().
+					Err(err).
+					Str("session_id", session.ID).
+					Str("requested_user", session.UserID).
+					Msg("Rejected authentication: required group membership not satisfied")
+				if b.metrics != nil {
+					b.metrics.RecordAuth(provider.Name, "failure", "GROUP_DENIED")
+				}
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType:    "authentication_denied",
+					UserID:       session.UserID,
+					Email:        userInfo.Email,
+					Groups:       userInfo.Groups,
+					SessionID:    session.ID,
+					Success:      false,
+					ErrorCode:    "GROUP_DENIED",
+					ErrorMessage: err.Error(),
+					Timestamp:    time.Now(),
+				})
+				b.removeSession(session.ID)
+				return
+			}
+
 			// Clone before mutation: getSession returns the raw pointer stored in
 			// the map; writing to it without a lock races with concurrent readers.
 			updated := *session
@@ -973,6 +1027,101 @@ func sanitizeErrorForClient(err error) string {
 	default:
 		return "authentication failed"
 	}
+}
+
+// verifyIdentityBinding ensures the authenticated OIDC identity actually maps
+// to the local username the login was requested for (requestedUser). This is
+// the authn->authz boundary: it prevents an IdP user from logging in as an
+// arbitrary local account. It fails closed — any misconfiguration or mismatch
+// returns an error rather than allowing the login.
+//
+// The expected local username is resolved from the configured username_claim
+// (falling back to the standard "preferred_username" claim). Comparison is
+// case-insensitive on the local-part, matching typical POSIX/login behavior.
+func (b *Broker) verifyIdentityBinding(provider *OIDCProvider, userInfo *UserInfo, requestedUser string) error {
+	if userInfo == nil {
+		return fmt.Errorf("no user info available")
+	}
+	requested := strings.TrimSpace(strings.ToLower(requestedUser))
+	if requested == "" {
+		return fmt.Errorf("requested username is empty")
+	}
+
+	claimName := strings.TrimSpace(provider.Config.UserMapping.UsernameClaim)
+	if claimName == "" {
+		// Fail closed: without an explicit mapping we will not guess which
+		// claim authorizes a local login.
+		return fmt.Errorf("username_claim is not configured for provider %q; refusing to bind identity", provider.Config.Name)
+	}
+
+	mapped, err := claimToUsername(userInfo, claimName)
+	if err != nil {
+		return err
+	}
+	mapped = strings.TrimSpace(strings.ToLower(mapped))
+	if mapped == "" {
+		return fmt.Errorf("username_claim %q produced an empty username", claimName)
+	}
+
+	// If the claim is an email (e.g. preferred_username/email), allow matching
+	// either the full value or its local-part against the requested user.
+	if mapped == requested {
+		return nil
+	}
+	if local, _, found := strings.Cut(mapped, "@"); found && local == requested {
+		return nil
+	}
+	return fmt.Errorf("authenticated identity %q (claim %q) does not match requested local user %q", mapped, claimName, requested)
+}
+
+// claimToUsername extracts a string username from the resolved claims using the
+// configured claim name, with sensible fallbacks to well-known UserInfo fields.
+func claimToUsername(userInfo *UserInfo, claimName string) (string, error) {
+	if userInfo.Claims != nil {
+		if v, ok := userInfo.Claims[claimName]; ok {
+			if s, ok := v.(string); ok {
+				return s, nil
+			}
+			return "", fmt.Errorf("username_claim %q is not a string", claimName)
+		}
+	}
+	// Fallbacks for the common standard claims even if not present in the raw map.
+	switch claimName {
+	case "preferred_username", "sub":
+		if userInfo.Subject != "" {
+			return userInfo.Subject, nil
+		}
+	case "email":
+		if userInfo.Email != "" {
+			return userInfo.Email, nil
+		}
+	}
+	return "", fmt.Errorf("username_claim %q not present in token claims", claimName)
+}
+
+// verifyRequiredGroups enforces that the authenticated user is a member of all
+// globally required groups (Authentication.RequireGroups). Returns nil when no
+// groups are required. Comparison is exact and case-sensitive (group names are
+// provider-defined identifiers).
+func (b *Broker) verifyRequiredGroups(userGroups []string) error {
+	required := b.config.Authentication.RequireGroups
+	if len(required) == 0 {
+		return nil
+	}
+	have := make(map[string]struct{}, len(userGroups))
+	for _, g := range userGroups {
+		have[g] = struct{}{}
+	}
+	var missing []string
+	for _, r := range required {
+		if _, ok := have[r]; !ok {
+			missing = append(missing, r)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("user is not a member of required group(s): %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // SSHKey represents an SSH key

--- a/pkg/auth/identity_binding_test.go
+++ b/pkg/auth/identity_binding_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+func providerWithClaim(claim string) *OIDCProvider {
+	return &OIDCProvider{
+		Config: config.OIDCProvider{
+			Name:        "test",
+			UserMapping: config.UserMapping{UsernameClaim: claim},
+		},
+	}
+}
+
+// TestVerifyIdentityBinding covers the C-1 fix: an authenticated OIDC identity
+// must map to the requested local username, and the check must fail closed.
+func TestVerifyIdentityBinding(t *testing.T) {
+	b := &Broker{config: &config.Config{}}
+
+	tests := []struct {
+		name      string
+		claim     string
+		userInfo  *UserInfo
+		requested string
+		wantErr   bool
+	}{
+		{
+			name:      "preferred_username matches",
+			claim:     "preferred_username",
+			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}},
+			requested: "alice",
+			wantErr:   false,
+		},
+		{
+			name:      "email local-part matches requested user",
+			claim:     "email",
+			userInfo:  &UserInfo{Email: "alice@example.com", Claims: map[string]interface{}{"email": "alice@example.com"}},
+			requested: "alice",
+			wantErr:   false,
+		},
+		{
+			name:      "case-insensitive match",
+			claim:     "preferred_username",
+			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "Alice"}},
+			requested: "alice",
+			wantErr:   false,
+		},
+		{
+			name:      "mismatch is rejected (impersonation attempt)",
+			claim:     "preferred_username",
+			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "attacker"}},
+			requested: "root",
+			wantErr:   true,
+		},
+		{
+			name:      "missing claim configured fails closed",
+			claim:     "",
+			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}},
+			requested: "alice",
+			wantErr:   true,
+		},
+		{
+			name:      "claim absent in token fails closed",
+			claim:     "preferred_username",
+			userInfo:  &UserInfo{Claims: map[string]interface{}{"email": "alice@example.com"}},
+			requested: "alice",
+			wantErr:   true,
+		},
+		{
+			name:      "empty requested user rejected",
+			claim:     "preferred_username",
+			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}},
+			requested: "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := b.verifyIdentityBinding(providerWithClaim(tc.claim), tc.userInfo, tc.requested)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestVerifyRequiredGroups covers the H-1 fix.
+func TestVerifyRequiredGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		required []string
+		have     []string
+		wantErr  bool
+	}{
+		{"no groups required", nil, []string{"x"}, false},
+		{"member satisfies", []string{"hpc-admins"}, []string{"a", "hpc-admins"}, false},
+		{"missing required group denied", []string{"hpc-admins"}, []string{"users"}, true},
+		{"all required present", []string{"a", "b"}, []string{"a", "b", "c"}, false},
+		{"one of several missing denied", []string{"a", "b"}, []string{"a"}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &Broker{config: &config.Config{
+				Authentication: config.AuthenticationConfig{RequireGroups: tc.required},
+			}}
+			err := b.verifyRequiredGroups(tc.have)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -16,8 +16,12 @@ import (
 // withFileLock acquires an exclusive POSIX file lock on a lockfile adjacent to
 // the authorized_keys file, runs fn, then releases the lock. This serializes
 // concurrent read-then-write operations across processes.
+//
+// The lock file is opened with O_NOFOLLOW so a symlink planted at the lock path
+// (in a user-controlled .ssh directory) cannot redirect the open to another
+// file (see ensureSecureSSHDir for the surrounding symlink defenses).
 func withFileLock(lockPath string, fn func() error) error {
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open lock file: %w", err)
 	}
@@ -31,6 +35,93 @@ func withFileLock(lockPath string, fn func() error) error {
 	}
 
 	return fn()
+}
+
+// ensureSecureSSHDir verifies that the user's .ssh directory is safe for the
+// root broker to write into, creating it if absent. It defends against symlink
+// attacks (CVE-class TOCTOU): a user owns their own ~/.ssh and could point it,
+// or authorized_keys within it, at an arbitrary file (e.g. /etc/passwd) so that
+// the root process follows the link and writes/truncates the target.
+//
+// It rejects the operation if .ssh exists but is a symlink or not a directory.
+// Callers must additionally open files within it using O_NOFOLLOW (see
+// openAuthorizedKeysForAppend / writeAuthorizedKeysAtomic).
+func ensureSecureSSHDir(sshDir string) error {
+	info, err := os.Lstat(sshDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if mkErr := os.MkdirAll(sshDir, 0700); mkErr != nil {
+				return fmt.Errorf("failed to create .ssh directory: %w", mkErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to stat .ssh directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to use .ssh: %q is a symlink", sshDir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("refusing to use .ssh: %q is not a directory", sshDir)
+	}
+	return nil
+}
+
+// rejectIfSymlink returns an error if path exists and is a symbolic link. Used
+// before opening/replacing authorized_keys so the root broker never follows a
+// user-planted link.
+func rejectIfSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to operate on %q: it is a symlink", path)
+	}
+	return nil
+}
+
+// openAuthorizedKeysForAppend opens the authorized_keys file for appending with
+// O_NOFOLLOW, refusing to follow a symlink at the final path component.
+func openAuthorizedKeysForAppend(path string) (*os.File, error) {
+	if err := rejectIfSymlink(path); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW, 0600)
+}
+
+// writeAuthorizedKeysAtomic writes content to the authorized_keys file safely:
+// it refuses if the target is a symlink, writes to a temporary file in the same
+// directory (created with O_NOFOLLOW|O_EXCL), then atomically renames over the
+// target. Rename replaces the directory entry rather than following/truncating
+// a link, so a planted symlink cannot redirect the write.
+func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
+	if err := rejectIfSymlink(path); err != nil {
+		return err
+	}
+	tmpPath := filepath.Join(sshDir, fmt.Sprintf(".authorized_keys.tmp.%d", os.Getpid()))
+	_ = os.Remove(tmpPath) // clear any stale temp from a prior crash
+	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to create temp authorized_keys: %w", err)
+	}
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("failed to write temp authorized_keys: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to close temp authorized_keys: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to replace authorized_keys: %w", err)
+	}
+	return nil
 }
 
 // AuthorizedKeysManager manages authorized_keys files for users
@@ -50,14 +141,19 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 	if err := validateUsername(username); err != nil {
 		return fmt.Errorf("invalid username: %w", err)
 	}
+	// Reject embedded newlines/CR: a multi-line value would inject additional
+	// authorized_keys entries or options (e.g. command=) (M-8).
+	if err := validatePublicKeyLine(publicKey); err != nil {
+		return err
+	}
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
 	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
 
-	// Create .ssh directory if it doesn't exist
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		return fmt.Errorf("failed to create .ssh directory: %w", err)
+	// Create/verify .ssh directory, rejecting a symlinked .ssh (C-2).
+	if err := ensureSecureSSHDir(sshDir); err != nil {
+		return err
 	}
 
 	return withFileLock(lockPath, func() error {
@@ -78,8 +174,8 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 			}
 		}
 
-		// Add the new key
-		file, err := os.OpenFile(authorizedKeysPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		// Add the new key (O_NOFOLLOW: never follow a planted symlink — C-2).
+		file, err := openAuthorizedKeysForAppend(authorizedKeysPath)
 		if err != nil {
 			return fmt.Errorf("failed to open authorized_keys file: %w", err)
 		}
@@ -154,9 +250,9 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 			return nil
 		}
 
-		// Write filtered content back
+		// Write filtered content back atomically, refusing to follow symlinks (C-2).
 		newContent := strings.Join(filteredLines, "\n")
-		if err := os.WriteFile(authorizedKeysPath, []byte(newContent), 0600); err != nil {
+		if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, []byte(newContent)); err != nil {
 			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
 
@@ -171,6 +267,9 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 
 // RemoveExpiredKeys removes expired OIDC PAM keys from authorized_keys
 func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
+	if err := validateUsername(username); err != nil {
+		return fmt.Errorf("invalid username: %w", err)
+	}
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
@@ -182,8 +281,11 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 	}
 
 	return withFileLock(lockPath, func() error {
-		// Read existing authorized_keys file
-		file, err := os.Open(authorizedKeysPath)
+		// Read existing authorized_keys file (O_NOFOLLOW: never follow a symlink — C-2).
+		if err := rejectIfSymlink(authorizedKeysPath); err != nil {
+			return err
+		}
+		file, err := os.OpenFile(authorizedKeysPath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil // File doesn't exist, nothing to clean
@@ -228,9 +330,9 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 		}
 
 		if removedCount > 0 {
-			// Write filtered content back
+			// Write filtered content back atomically, refusing to follow symlinks (C-2).
 			newContent := strings.Join(filteredLines, "\n")
-			if err := os.WriteFile(authorizedKeysPath, []byte(newContent), 0600); err != nil {
+			if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, []byte(newContent)); err != nil {
 				return fmt.Errorf("failed to write authorized_keys file: %w", err)
 			}
 
@@ -292,13 +394,28 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 		return nil // No file to backup
 	}
 
-	// Copy the file
+	// Copy the file (refuse to read through a symlinked authorized_keys — C-2).
+	if err := rejectIfSymlink(authorizedKeysPath); err != nil {
+		return err
+	}
 	data, err := os.ReadFile(authorizedKeysPath)
 	if err != nil {
 		return fmt.Errorf("failed to read authorized_keys file: %w", err)
 	}
 
-	if err := os.WriteFile(backupPath, data, 0600); err != nil {
+	// Write the backup without following a planted symlink at the backup path.
+	if err := rejectIfSymlink(backupPath); err != nil {
+		return err
+	}
+	bf, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to create backup: %w", err)
+	}
+	if _, err := bf.Write(data); err != nil {
+		_ = bf.Close()
+		return fmt.Errorf("failed to create backup: %w", err)
+	}
+	if err := bf.Close(); err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
 
@@ -326,12 +443,18 @@ func (akm *AuthorizedKeysManager) RestoreAuthorizedKeys(username string) error {
 	}
 
 	// Copy backup to authorized_keys
+	if err := rejectIfSymlink(backupPath); err != nil {
+		return err
+	}
 	data, err := os.ReadFile(backupPath)
 	if err != nil {
 		return fmt.Errorf("failed to read backup file: %w", err)
 	}
 
-	if err := os.WriteFile(authorizedKeysPath, data, 0600); err != nil {
+	if err := ensureSecureSSHDir(sshDir); err != nil {
+		return err
+	}
+	if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, data); err != nil {
 		return fmt.Errorf("failed to restore authorized_keys: %w", err)
 	}
 
@@ -343,13 +466,27 @@ func (akm *AuthorizedKeysManager) RestoreAuthorizedKeys(username string) error {
 	return nil
 }
 
-// ValidateKeyFormat validates that a public key is in the correct format
-func (akm *AuthorizedKeysManager) ValidateKeyFormat(publicKey []byte) error {
+// validatePublicKeyLine rejects a public key value that is empty or contains
+// embedded newline/carriage-return characters. Without this, a multi-line value
+// written to authorized_keys would inject additional key entries or per-key
+// options such as command=/no-pty (M-8).
+func validatePublicKeyLine(publicKey []byte) error {
 	keyStr := strings.TrimSpace(string(publicKey))
-
 	if keyStr == "" {
 		return fmt.Errorf("empty public key")
 	}
+	if strings.ContainsAny(keyStr, "\n\r") {
+		return fmt.Errorf("public key contains embedded newline characters")
+	}
+	return nil
+}
+
+// ValidateKeyFormat validates that a public key is in the correct format
+func (akm *AuthorizedKeysManager) ValidateKeyFormat(publicKey []byte) error {
+	if err := validatePublicKeyLine(publicKey); err != nil {
+		return err
+	}
+	keyStr := strings.TrimSpace(string(publicKey))
 
 	parts := strings.Fields(keyStr)
 	if len(parts) < 2 {

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -21,6 +21,8 @@ import (
 // (in a user-controlled .ssh directory) cannot redirect the open to another
 // file (see ensureSecureSSHDir for the surrounding symlink defenses).
 func withFileLock(lockPath string, fn func() error) error {
+	// #nosec G304 -- lockPath is under the validated .ssh dir; O_NOFOLLOW prevents
+	// following a planted symlink at the lock path.
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open lock file: %w", err)
@@ -89,6 +91,9 @@ func openAuthorizedKeysForAppend(path string) (*os.File, error) {
 	if err := rejectIfSymlink(path); err != nil {
 		return nil, err
 	}
+	// #nosec G304 -- path is built from an allowlisted username (validateUsername)
+	// under the broker's base dir; the final component is symlink-checked above
+	// and opened with O_NOFOLLOW so a planted symlink cannot redirect the write.
 	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW, 0600)
 }
 
@@ -103,6 +108,8 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
 	}
 	tmpPath := filepath.Join(sshDir, fmt.Sprintf(".authorized_keys.tmp.%d", os.Getpid()))
 	_ = os.Remove(tmpPath) // clear any stale temp from a prior crash
+	// #nosec G304 -- tmpPath is under the validated .ssh dir and opened with
+	// O_EXCL|O_NOFOLLOW, so it cannot follow or clobber a pre-existing symlink.
 	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create temp authorized_keys: %w", err)
@@ -285,6 +292,7 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 		if err := rejectIfSymlink(authorizedKeysPath); err != nil {
 			return err
 		}
+		// #nosec G304 -- validated username path; symlink-checked above and opened O_NOFOLLOW.
 		file, err := os.OpenFile(authorizedKeysPath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -407,6 +415,7 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 	if err := rejectIfSymlink(backupPath); err != nil {
 		return err
 	}
+	// #nosec G304 -- validated username path; symlink-checked above and opened O_NOFOLLOW.
 	bf, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -38,16 +39,22 @@ type SSHKey struct {
 	ExpiresAt  time.Time
 }
 
-// validateUsername rejects usernames that could be used for path traversal attacks.
+// usernamePattern is a strict allowlist for POSIX-style login names: a leading
+// lowercase letter or underscore, followed by lowercase letters, digits,
+// underscores, or hyphens, with an optional trailing '$'. Anchored and length
+// bounded. This is a positive allowlist (M-7) rather than a denylist, so it also
+// rejects "..", path separators, leading dots, and other traversal tricks.
+var usernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}\$?$`)
+
+// validateUsername rejects usernames that are not valid POSIX login names,
+// which also prevents path-traversal when usernames are joined into filesystem
+// paths under the broker's base directory.
 func validateUsername(username string) error {
 	if username == "" {
 		return fmt.Errorf("username cannot be empty")
 	}
-	if strings.ContainsAny(username, "/\\\x00") {
-		return fmt.Errorf("username contains invalid characters")
-	}
-	if strings.Contains(username, "..") {
-		return fmt.Errorf("username cannot contain '..'")
+	if !usernamePattern.MatchString(username) {
+		return fmt.Errorf("username %q is not a valid POSIX login name", username)
 	}
 	return nil
 }

--- a/pkg/ssh/security_hardening_test.go
+++ b/pkg/ssh/security_hardening_test.go
@@ -1,0 +1,100 @@
+package ssh
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAddPublicKeyRejectsSymlinkedAuthorizedKeys verifies the C-2 fix: the root
+// broker must not follow a symlink planted at authorized_keys to write/append
+// into an arbitrary file outside the user's .ssh directory.
+func TestAddPublicKeyRejectsSymlinkedAuthorizedKeys(t *testing.T) {
+	base := t.TempDir()
+	username := "testuser"
+	sshDir := filepath.Join(base, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Attacker-controlled target outside .ssh that must NOT be modified.
+	target := filepath.Join(base, "victim")
+	if err := os.WriteFile(target, []byte("original\n"), 0600); err != nil {
+		t.Fatalf("setup target: %v", err)
+	}
+
+	// Plant the symlink: ~/.ssh/authorized_keys -> ../../victim
+	link := filepath.Join(sshDir, "authorized_keys")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	akm := NewAuthorizedKeysManager(base)
+	err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key"))
+	if err == nil {
+		t.Fatal("expected AddPublicKey to reject symlinked authorized_keys, got nil error")
+	}
+
+	// The victim file must be untouched.
+	data, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("reading target: %v", readErr)
+	}
+	if string(data) != "original\n" {
+		t.Fatalf("victim file was modified through symlink: %q", string(data))
+	}
+}
+
+// TestAddPublicKeyRejectsSymlinkedSSHDir verifies a symlinked .ssh directory is
+// refused (C-2).
+func TestAddPublicKeyRejectsSymlinkedSSHDir(t *testing.T) {
+	base := t.TempDir()
+	username := "testuser"
+	if err := os.MkdirAll(filepath.Join(base, username), 0700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// Point ~/.ssh at an attacker-chosen directory.
+	evil := filepath.Join(base, "evil")
+	if err := os.MkdirAll(evil, 0700); err != nil {
+		t.Fatalf("setup evil dir: %v", err)
+	}
+	if err := os.Symlink(evil, filepath.Join(base, username, ".ssh")); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	akm := NewAuthorizedKeysManager(base)
+	if err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key")); err == nil {
+		t.Fatal("expected AddPublicKey to reject symlinked .ssh dir, got nil error")
+	}
+}
+
+// TestAddPublicKeyRejectsEmbeddedNewline verifies the M-8 fix: a key value with
+// an embedded newline (which would inject a second authorized_keys entry or
+// options) is rejected.
+func TestAddPublicKeyRejectsEmbeddedNewline(t *testing.T) {
+	base := t.TempDir()
+	akm := NewAuthorizedKeysManager(base)
+	injected := []byte("ssh-ed25519 AAAAreal key\ncommand=\"evil\" ssh-ed25519 AAAAevil key2")
+	if err := akm.AddPublicKey("testuser", injected); err == nil {
+		t.Fatal("expected AddPublicKey to reject embedded newline, got nil error")
+	}
+}
+
+func TestValidateUsernameAllowlist(t *testing.T) {
+	valid := []string{"alice", "bob_123", "svc-account", "_systemd", "user$"}
+	for _, u := range valid {
+		if err := validateUsername(u); err != nil {
+			t.Errorf("expected %q to be valid, got: %v", u, err)
+		}
+	}
+	invalid := []string{
+		"", "..", "../etc", "/etc/passwd", ".", ".ssh",
+		"Alice", "user name", "evil;rm", "a\x00b", "1user",
+		"toolongusernameusernameusernameusernameusername",
+	}
+	for _, u := range invalid {
+		if err := validateUsername(u); err == nil {
+			t.Errorf("expected %q to be rejected", u)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the two **Critical** findings from the 2026-05 security audit plus three tightly-coupled findings in the same identity→provisioning path.

Closes #90, closes #91, closes #92. Partially addresses #95 (M-7, M-8).

## C-1 — OIDC identity now bound to the requested local username (#90)
`pkg/auth/broker.go`: new `verifyIdentityBinding()` resolves the expected local username from the provider's `username_claim` and requires it to equal `session.UserID` (case-insensitive; email local-part accepted) **before** `IsActive = true`. **Fails closed** when `username_claim` is unset or the claim is absent. Previously `req.UserID` was trusted verbatim — any IdP user could log in as any local account, including root.

## C-2 — authorized_keys writes are symlink/TOCTOU-safe (#91)
`pkg/ssh/authorized_keys.go`: the root broker now
- refuses a symlinked `.ssh` dir or `authorized_keys` (`Lstat` checks),
- opens all files with `O_NOFOLLOW`,
- replaces files atomically via temp-file + `rename` instead of following/truncating a user-planted symlink.
Applied across Add/Remove/RemoveExpired/Restore/Backup.

## H-1 — require_groups enforced (#92)
`verifyRequiredGroups()` checks `Authentication.RequireGroups` against the user's actual groups (was collected but never compared).

## M-7 / M-8 (#95)
- `validateUsername` is now a strict POSIX login-name allowlist, and is applied in `RemoveExpiredKeys` (previously skipped).
- Public keys with embedded newlines are rejected (authorized_keys injection); `ValidateKeyFormat` enforces it and is wired into `AddPublicKey`.

## Tests
New: identity binding (incl. impersonation + fail-closed cases), group enforcement, symlink rejection (authorized_keys and .ssh dir), newline-injection rejection, username allowlist. All existing tests pass; gofmt/vet clean.

## Notes / follow-ups (not in this PR)
- Per-resource policy `RequiredGroups` (vs the global gate fixed here) and full privilege-drop/`chown`-to-user are tracked under #91/#95 for a deeper pass.
- H-2 (device-flow nonce), H-3 (PAM framing), and remaining M/L items remain in #93, #94, #95.