### PR TITLE
fix(security): remediate remaining #95 findings (all but M-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **(#95) L-1:** Non-Linux peer-credential stub now fails closed (returns an error) instead of returning uid 0.
 - **(#95) L-3:** Broker aborts startup if it cannot set the IPC socket permissions (was a non-fatal warning).
 - **(#95) M-2:** Corrected the `NewEncryption` doc comment to match the actual PBKDF2 derivation; **L-17:** guarded `truncateString` against a panic when `maxLen < 3`.
+- **(#95) M-3:** Audience (client_id) verification is now only skippable in development mode; production always verifies regardless of `verify_audience`, consistent with the auth-code flow.
+- **(#95) M-4:** The device-authorization discovery fallback endpoint is now run through the same scheme/host validation as discovered endpoints instead of being used unvalidated.
+- **(#95) L-2:** Darwin/FreeBSD peer-credential checks now reject an unexpected `Xucred` version (avoids misreading an unpopulated struct as uid 0).
+- **(#95) L-4:** IPC server caps concurrent connections (bounded semaphore) so a peer cannot exhaust goroutines/FDs.
+- **(#95) L-5:** Documented that `pam_sm_acct_mgmt` performs no authorization (auth phase is authoritative); deployments must not rely on the PAM `account` stack as the sole gate.
+- **(#95) L-6:** `pam-helper` ignores caller-supplied `-config`/`-socket` when running as root, preventing redirection to a rogue broker.
+- **(#95) L-7:** Unknown risk-policy conditions now log a warning instead of silently evaluating to false (visible misconfiguration).
+- **(#95) L-9:** Audit overflow strategy defaults to `block` (backpressure) instead of silently dropping; `drop` must be explicitly opted into.
+- **(#95) L-10:** Audit write failures are counted and exposed via `FailedWrites()` for alerting.
+- **(#95) L-11:** Fixed a per-authentication json-c object leak in the PAM module's request builder.
+- **(#95) L-14:** Documented that authorized_keys expiry parsing is best-effort and fail-safe (forged/malformed comments retain the key).
+- **(#95) L-15:** Token-ownership comparison in `ValidateToken` is now constant-time.
+- **(#95) L-16:** Added best-effort zeroization of the derived encryption key (`Encryption.Destroy`) and transient decrypt buffers.
 
 ### Added
 - DEPLOYMENT.md: "Identity vs. Authentication" guidance explaining that oidc-pam is an authentication layer (use SSSD/a directory for NSS identity and consistent cluster UIDs), why no `libnss_oidc.so` module is shipped, and the provision-on-first-login pattern for directory-less environments

--- a/cmd/pam-helper/main.go
+++ b/cmd/pam-helper/main.go
@@ -47,6 +47,25 @@ func main() {
 		os.Exit(0)
 	}
 
+	// L-6: when running privileged (EUID 0), ignore caller-supplied -config and
+	// -socket and force the compiled defaults. Otherwise a privileged invocation
+	// with attacker-controlled argv could point the helper at a rogue broker
+	// socket (which could answer success) or a rogue config.
+	const (
+		defaultConfigPath = "/etc/oidc-auth/pam.conf"
+		defaultSocketPath = "/var/run/oidc-auth/broker.sock"
+	)
+	if os.Geteuid() == 0 {
+		if *configFile != defaultConfigPath {
+			log.Warn().Str("ignored", *configFile).Msg("Ignoring caller-supplied -config while running as root; using default")
+			*configFile = defaultConfigPath
+		}
+		if *socketPath != defaultSocketPath {
+			log.Warn().Str("ignored", *socketPath).Msg("Ignoring caller-supplied -socket while running as root; using default")
+			*socketPath = defaultSocketPath
+		}
+	}
+
 	// Set up logging
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	if *debug {

--- a/internal/ipc/peercred_darwin.go
+++ b/internal/ipc/peercred_darwin.go
@@ -9,6 +9,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// xucredVersion0 is the expected struct version returned by LOCAL_PEERCRED on
+// macOS (XUCRED_VERSION). x/sys/unix does not export a constant for it.
+const xucredVersion0 = 0
+
 // getPeerCredentials extracts the UID and GID of the peer process from a Unix socket connection
 // using the LOCAL_PEERCRED socket option (macOS/Darwin).
 func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
@@ -26,6 +30,12 @@ func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
 	cred, err := unix.GetsockoptXucred(int(f.Fd()), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get peer credentials: %w", err)
+	}
+
+	// Reject an unexpected/zeroed struct version so an unpopulated Xucred is not
+	// misread as uid 0 (root) (L-2).
+	if cred.Version != xucredVersion0 {
+		return 0, 0, fmt.Errorf("unexpected xucred version %d", cred.Version)
 	}
 
 	// Xucred has Uid and Groups[0..Ngroups-1]; Groups[0] is the primary GID

--- a/internal/ipc/peercred_freebsd.go
+++ b/internal/ipc/peercred_freebsd.go
@@ -9,6 +9,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// xucredVersion0 is the expected struct version returned by LOCAL_PEERCRED on
+// FreeBSD (XUCRED_VERSION). x/sys/unix does not export a constant for it.
+const xucredVersion0 = 0
+
 // getPeerCredentials extracts the UID and GID of the peer process from a Unix socket connection
 // using the LOCAL_PEERCRED socket option (FreeBSD).
 func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
@@ -26,6 +30,12 @@ func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
 	cred, err := unix.GetsockoptXucred(int(f.Fd()), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get peer credentials: %w", err)
+	}
+
+	// Reject an unexpected/zeroed struct version so an unpopulated Xucred is not
+	// misread as uid 0 (root) (L-2).
+	if cred.Version != xucredVersion0 {
+		return 0, 0, fmt.Errorf("unexpected xucred version %d", cred.Version)
 	}
 
 	// Xucred has Uid and Groups[0..Ngroups-1]; Groups[0] is the primary GID

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -30,7 +30,12 @@ type Server struct {
 	stopChan        chan struct{}
 	wg              sync.WaitGroup
 	stopOnce        sync.Once
+	connSem         chan struct{} // bounds concurrent in-flight connections (L-4)
 }
+
+// maxConcurrentConnections caps the number of simultaneously handled IPC
+// connections so a peer cannot exhaust goroutines/FDs by opening many at once.
+const maxConcurrentConnections = 128
 
 // Request represents a request from PAM module
 type Request struct {
@@ -78,6 +83,7 @@ func NewServer(socketPath string, broker *auth.Broker, socketMode os.FileMode, s
 		broker:          broker,
 		rateLimiter:     NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths),
 		stopChan:        make(chan struct{}),
+		connSem:         make(chan struct{}, maxConcurrentConnections),
 	}, nil
 }
 
@@ -209,6 +215,17 @@ func (s *Server) acceptConnections(ctx context.Context) {
 				}
 			}
 
+			// Bound concurrent connections (L-4): if at capacity, reject rather
+			// than spawning an unbounded number of handler goroutines.
+			select {
+			case s.connSem <- struct{}{}:
+			default:
+				log.Warn().Msg("Connection rejected: at maximum concurrent connections")
+				s.sendErrorResponse(conn, "SERVER_BUSY", "Server at capacity, try again")
+				_ = conn.Close()
+				continue
+			}
+
 			// Handle connection in goroutine
 			s.wg.Add(1)
 			go s.handleConnection(conn)
@@ -219,6 +236,7 @@ func (s *Server) acceptConnections(ctx context.Context) {
 // handleConnection handles a single IPC connection
 func (s *Server) handleConnection(conn net.Conn) {
 	defer s.wg.Done()
+	defer func() { <-s.connSem }() // release the concurrency slot (L-4)
 	defer func() { _ = conn.Close() }()
 
 	// Verify peer is root — PAM modules always run as root

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -130,6 +130,15 @@ func NewOIDCProvider(providerCfg OIDCProviderConfig, secCfg config.SecurityConfi
 	var verifier *oidc.IDTokenVerifier
 	var oauth2Config *oauth2.Config
 
+	// M-3: only skip audience (client_id) verification when explicitly disabled
+	// AND running in development mode. In production the aud check is always on,
+	// regardless of verify_audience, matching the authorization-code flow which
+	// never skips it.
+	skipAudience := !secCfg.VerifyAudience && config.IsDevelopmentMode()
+	if !secCfg.VerifyAudience && !config.IsDevelopmentMode() {
+		log.Warn().Str("provider", providerCfg.Name).Msg("verify_audience is disabled but ignored outside development mode; audience will be verified")
+	}
+
 	if providerCfg.SkipDiscovery {
 		// Manual provider construction — used for providers without a public
 		// /.well-known/openid-configuration (e.g. AWS IAM Identity Center).
@@ -151,7 +160,7 @@ func NewOIDCProvider(providerCfg OIDCProviderConfig, secCfg config.SecurityConfi
 		provider = provCfg.NewProvider(ctx)
 		verifier = provider.Verifier(&oidc.Config{
 			ClientID:             providerCfg.ClientID,
-			SkipClientIDCheck:    !secCfg.VerifyAudience,
+			SkipClientIDCheck:    skipAudience,
 			SupportedSigningAlgs: []string{"RS256", "ES256"},
 		})
 		oauth2Config = &oauth2.Config{
@@ -168,7 +177,7 @@ func NewOIDCProvider(providerCfg OIDCProviderConfig, secCfg config.SecurityConfi
 
 		verifier = provider.Verifier(&oidc.Config{
 			ClientID:             providerCfg.ClientID,
-			SkipClientIDCheck:    !secCfg.VerifyAudience,
+			SkipClientIDCheck:    skipAudience,
 			SupportedSigningAlgs: []string{"RS256", "ES256"},
 		})
 		oauth2Config = &oauth2.Config{
@@ -643,19 +652,28 @@ func (p *OIDCProvider) getDeviceAuthorizationEndpoint() (string, error) {
 		return deviceEndpoint, nil
 	}
 
+	// M-4: the fallback endpoint is run through the same validateEndpoint checks
+	// (HTTPS + issuer-host match) as discovered/configured endpoints, so a
+	// discovery failure cannot cause requests to be sent to an unvalidated URL.
+	fallback := func() (string, error) {
+		guessed := p.Config.Issuer + "/protocol/openid-connect/auth/device"
+		if err := validateEndpoint(guessed); err != nil {
+			return "", fmt.Errorf("device authorization endpoint could not be discovered and the fallback was rejected: %w", err)
+		}
+		return guessed, nil
+	}
+
 	// Try to discover from provider metadata
 	discoveryURL := p.Config.Issuer + "/.well-known/openid-configuration"
 
 	resp, err := p.httpClient.Get(discoveryURL)
 	if err != nil {
-		// Fallback to common endpoint patterns
-		return p.Config.Issuer + "/protocol/openid-connect/auth/device", nil
+		return fallback()
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		// Fallback to common endpoint patterns
-		return p.Config.Issuer + "/protocol/openid-connect/auth/device", nil
+		return fallback()
 	}
 
 	var discoveryResp struct {
@@ -663,8 +681,7 @@ func (p *OIDCProvider) getDeviceAuthorizationEndpoint() (string, error) {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&discoveryResp); err != nil {
-		// Fallback to common endpoint patterns
-		return p.Config.Issuer + "/protocol/openid-connect/auth/device", nil
+		return fallback()
 	}
 
 	if discoveryResp.DeviceAuthorizationEndpoint != "" {
@@ -674,8 +691,7 @@ func (p *OIDCProvider) getDeviceAuthorizationEndpoint() (string, error) {
 		return discoveryResp.DeviceAuthorizationEndpoint, nil
 	}
 
-	// Fallback to common endpoint patterns
-	return p.Config.Issuer + "/protocol/openid-connect/auth/device", nil
+	return fallback()
 }
 
 // generateNonce returns a cryptographically random 16-byte hex nonce.

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -465,6 +465,12 @@ func (pe *PolicyEngine) evaluateRiskCondition(condition string, req *AuthRequest
 	case "untrusted_network":
 		return !pe.isPrivateIP(req.SourceIP)
 	default:
+		// L-7: an unrecognized condition silently evaluates to "does not fire",
+		// which means a misconfigured DENY policy would never apply. Log loudly so
+		// the misconfiguration is visible rather than failing open silently.
+		log.Warn().
+			Str("condition", condition).
+			Msg("Unknown risk policy condition; it will not match. Check policy configuration")
 		return false
 	}
 }

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"sync"
@@ -257,7 +258,9 @@ func (tm *TokenManager) ValidateToken(tokenFingerprint, userID string) (*StoredT
 		return nil, fmt.Errorf("token not found")
 	}
 
-	if storedToken.UserID != userID {
+	// Constant-time comparison so validation timing does not leak which user a
+	// stored token belongs to (L-15).
+	if subtle.ConstantTimeCompare([]byte(storedToken.UserID), []byte(userID)) != 1 {
 		return nil, fmt.Errorf("token does not belong to requesting user")
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -291,9 +291,10 @@ type AuditConfig struct {
 	BufferSize int `mapstructure:"buffer_size"`
 	// OverflowStrategy controls what happens when the event buffer is full.
 	// Valid values:
-	//   "drop"  – discard the event and increment the dropped counter (default)
-	//   "block" – block the caller until buffer space is available (backpressure)
+	//   "block" – block the caller until buffer space is available (backpressure) (default)
 	//   "sync"  – bypass the channel and write the event synchronously
+	//   "drop"  – discard the event and increment the dropped counter (must be
+	//             explicitly opted into; audit records can be lost under load)
 	OverflowStrategy string `mapstructure:"overflow_strategy"`
 }
 
@@ -536,6 +537,13 @@ func validateHTTPSEndpoint(raw string) error {
 func isDevelopmentMode() bool {
 	val := strings.ToLower(os.Getenv("OIDC_AUTH_DEV"))
 	return val == "true" || val == "1" || val == "yes"
+}
+
+// IsDevelopmentMode reports whether development mode is enabled (OIDC_AUTH_DEV).
+// Security-relaxing options (e.g. skipping audience verification) must only take
+// effect when this returns true.
+func IsDevelopmentMode() bool {
+	return isDevelopmentMode()
 }
 
 // bindSafeEnvironmentVariables binds only non-security-critical config keys to environment variables.

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -107,32 +107,32 @@ int send_auth_request(int sock, const char *username, const char *service, const
     json_object *request = json_object_new_object();
     json_object *type = json_object_new_string("authenticate");
     json_object *user_id = json_object_new_string(username);
-    json_object *login_type = json_object_new_string("unknown");
     json_object *target_host = json_object_new_string(rhost);
     json_object *metadata = json_object_new_object();
     json_object *service_obj = json_object_new_string(service);
     json_object *tty_obj = json_object_new_string(tty);
-    
-    // Determine login type based on service and TTY
+
+    // Determine login type based on service and TTY.
+    const char *login_type_str = "unknown";
     if (strcmp(service, "sshd") == 0) {
-        json_object_object_del(request, "login_type");
-        json_object_object_add(request, "login_type", json_object_new_string("ssh"));
+        login_type_str = "ssh";
     } else if (strstr(tty, "tty") != NULL) {
-        json_object_object_del(request, "login_type");
-        json_object_object_add(request, "login_type", json_object_new_string("console"));
+        login_type_str = "console";
     } else if (strstr(service, "gdm") != NULL || strstr(service, "lightdm") != NULL) {
-        json_object_object_del(request, "login_type");
-        json_object_object_add(request, "login_type", json_object_new_string("gui"));
+        login_type_str = "gui";
     }
-    
+
     // Add metadata
     json_object_object_add(metadata, "service", service_obj);
     json_object_object_add(metadata, "tty", tty_obj);
     json_object_object_add(metadata, "pid", json_object_new_int(getpid()));
-    
-    // Build request
+
+    // Build request. Each value is added exactly once and owned by the tree, so
+    // a single json_object_put(request) frees everything (L-11: previously the
+    // login_type object was allocated but never attached, leaking each call).
     json_object_object_add(request, "type", type);
     json_object_object_add(request, "user_id", user_id);
+    json_object_object_add(request, "login_type", json_object_new_string(login_type_str));
     json_object_object_add(request, "target_host", target_host);
     json_object_object_add(request, "metadata", metadata);
     
@@ -434,9 +434,12 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const c
     }
     
     log_pam_message(LOG_DEBUG, "Account management check for user: %s", username);
-    
-    // For OIDC authentication, account management is handled by the identity provider
-    // We could add additional checks here if needed
+
+    // L-5: Authorization is enforced entirely in the auth phase (pam_sm_authenticate
+    // -> broker: identity binding, group checks, risk policy). This module does NOT
+    // implement account-phase (acct_mgmt) authorization, so deployments MUST NOT
+    // rely on the PAM `account` stack with pam_oidc as the sole gate. Returning
+    // PAM_SUCCESS here is intentional and documented; see DEPLOYMENT.md.
     return PAM_SUCCESS;
 }
 

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -28,6 +28,7 @@ type AuditLogger struct {
 	stopChan      chan struct{}
 	wg            sync.WaitGroup
 	droppedEvents atomic.Int64 // total events dropped due to full channel
+	failedWrites  atomic.Int64 // total events that failed to write to an output (L-10)
 	lastDropLog   atomic.Int64 // Unix second of last drop error log (rate limiter)
 	// writeMu serializes all writes to outputs so that synchronous critical-event
 	// writes (from any goroutine) don't race with the async processEvents goroutine.
@@ -38,6 +39,14 @@ type AuditLogger struct {
 // the event channel was full and the overflow strategy is "drop" (the default).
 func (al *AuditLogger) DroppedEvents() int64 {
 	return al.droppedEvents.Load()
+}
+
+// FailedWrites returns the cumulative number of audit events that could not be
+// written to an output (e.g. disk full, sink unreachable). Surfacing this lets
+// operators alert on audit-pipeline failures rather than silently losing
+// records (L-10).
+func (al *AuditLogger) FailedWrites() int64 {
+	return al.failedWrites.Load()
 }
 
 // AuditEvent represents a security audit event
@@ -197,16 +206,18 @@ func (al *AuditLogger) LogAuthEvent(event AuditEvent) {
 		return
 	}
 
-	// Non-critical events are dispatched according to the configured overflow strategy.
+	// Non-critical events are dispatched according to the configured overflow
+	// strategy. The default (unset) is "block" so audit records are not silently
+	// lost under load (L-9); operators must explicitly opt into "drop".
 	switch al.config.OverflowStrategy {
-	case "block":
+	case "", "block":
 		// Apply backpressure: block the caller until the channel has room.
 		al.eventChan <- event
 	case "sync":
 		// Bypass the async channel and write directly, serialised by writeMu so
 		// concurrent callers do not interleave partial writes.
 		al.writeEventSync(event)
-	default: // "drop" (and any unrecognised value)
+	default: // "drop" (explicitly configured) or any unrecognised value
 		select {
 		case al.eventChan <- event:
 		default:
@@ -252,10 +263,12 @@ func (al *AuditLogger) processEvents(ctx context.Context) {
 func (al *AuditLogger) writeEvent(event AuditEvent) {
 	for _, output := range al.outputs {
 		if err := output.Write(event); err != nil {
+			al.failedWrites.Add(1)
 			log.Error().
 				Err(err).
 				Str("event_type", event.EventType).
 				Str("event_id", event.EventID).
+				Int64("total_failed_writes", al.failedWrites.Load()).
 				Msg("Failed to write audit event")
 		}
 	}

--- a/pkg/security/audit_test.go
+++ b/pkg/security/audit_test.go
@@ -519,14 +519,16 @@ func TestAuditLoggerDropCounter(t *testing.T) {
 	}
 }
 
-// TestAuditLoggerDropCounterDefault verifies the same behaviour when
-// OverflowStrategy is empty (should default to "drop").
-func TestAuditLoggerDropCounterDefault(t *testing.T) {
+// TestAuditLoggerDefaultDoesNotDrop verifies the L-9 fix: an unset overflow
+// strategy now defaults to "block" (backpressure) rather than silently dropping
+// audit records. With processEvents running to drain the channel, no events are
+// dropped.
+func TestAuditLoggerDefaultDoesNotDrop(t *testing.T) {
 	out := &captureOutput{}
 	cfg := config.AuditConfig{
 		Enabled:          true,
-		BufferSize:       1,
-		OverflowStrategy: "", // empty → drop
+		BufferSize:       4,
+		OverflowStrategy: "", // empty → block (default)
 	}
 	logger, err := NewAuditLogger(cfg)
 	if err != nil {
@@ -534,13 +536,18 @@ func TestAuditLoggerDropCounterDefault(t *testing.T) {
 	}
 	logger.outputs = []AuditOutput{out}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger.wg.Add(1)
+	go logger.processEvents(ctx)
+
 	event := AuditEvent{EventType: "test", UserID: "u1", Success: true}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 20; i++ {
 		logger.LogAuthEvent(event)
 	}
 
-	if dropped := logger.DroppedEvents(); dropped != 2 {
-		t.Errorf("Expected 2 dropped events (buffer=1, sent=3), got %d", dropped)
+	if dropped := logger.DroppedEvents(); dropped != 0 {
+		t.Errorf("Expected 0 dropped events with default (block) strategy, got %d", dropped)
 	}
 }
 

--- a/pkg/security/encryption.go
+++ b/pkg/security/encryption.go
@@ -108,7 +108,29 @@ func (e *Encryption) Decrypt(ciphertext string) (string, error) {
 		return "", fmt.Errorf("failed to decrypt: %w", err)
 	}
 
-	return string(plaintext), nil
+	// Best-effort: zero the transient plaintext buffer after copying to a string.
+	// Go strings are immutable and may be copied by the GC, so this cannot fully
+	// scrub the secret, but it minimizes the window the raw bytes live in the heap
+	// buffer we control (L-16).
+	out := string(plaintext)
+	Zero(plaintext)
+	return out, nil
+}
+
+// Zero overwrites b with zeros. Used to scrub key material and transient
+// plaintext buffers (L-16). Note: this cannot scrub data already copied into Go
+// strings, which are immutable.
+func Zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// Destroy zeroes the derived encryption key. After Destroy the Encryption value
+// must not be used again. Call when the broker shuts down to limit how long key
+// material persists in memory (L-16).
+func (e *Encryption) Destroy() {
+	Zero(e.key)
 }
 
 // EncryptBytes encrypts the given byte slice

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -309,7 +309,13 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			// Check if this is an OIDC PAM key
+			// L-14: expiry is read from the (broker-written) key comment. A
+			// malformed/forged comment simply causes the key to be retained
+			// (fail-safe for cleanup: it is never removed early), and the keys are
+			// broker-generated so the comment is not attacker-controlled in the
+			// supported flow. Authoritative expiry lives in the broker session;
+			// this cleanup is best-effort. See TODO(L-3) in keys.go for moving
+			// expiry to a separate metadata file.
 			if strings.Contains(line, "@oidc-pam-") {
 				// Extract timestamp from comment
 				parts := strings.Fields(line)


### PR DESCRIPTION
Remediates every remaining item in the #95 roll-up **except M-1** (static PBKDF2 salt), which is left open pending a key-format/migration decision to discuss.

## Medium
- **M-3** — audience (`client_id`) verification is only skippable in development mode; production always verifies regardless of `verify_audience`, matching the auth-code flow. Adds `config.IsDevelopmentMode()`.
- **M-4** — the device-authorization discovery **fallback** endpoint now passes through the same scheme/host `validateEndpoint` checks instead of being returned unvalidated.

## Low
- **L-2** — Darwin/FreeBSD peer-cred reject an unexpected `Xucred.Version` (don't misread an unpopulated struct as uid 0).
- **L-4** — IPC server caps concurrent connections with a bounded semaphore (128); excess connections get `SERVER_BUSY` and are closed.
- **L-5** — documented that `pam_sm_acct_mgmt` performs no authorization (auth phase is authoritative); deployments must not rely on the PAM `account` stack alone.
- **L-6** — `pam-helper` ignores caller-supplied `-config`/`-socket` when EUID 0, preventing redirection to a rogue broker.
- **L-7** — unknown risk-policy conditions log a warning instead of silently evaluating false (visible misconfig).
- **L-9** — audit overflow defaults to `block` (backpressure) instead of silently dropping; `drop` is now opt-in.
- **L-10** — audit write failures are counted and exposed via `FailedWrites()` for alerting.
- **L-11** — fixed a per-authentication json-c object leak in the PAM request builder.
- **L-14** — documented best-effort/fail-safe authorized_keys expiry parsing.
- **L-15** — constant-time token-ownership comparison in `ValidateToken`.
- **L-16** — best-effort zeroization: `Encryption.Destroy()` + scrubbing the transient decrypt buffer.

## Tests
Updated the audit overflow test for the new `block` default and added a default-does-not-drop test. Full non-PAM suite + vet pass; gofmt clean.

> Note: this caught a real regression during development — changing the audit default to `block` hung an existing test that assumed `drop`; the test was corrected to match the new (safer) behavior.

## Remaining
- **M-1** static PBKDF2 salt — open; needs a decision (random per-deployment salt + migration, or mandate base64-32-byte keys and drop stretching). Left for discussion.