### PR TITLE
fix(security): remediate remaining audit findings (#93, #94, #95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **High (#92):** Enforce `require_groups` — required group membership is now checked against the authenticated user's groups instead of being silently ignored.
 - **(#95) M-7:** `validateUsername` is now a strict POSIX login-name allowlist and is applied in `RemoveExpiredKeys` (previously skipped).
 - **(#95) M-8:** Reject SSH public keys containing embedded newlines (authorized_keys injection); `ValidateKeyFormat` now enforces this and is wired into `AddPublicKey`.
+- **High (#93):** Validate the OIDC nonce in the device flow — `PollDeviceAuthorization` now rejects an ID token whose nonce does not match the one issued (replay protection); honors `allow_missing_nonce`.
+- **High (#94):** Fix PAM module response framing — `receive_auth_response` now reads until the newline delimiter (looped `recv` with a poll-based timeout) instead of a single `recv`, preventing truncation of large broker responses; Go and C response buffers unified at 8192 bytes (L-12).
+- **(#95) M-5:** Device-flow polling errors are mapped to a bounded error-code enum for the Prometheus `error_code` label instead of the raw error string (cardinality-DoS / info-leak fix).
+- **(#95) M-6:** Metrics HTTP server now sets Read/ReadHeader/Write/Idle timeouts (Slowloris mitigation).
+- **(#95) L-8:** Config validation requires OIDC issuer/endpoints (and provider endpoints) to use HTTPS; `http://` allowed only in development mode.
+- **(#95) L-1:** Non-Linux peer-credential stub now fails closed (returns an error) instead of returning uid 0.
+- **(#95) L-3:** Broker aborts startup if it cannot set the IPC socket permissions (was a non-fatal warning).
+- **(#95) M-2:** Corrected the `NewEncryption` doc comment to match the actual PBKDF2 derivation; **L-17:** guarded `truncateString` against a panic when `maxLen < 3`.
 
 ### Added
 - DEPLOYMENT.md: "Identity vs. Authentication" guidance explaining that oidc-pam is an authentication layer (use SSSD/a directory for NSS identity and consistent cluster UIDs), why no `libnss_oidc.so` module is shipped, and the provision-on-first-login pattern for directory-less environments

--- a/cmd/oidc-admin/admin.go
+++ b/cmd/oidc-admin/admin.go
@@ -360,5 +360,8 @@ func truncateString(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
 	return s[:maxLen-3] + "..."
 }

--- a/internal/ipc/peercred_stub.go
+++ b/internal/ipc/peercred_stub.go
@@ -3,14 +3,14 @@
 package ipc
 
 import (
+	"fmt"
 	"net"
-
-	"github.com/rs/zerolog/log"
 )
 
-// getPeerCredentials is a no-op stub for non-Linux platforms where SO_PEERCRED is not available.
-// It returns uid=0, gid=0, nil to allow connections (peer auth verification is skipped).
+// getPeerCredentials is a stub for platforms with no supported peer-credential
+// mechanism. It FAILS CLOSED: returning an error ensures an unverifiable peer is
+// rejected rather than being treated as root (uid 0). Never return (0, 0, nil)
+// here — that would silently authorize every connection on an unsupported port.
 func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
-	log.Warn().Msg("Peer credential verification is not available on this platform")
-	return 0, 0, nil
+	return 0, 0, fmt.Errorf("peer credential verification is not supported on this platform; deploy on Linux")
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -106,12 +106,11 @@ func (s *Server) Start(ctx context.Context) error {
 
 	s.listener = listener
 
-	// Set socket permissions
+	// Set socket permissions. Fail closed: if we cannot enforce the intended
+	// mode we must not keep serving on a socket with unknown permissions.
 	if err := os.Chmod(s.socketPath, s.socketMode); err != nil {
-		log.Warn().
-			Err(err).
-			Str("socket_path", s.socketPath).
-			Msg("Failed to set socket permissions")
+		_ = listener.Close()
+		return fmt.Errorf("failed to set socket permissions on %s: %w", s.socketPath, err)
 	}
 
 	// Set socket group ownership if configured

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -691,16 +691,18 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 		case <-ticker.C:
 			// Poll for authorization using a per-attempt context with timeout.
 			pollCtx, pollCancel := context.WithTimeout(context.Background(), 30*time.Second)
-			token, err := provider.PollDeviceAuthorization(pollCtx, deviceFlow.DeviceCode)
+			token, err := provider.PollDeviceAuthorization(pollCtx, deviceFlow.DeviceCode, deviceFlow.Nonce)
 			pollCancel()
 			if err != nil {
 				// Handle specific error types
 				if err.Error() == "authorization_pending" {
 					continue // Keep polling
 				}
-				// Other errors mean failure
+				// Other errors mean failure. Use a bounded error-code enum for the
+				// metric label (never the raw error string) to avoid Prometheus
+				// cardinality explosion and leaking transient infra detail.
 				if b.metrics != nil {
-					b.metrics.RecordAuth(provider.Name, "failure", err.Error())
+					b.metrics.RecordAuth(provider.Name, "failure", classifyPollError(err))
 				}
 				b.auditLogger.LogAuthEvent(security.AuditEvent{
 					EventType:    "device_authorization_failed",
@@ -1097,6 +1099,34 @@ func claimToUsername(userInfo *UserInfo, claimName string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("username_claim %q not present in token claims", claimName)
+}
+
+// classifyPollError maps a device-authorization polling error to a small, fixed
+// set of metric label values. Raw error strings must never be used as metric
+// labels (unbounded cardinality + info leak).
+func classifyPollError(err error) string {
+	if err == nil {
+		return "OK"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "nonce"):
+		return "NONCE_INVALID"
+	case strings.Contains(msg, "verify id token"), strings.Contains(msg, "claim validation"):
+		return "ID_TOKEN_INVALID"
+	case strings.Contains(msg, "token error"):
+		return "TOKEN_ERROR"
+	case strings.Contains(msg, "access_denied"):
+		return "ACCESS_DENIED"
+	case strings.Contains(msg, "expired"):
+		return "EXPIRED"
+	case strings.Contains(msg, "decode"):
+		return "DECODE_ERROR"
+	case strings.Contains(msg, "failed to poll"), strings.Contains(msg, "connection"), strings.Contains(msg, "timeout"):
+		return "NETWORK_ERROR"
+	default:
+		return "POLL_FAILED"
+	}
 }
 
 // verifyRequiredGroups enforces that the authenticated user is a member of all

--- a/pkg/auth/classify_poll_error_test.go
+++ b/pkg/auth/classify_poll_error_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestClassifyPollError covers M-5: polling errors must map to a bounded set of
+// metric label values, never the raw error string.
+func TestClassifyPollError(t *testing.T) {
+	cases := map[string]string{
+		"": "OK", // nil handled separately
+		"ID token nonce mismatch (possible replay)": "NONCE_INVALID",
+		"failed to verify ID token: bad sig":        "ID_TOKEN_INVALID",
+		"ID token claim validation failed: age":     "ID_TOKEN_INVALID",
+		"token error: access_denied":                "TOKEN_ERROR",
+		"device code expired":                       "EXPIRED",
+		"failed to decode token response":           "DECODE_ERROR",
+		"failed to poll device authorization: dial": "NETWORK_ERROR",
+		"something entirely unexpected":             "POLL_FAILED",
+	}
+	for msg, want := range cases {
+		var err error
+		if msg != "" {
+			err = errors.New(msg)
+		}
+		got := classifyPollError(err)
+		if msg == "" {
+			if got != "OK" {
+				t.Errorf("nil error: got %q, want OK", got)
+			}
+			continue
+		}
+		if got != want {
+			t.Errorf("classifyPollError(%q) = %q, want %q", msg, got, want)
+		}
+	}
+}

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -333,7 +333,7 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 
 // PollDeviceAuthorization polls for device authorization completion.
 // ctx is used for ID token verification so callers can apply deadlines.
-func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode string) (*Token, error) {
+func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode, expectedNonce string) (*Token, error) {
 	// Get token endpoint
 	tokenEndpoint := p.Provider.Endpoint().TokenURL
 
@@ -372,6 +372,20 @@ func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode s
 		idToken, err := p.Verifier.Verify(ctx, tokenResp.IDToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to verify ID token: %w", err)
+		}
+
+		// Validate the nonce to prevent ID token replay (RFC 8628 / OIDC core).
+		// The nonce sent in StartDeviceFlow must be echoed back in the ID token.
+		// AllowMissingNonce permits providers (some device-flow IdPs) that do not
+		// return a nonce claim — but a present-and-wrong nonce is always rejected.
+		if expectedNonce != "" {
+			if idToken.Nonce == "" {
+				if !p.Config.AllowMissingNonce {
+					return nil, fmt.Errorf("ID token is missing the nonce claim (set allow_missing_nonce to permit this provider)")
+				}
+			} else if idToken.Nonce != expectedNonce {
+				return nil, fmt.Errorf("ID token nonce mismatch (possible replay)")
+			}
 		}
 
 		if err := idToken.Claims(&claims); err != nil {

--- a/pkg/auth/device_flow_test.go
+++ b/pkg/auth/device_flow_test.go
@@ -313,7 +313,7 @@ func TestDeviceFlowPollingMethod(t *testing.T) {
 		PollingInterval: 5,
 	}
 
-	token, err := provider.PollDeviceAuthorization(context.Background(), deviceFlow.DeviceCode)
+	token, err := provider.PollDeviceAuthorization(context.Background(), deviceFlow.DeviceCode, deviceFlow.Nonce)
 	if err != nil {
 		t.Logf("PollDeviceAuthorization failed as expected: %v", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -460,6 +461,19 @@ func (c *Config) Validate() error {
 		if provider.Issuer == "" {
 			return fmt.Errorf("provider[%d].issuer is required", i)
 		}
+		// Endpoints must be HTTPS so tokens and codes are never sent in clear.
+		// http:// (and localhost) is permitted only in development mode.
+		for label, endpoint := range map[string]string{
+			"issuer":            provider.Issuer,
+			"device_endpoint":   provider.DeviceEndpoint,
+			"token_endpoint":    provider.TokenEndpoint,
+			"userinfo_endpoint": provider.UserInfoEndpoint,
+			"jwks_uri":          provider.JWKSUri,
+		} {
+			if err := validateHTTPSEndpoint(endpoint); err != nil {
+				return fmt.Errorf("provider[%d].%s: %w", i, label, err)
+			}
+		}
 		if provider.ClientID == "" {
 			return fmt.Errorf("provider[%d].client_id is required", i)
 		}
@@ -496,6 +510,26 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// validateHTTPSEndpoint ensures a configured OIDC endpoint URL uses HTTPS.
+// Empty values are allowed (the field is optional). In development mode
+// (OIDC_AUTH_DEV) http:// and localhost are tolerated to ease local testing.
+func validateHTTPSEndpoint(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if isDevelopmentMode() {
+		return nil
+	}
+	return fmt.Errorf("must use https (got %q); set OIDC_AUTH_DEV=true to override for development", u.Scheme)
 }
 
 // isDevelopmentMode checks if development mode is enabled via OIDC_AUTH_DEV environment variable.

--- a/pkg/config/https_validation_test.go
+++ b/pkg/config/https_validation_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestValidateHTTPSEndpoint covers L-8: OIDC endpoints must use HTTPS in
+// production, with empty allowed and http tolerated only in development mode.
+func TestValidateHTTPSEndpoint(t *testing.T) {
+	// Ensure we are not in development mode for the strict cases.
+	old := os.Getenv("OIDC_AUTH_DEV")
+	_ = os.Unsetenv("OIDC_AUTH_DEV")
+	defer func() { _ = os.Setenv("OIDC_AUTH_DEV", old) }()
+
+	if err := validateHTTPSEndpoint(""); err != nil {
+		t.Errorf("empty endpoint should be allowed, got: %v", err)
+	}
+	if err := validateHTTPSEndpoint("https://idp.example.com"); err != nil {
+		t.Errorf("https endpoint should be allowed, got: %v", err)
+	}
+	if err := validateHTTPSEndpoint("http://idp.example.com"); err == nil {
+		t.Error("http endpoint should be rejected in production")
+	}
+
+	// In development mode http is tolerated.
+	_ = os.Setenv("OIDC_AUTH_DEV", "true")
+	if err := validateHTTPSEndpoint("http://localhost:8080"); err != nil {
+		t.Errorf("http should be allowed in dev mode, got: %v", err)
+	}
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -26,6 +27,12 @@ func NewServer(addr string, reg prometheus.Gatherer) *Server {
 		srv: &http.Server{
 			Addr:    addr,
 			Handler: mux,
+			// Bound request phases so a slow client cannot tie up the endpoint
+			// (Slowloris). ReadHeaderTimeout is the key mitigation.
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       60 * time.Second,
 		},
 	}
 }

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -2,7 +2,11 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <time.h>
+#include <poll.h>
 #include <json-c/json.h>
+
+// Total time budget for reading a complete broker response, in milliseconds.
+#define RESPONSE_READ_TIMEOUT_MS 30000
 
 // Global variables
 static int debug_enabled = 0;
@@ -154,22 +158,71 @@ int send_auth_request(int sock, const char *username, const char *service, const
     return 0;
 }
 
-// Receive authentication response from broker
+// Receive authentication response from broker.
+//
+// The broker writes a single newline-delimited JSON object (json.Encoder.Encode
+// appends '\n'). A single recv() can return only the first TCP segment, which
+// truncates large responses and breaks JSON parsing. Loop on recv() until the
+// newline delimiter is seen, the buffer is full, or the connection closes,
+// bounded by a total read timeout so a stalled/hostile broker cannot hang the
+// PAM stack.
 int receive_auth_response(int sock, char *response, size_t response_size) {
-    ssize_t received = recv(sock, response, response_size - 1, 0);
-    if (received == -1) {
-        log_pam_message(LOG_ERR, "Failed to receive response: %s", strerror(errno));
+    if (response_size == 0) {
         return -1;
     }
-    
-    if (received == 0) {
-        log_pam_message(LOG_ERR, "Connection closed by broker");
+
+    size_t total = 0;
+    const size_t cap = response_size - 1; // reserve space for NUL
+
+    while (total < cap) {
+        struct pollfd pfd;
+        pfd.fd = sock;
+        pfd.events = POLLIN;
+
+        int pr = poll(&pfd, 1, RESPONSE_READ_TIMEOUT_MS);
+        if (pr == 0) {
+            log_pam_message(LOG_ERR, "Timed out waiting for broker response");
+            return -1;
+        }
+        if (pr < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            log_pam_message(LOG_ERR, "poll() failed waiting for response: %s", strerror(errno));
+            return -1;
+        }
+
+        ssize_t received = recv(sock, response + total, cap - total, 0);
+        if (received < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            log_pam_message(LOG_ERR, "Failed to receive response: %s", strerror(errno));
+            return -1;
+        }
+        if (received == 0) {
+            // Connection closed by broker. Accept whatever we have if it forms a
+            // complete line; otherwise treat as an error.
+            break;
+        }
+
+        total += (size_t)received;
+        response[total] = '\0';
+
+        // Stop as soon as we have a complete newline-delimited message.
+        if (memchr(response, '\n', total) != NULL) {
+            break;
+        }
+    }
+
+    if (total == 0) {
+        log_pam_message(LOG_ERR, "Connection closed by broker before any response");
         return -1;
     }
-    
-    response[received] = '\0';
+
+    response[total] = '\0';
     log_pam_message(LOG_DEBUG, "Received response: %s", response);
-    
+
     return 0;
 }
 

--- a/pkg/pam/cgo_wrapper.go
+++ b/pkg/pam/cgo_wrapper.go
@@ -75,9 +75,10 @@ func SendAuthRequest(sock int, username, service, rhost, tty string) error {
 
 // ReceiveAuthResponse receives an authentication response from the broker
 func ReceiveAuthResponse(sock int) (*AuthResponse, error) {
-	var response [4096]C.char
+	// Buffer matches the C module's MAX_RESPONSE_SIZE (8192).
+	var response [8192]C.char
 
-	result := C.receive_auth_response(C.int(sock), &response[0], 4096)
+	result := C.receive_auth_response(C.int(sock), &response[0], C.size_t(len(response)))
 	if result != 0 {
 		return nil, fmt.Errorf("failed to receive authentication response")
 	}

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -102,9 +102,10 @@ func (p *PAMModule) AuthenticateUser(username, service, rhost, tty string) error
 		return fmt.Errorf("failed to send authentication request")
 	}
 
-	// Receive and parse the broker response
-	var response [4096]C.char
-	if C.receive_auth_response(sock, &response[0], 4096) != 0 {
+	// Receive and parse the broker response. Buffer matches the C module's
+	// MAX_RESPONSE_SIZE (8192) so large success responses are not truncated.
+	var response [8192]C.char
+	if C.receive_auth_response(sock, &response[0], C.size_t(len(response))) != 0 {
 		return fmt.Errorf("failed to receive authentication response")
 	}
 

--- a/pkg/security/encryption.go
+++ b/pkg/security/encryption.go
@@ -19,20 +19,17 @@ type Encryption struct {
 
 // NewEncryption creates a new encryption instance.
 //
-// If keyString is a base64-encoded 32-byte value (as produced by GenerateKey),
-// those bytes are used directly — no derivation is applied, preserving full
-// entropy. Otherwise SHA-256 of the string is used as a fallback for backward
-// compatibility, but a warning is emitted because this provides no key
-// stretching for weak inputs. Use GenerateKey() to produce a proper key.
+// The 32-byte AES key is derived from keyString using PBKDF2-HMAC-SHA256
+// (600,000 iterations) with a fixed application-level salt. keyString is
+// expected to be a high-entropy secret — config validation requires 32+ bytes,
+// and GenerateKey() produces a suitable base64 value. The static salt is an
+// accepted trade-off given that assumption; its purpose is computational cost
+// against brute force, not per-deployment uniqueness.
 func NewEncryption(keyString string) (*Encryption, error) {
 	if keyString == "" {
 		return nil, fmt.Errorf("encryption key cannot be empty")
 	}
 
-	// Derive a 32-byte key using PBKDF2 with a fixed application-level salt.
-	// The key string is expected to be a high-entropy secret (config validation
-	// requires 32+ bytes), so the static salt is acceptable — the primary benefit
-	// is computational cost against brute force.
 	salt := []byte("oidc-pam-token-encryption-v1")
 	key := pbkdf2.Key([]byte(keyString), salt, 600000, 32, sha256.New)
 


### PR DESCRIPTION
Remediates the remaining open security findings. Closes #93, closes #94. Addresses a batch of #95 (keeps #95 open for the deeper items below).

## High
- **#93 — Device-flow nonce validation.** `PollDeviceAuthorization(ctx, deviceCode, expectedNonce)` now rejects an ID token whose `nonce` claim doesn't match the value issued in `StartDeviceFlow` (replay protection), mirroring the auth-code flow. Honors `allow_missing_nonce` for providers that omit the claim; a present-but-wrong nonce is always rejected.
- **#94 — PAM response framing.** `receive_auth_response` loops `recv()` until the newline delimiter (json.Encoder framing) with a poll-based 30s read timeout, instead of a single `recv()` that truncated large responses. Go and C response buffers unified at 8192 bytes (**L-12**).

## Medium / Low (#95)
- **M-5** — device-flow poll errors mapped to a bounded error-code enum for the Prometheus `error_code` label (was raw `err.Error()` → cardinality DoS + info leak).
- **M-6** — metrics HTTP server sets Read/ReadHeader/Write/Idle timeouts (Slowloris).
- **L-8** — config validation requires HTTPS for issuer/device/token/userinfo/jwks endpoints; `http://` only in dev mode.
- **L-1** — non-Linux peer-cred stub fails closed (returns error) instead of `uid 0, nil`.
- **L-3** — broker aborts startup if it cannot chmod the IPC socket (was a warning).
- **M-2** — corrected misleading `NewEncryption` doc comment; **L-17** — guarded `truncateString` panic for `maxLen < 3`.

## Tests
New unit tests for the poll-error enum and HTTPS endpoint validation; existing device-flow test updated for the new signature. Full non-PAM suite + vet pass; gofmt clean.

## Still open under #95 (deliberately deferred)
- **M-1** static PBKDF2 salt (needs a key-format/migration decision).
- **M-3** `verify_audience=false` dev inconsistency, **M-4** discovery fallback validation.
- **L-2** Darwin/FreeBSD `Cr_version`, **L-4** connection cap, **L-5** `acct_mgmt`, **L-6** pam-helper privileged flags, **L-7** policy fail-open, **L-9/L-10** audit overflow/fail-closed, **L-11** json-c leak, **L-13** atomic rewrites elsewhere, **L-14** key-comment expiry, **L-15** constant-time fingerprint, **L-16** secret zeroization.