### PR TITLE
feat(security)!: require base64 32-byte token_encryption_key (M-1, breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.4] - 2026-05-30
+## [0.4.0] - 2026-05-30
+
+### Changed (BREAKING)
+- **(#95 M-1) `token_encryption_key` must now be a base64-encoded 32-byte key.**
+  The key is used directly as the AES-256-GCM key; the previous PBKDF2 + static
+  salt derivation has been removed (the static salt was shared across all
+  deployments). A passphrase or wrong-length value is now rejected at startup.
+  - **Migration:** generate a key with `oidc-admin gen-key` (or
+    `openssl rand -base64 32`) and set it as `security.token_encryption_key`.
+    The token store is in-memory only, so there is no persisted ciphertext to
+    migrate — existing sessions simply re-authenticate after restart.
+
+### Added
+- `oidc-admin gen-key` subcommand that prints a new base64-encoded 32-byte
+  encryption key.
+- `security.ValidateKeyString` for startup key validation.
 
 ### Security
 - **Critical (#90):** Bind the authenticated OIDC identity to the requested local username via `username_claim` before activating a session; previously any IdP user could log in as any local account (including root). Fails closed when `username_claim` is unset.

--- a/cmd/oidc-admin/admin.go
+++ b/cmd/oidc-admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
 	"github.com/spf13/cobra"
 )
 
@@ -97,11 +98,28 @@ var adminKeysCmd = &cobra.Command{
 	},
 }
 
+var adminGenKeyCmd = &cobra.Command{
+	Use:   "gen-key",
+	Short: "Generate a token encryption key",
+	Long: `Generate a new base64-encoded 32-byte (AES-256) key suitable for
+security.token_encryption_key in broker.yaml. The output is the value to set;
+keep it secret and supply it via the config file or an env:/file: reference.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		key, err := security.GenerateKey()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to generate key")
+			os.Exit(1)
+		}
+		fmt.Println(key)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(adminStatusCmd)
 	rootCmd.AddCommand(adminHealthCmd)
 	rootCmd.AddCommand(adminSessionsCmd)
 	rootCmd.AddCommand(adminKeysCmd)
+	rootCmd.AddCommand(adminGenKeyCmd)
 }
 
 // System status

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -43,10 +43,13 @@ Choose your provider and follow the specific setup guide:
    sudo nano /etc/oidc-auth/broker.yaml
    ```
 
-3. **Generate encryption key:**
+3. **Generate encryption key** (base64-encoded 32-byte / AES-256 key):
    ```bash
-   openssl rand -base64 32
+   oidc-admin gen-key        # or: openssl rand -base64 32
    ```
+   The value is used directly as the AES-256 key — it must be a base64 32-byte
+   key, not a passphrase. A wrong-length or non-base64 value is rejected at
+   startup.
 
 4. **Update configuration with your settings:**
    - OIDC provider URL
@@ -87,7 +90,8 @@ oidc:
       scopes: ["openid", "email", "profile", "groups"]
 
 security:
-  token_encryption_key: "CHANGE-THIS-TO-A-SECURE-32-BYTE-KEY"
+  # base64-encoded 32-byte key from `oidc-admin gen-key`
+  token_encryption_key: "REPLACE-with-output-of-oidc-admin-gen-key"
 
 authentication:
   require_groups: ["linux-users"]

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -106,8 +106,11 @@ security:
   max_token_age: "24h"
   clock_skew_tolerance: "5m"
   
-  # Token encryption (generate with: openssl rand -base64 32)
-  token_encryption_key: "your-32-byte-base64-encoded-key-here"
+  # Token encryption key — MUST be a base64-encoded 32-byte (256-bit) key.
+  # Generate with:  oidc-admin gen-key   (or: openssl rand -base64 32)
+  # The value is used directly as the AES-256 key (no passphrase stretching);
+  # a passphrase or wrong-length value is rejected at startup.
+  token_encryption_key: "REPLACE-with-output-of-oidc-admin-gen-key"
   
   # TLS verification
   tls_verification:

--- a/configs/production/broker-minimal.yaml
+++ b/configs/production/broker-minimal.yaml
@@ -59,8 +59,10 @@ security:
   max_token_age: "24h"
   clock_skew_tolerance: "5m"
   
-  # REQUIRED: Generate with: openssl rand -base64 32
-  token_encryption_key: "CHANGE-THIS-TO-A-SECURE-32-BYTE-KEY"
+  # REQUIRED: base64-encoded 32-byte key. Generate with:
+  #   oidc-admin gen-key    (or: openssl rand -base64 32)
+  # Used directly as the AES-256 key; a passphrase/wrong length is rejected.
+  token_encryption_key: "REPLACE-with-output-of-oidc-admin-gen-key"
   
   # Rate limiting
   rate_limiting:

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -115,13 +115,14 @@ func NewBroker(cfg *config.Config) (*Broker, error) {
 		return nil, fmt.Errorf("at least one OIDC provider must be configured")
 	}
 
-	// Validate security configuration
+	// Validate security configuration. The key must be a base64-encoded 32-byte
+	// value (as produced by GenerateKey); it is used directly as the AES-256 key
+	// with no passphrase stretching.
 	if cfg.Security.TokenEncryptionKey == "" {
 		return nil, fmt.Errorf("token encryption key is required for security")
 	}
-
-	if len(cfg.Security.TokenEncryptionKey) < 32 {
-		return nil, fmt.Errorf("token encryption key must be at least 32 bytes for security")
+	if err := security.ValidateKeyString(cfg.Security.TokenEncryptionKey); err != nil {
+		return nil, fmt.Errorf("invalid token_encryption_key: %w", err)
 	}
 
 	// Validate OIDC provider security

--- a/pkg/auth/broker_core_test.go
+++ b/pkg/auth/broker_core_test.go
@@ -28,7 +28,7 @@ func TestBrokerCoreAuthenticate(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -92,7 +92,7 @@ func TestPolicyEngineEvaluateCore(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -144,7 +144,7 @@ func TestPolicyEngineEvaluateCore(t *testing.T) {
 func TestTokenManagerCore(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -243,7 +243,7 @@ func TestSessionManagementCore(t *testing.T) {
 				MaxConcurrentSessions: 10,
 			},
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		providers: make(map[string]*OIDCProvider),

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -19,7 +19,7 @@ func TestBrokerInternalMethods(t *testing.T) {
 	broker := &Broker{
 		config: &config.Config{
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		sessions: make(map[string]*Session),
@@ -75,7 +75,7 @@ func TestBrokerSessionHelpers(t *testing.T) {
 				MaxConcurrentSessions: 10,
 			},
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		sessions:     make(map[string]*Session),
@@ -149,7 +149,7 @@ func TestBrokerFieldInitialization(t *testing.T) {
 				MaxConcurrentSessions: 10,
 			},
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		sessions:     make(map[string]*Session),
@@ -311,7 +311,7 @@ func TestBrokerSSHKeyMethods(t *testing.T) {
 	broker := &Broker{
 		config: &config.Config{
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		keyManager:            sshpkg.NewKeyManager(keyDir),
@@ -410,7 +410,7 @@ func TestBrokerStartStopIntegration(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -457,7 +457,7 @@ func TestBrokerAuthenticateScenarios(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -534,7 +534,7 @@ func TestBrokerPollDeviceAuthorization(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 

--- a/pkg/auth/broker_session_test.go
+++ b/pkg/auth/broker_session_test.go
@@ -27,7 +27,7 @@ func TestBrokerSessionMethods(t *testing.T) {
 				MaxConcurrentSessions: 10,
 			},
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		sessions:     make(map[string]*Session),
@@ -122,7 +122,7 @@ func TestBrokerSessionCleanup(t *testing.T) {
 				MaxConcurrentSessions: 10,
 			},
 			Security: config.SecurityConfig{
-				TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+				TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			},
 		},
 		sessions:     make(map[string]*Session),
@@ -226,7 +226,7 @@ func TestBrokerStartStop(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 

--- a/pkg/auth/broker_test.go
+++ b/pkg/auth/broker_test.go
@@ -40,7 +40,7 @@ func TestNewBroker(t *testing.T) {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-encryption-key-32-bytes-long!",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			AuditEnabled:       true,
 		},
 		Audit: config.AuditConfig{

--- a/pkg/auth/security_test.go
+++ b/pkg/auth/security_test.go
@@ -78,7 +78,7 @@ func TestBrokerSecurityValidation(t *testing.T) {
 					},
 				},
 				Security: config.SecurityConfig{
-					TokenEncryptionKey: "test-encryption-key-32-bytes-long!",
+					TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 				},
 			},
 			expectedError: "provider",
@@ -101,7 +101,7 @@ func TestBrokerSecurityValidation(t *testing.T) {
 					},
 				},
 				Security: config.SecurityConfig{
-					TokenEncryptionKey: "test-encryption-key-32-bytes-long!",
+					TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 				},
 			},
 			expectedError: "openid",
@@ -240,7 +240,7 @@ func TestBrokerAuditingSecurity(t *testing.T) {
 func TestBrokerTokenSecurity(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-encryption-key-32-bytes-long!",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			SecureTokenStorage: true,
 			VerifyAudience:     true,
 			RequireAuthTime:    true,

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -16,7 +16,7 @@ func TestTokenManagerCreation(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -36,7 +36,7 @@ func TestTokenManagerStartStop(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -67,7 +67,7 @@ func TestTokenManagerBasicOperations(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -121,7 +121,7 @@ func TestTokenManagerRevocation(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -155,7 +155,7 @@ func TestTokenManagerRefresh(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -180,7 +180,7 @@ func TestTokenManagerInternalMethods(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -221,7 +221,7 @@ func TestTokenManagerCleanup(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -254,7 +254,7 @@ func TestTokenManagerConcurrency(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -299,7 +299,7 @@ func TestValidateTokenConcurrent(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 
@@ -352,7 +352,7 @@ func newTMForTest(t *testing.T) *TokenManager {
 	tm, err := NewTokenManager(&config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	})
 	if err != nil {
@@ -621,7 +621,7 @@ func TestTokenManagerAlwaysEncrypts(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "test-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	}
 

--- a/pkg/security/encryption.go
+++ b/pkg/security/encryption.go
@@ -4,13 +4,13 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
-
-	"golang.org/x/crypto/pbkdf2"
 )
+
+// KeyBytes is the required raw key length for AES-256 (32 bytes).
+const KeyBytes = 32
 
 // Encryption handles encryption and decryption of sensitive data
 type Encryption struct {
@@ -19,23 +19,52 @@ type Encryption struct {
 
 // NewEncryption creates a new encryption instance.
 //
-// The 32-byte AES key is derived from keyString using PBKDF2-HMAC-SHA256
-// (600,000 iterations) with a fixed application-level salt. keyString is
-// expected to be a high-entropy secret — config validation requires 32+ bytes,
-// and GenerateKey() produces a suitable base64 value. The static salt is an
-// accepted trade-off given that assumption; its purpose is computational cost
-// against brute force, not per-deployment uniqueness.
+// keyString MUST be a base64-encoded 32-byte (256-bit) key, exactly as produced
+// by GenerateKey(). The decoded bytes are used directly as the AES-256-GCM key —
+// no password-based derivation is performed, so the key must already be full
+// entropy. A passphrase, short string, or wrong-length key is rejected.
+//
+// BREAKING CHANGE (v0.4.0): earlier versions accepted an arbitrary passphrase
+// and stretched it with PBKDF2 + a static salt. Operators must now supply a
+// machine-generated key (see `oidc-admin`/GenerateKey). The static-salt
+// derivation has been removed.
 func NewEncryption(keyString string) (*Encryption, error) {
 	if keyString == "" {
 		return nil, fmt.Errorf("encryption key cannot be empty")
 	}
 
-	salt := []byte("oidc-pam-token-encryption-v1")
-	key := pbkdf2.Key([]byte(keyString), salt, 600000, 32, sha256.New)
+	key, err := decodeKey(keyString)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Encryption{
 		key: key,
 	}, nil
+}
+
+// decodeKey base64-decodes keyString and validates it is exactly KeyBytes long.
+// It accepts both standard and raw (unpadded) base64 for operator convenience.
+func decodeKey(keyString string) ([]byte, error) {
+	var key []byte
+	var err error
+	if key, err = base64.StdEncoding.DecodeString(keyString); err != nil {
+		if key, err = base64.RawStdEncoding.DecodeString(keyString); err != nil {
+			return nil, fmt.Errorf("encryption key must be base64-encoded: %w", err)
+		}
+	}
+	if len(key) != KeyBytes {
+		return nil, fmt.Errorf("encryption key must decode to exactly %d bytes, got %d (generate one with `oidc-admin` or GenerateKey)", KeyBytes, len(key))
+	}
+	return key, nil
+}
+
+// ValidateKeyString reports whether keyString is a valid base64-encoded 32-byte
+// key, without constructing an Encryption. Used by config validation so a bad
+// key is caught at startup rather than first use.
+func ValidateKeyString(keyString string) error {
+	_, err := decodeKey(keyString)
+	return err
 }
 
 // Encrypt encrypts the given plaintext

--- a/pkg/security/encryption_test.go
+++ b/pkg/security/encryption_test.go
@@ -6,9 +6,15 @@ import (
 	"testing"
 )
 
+// Valid base64-encoded 32-byte keys for tests (Option B requires real keys).
+var (
+	testKey1 = base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	testKey2 = base64.StdEncoding.EncodeToString([]byte("fedcba9876543210fedcba9876543210"))
+)
+
 func TestNewEncryption(t *testing.T) {
 	// Test with valid key
-	enc, err := NewEncryption("test-key")
+	enc, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption: %v", err)
 	}
@@ -27,7 +33,7 @@ func TestNewEncryption(t *testing.T) {
 }
 
 func TestEncryptDecrypt(t *testing.T) {
-	enc, err := NewEncryption("test-key-for-encryption")
+	enc, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption: %v", err)
 	}
@@ -78,7 +84,7 @@ func TestEncryptDecrypt(t *testing.T) {
 }
 
 func TestEncryptDecryptBytes(t *testing.T) {
-	enc, err := NewEncryption("test-key-for-bytes")
+	enc, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption: %v", err)
 	}
@@ -129,7 +135,7 @@ func TestEncryptDecryptBytes(t *testing.T) {
 }
 
 func TestDecryptInvalidData(t *testing.T) {
-	enc, err := NewEncryption("test-key")
+	enc, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption: %v", err)
 	}
@@ -177,7 +183,7 @@ func TestDecryptInvalidData(t *testing.T) {
 }
 
 func TestDecryptBytesInvalidData(t *testing.T) {
-	enc, err := NewEncryption("test-key")
+	enc, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption: %v", err)
 	}
@@ -287,12 +293,12 @@ func TestGenerateKey(t *testing.T) {
 
 func TestEncryptionWithDifferentKeys(t *testing.T) {
 	// Create two different encryption instances
-	enc1, err := NewEncryption("key1")
+	enc1, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption 1: %v", err)
 	}
 
-	enc2, err := NewEncryption("key2")
+	enc2, err := NewEncryption(testKey2)
 	if err != nil {
 		t.Fatalf("Failed to create encryption 2: %v", err)
 	}
@@ -324,7 +330,7 @@ func TestEncryptionWithDifferentKeys(t *testing.T) {
 }
 
 func TestEncryptionConsistency(t *testing.T) {
-	enc, err := NewEncryption("consistent-key")
+	enc, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption: %v", err)
 	}
@@ -352,12 +358,12 @@ func TestEncryptionConsistency(t *testing.T) {
 
 func TestEncryptionKeyDerivation(t *testing.T) {
 	// Same key string should produce same encryption key
-	enc1, err := NewEncryption("same-key")
+	enc1, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption 1: %v", err)
 	}
 
-	enc2, err := NewEncryption("same-key")
+	enc2, err := NewEncryption(testKey1)
 	if err != nil {
 		t.Fatalf("Failed to create encryption 2: %v", err)
 	}

--- a/pkg/security/key_format_test.go
+++ b/pkg/security/key_format_test.go
@@ -1,0 +1,65 @@
+package security
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// TestNewEncryptionRequiresBase64Key covers the Option B breaking change: the
+// key must be a base64-encoded 32-byte value, used directly (no PBKDF2).
+func TestNewEncryptionRequiresBase64Key(t *testing.T) {
+	// A freshly generated key must be accepted.
+	good, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if _, err := NewEncryption(good); err != nil {
+		t.Errorf("GenerateKey output should be accepted, got: %v", err)
+	}
+
+	// Raw (unpadded) base64 of 32 bytes should also work.
+	raw := base64.RawStdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+	if _, err := NewEncryption(raw); err != nil {
+		t.Errorf("raw base64 32-byte key should be accepted, got: %v", err)
+	}
+
+	bad := []struct {
+		name, key string
+	}{
+		{"passphrase", "this-is-a-passphrase-not-a-key!!"},
+		{"too short (base64 of 16 bytes)", base64.StdEncoding.EncodeToString([]byte("0123456789abcdef"))},
+		{"too long (base64 of 48 bytes)", base64.StdEncoding.EncodeToString(make([]byte, 48))},
+		{"not base64", "@@@@not-base64@@@@"},
+	}
+	for _, tc := range bad {
+		if _, err := NewEncryption(tc.key); err == nil {
+			t.Errorf("%s: expected rejection, got nil error", tc.name)
+		}
+		if err := ValidateKeyString(tc.key); err == nil {
+			t.Errorf("%s: ValidateKeyString should reject", tc.name)
+		}
+	}
+}
+
+// TestEncryptionDestroyZeroesKey verifies Destroy scrubs the key material.
+func TestEncryptionDestroyZeroesKey(t *testing.T) {
+	enc, err := NewEncryption(mustKey(t))
+	if err != nil {
+		t.Fatalf("NewEncryption: %v", err)
+	}
+	enc.Destroy()
+	for i, b := range enc.key {
+		if b != 0 {
+			t.Fatalf("key byte %d not zeroed after Destroy", i)
+		}
+	}
+}
+
+func mustKey(t *testing.T) string {
+	t.Helper()
+	k, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return k
+}


### PR DESCRIPTION
Implements **Option B** for the last open audit finding (#95 **M-1**): the static-salt PBKDF2 key derivation is removed; `token_encryption_key` must now be a base64-encoded 32-byte key used directly as the AES-256-GCM key.

**This is a breaking change → targeted for v0.4.0.**

## Why
The previous derivation used a hardcoded salt (`"oidc-pam-token-encryption-v1"`) identical across every deployment, allowing one precomputed table to attack all installs and making two installs with the same passphrase derive the same key. The token store is in-memory only today, so there is no persisted ciphertext — making this the cheapest moment to change the format.

## Changes
- `NewEncryption` base64-decodes the key and requires exactly 32 bytes (accepts standard and raw base64); rejects passphrases / wrong lengths. Adds `ValidateKeyString`.
- Broker validates the key at startup via `ValidateKeyString` (replaces the old `len >= 32` byte check).
- New **`oidc-admin gen-key`** subcommand prints a valid key.
- `Encryption.Destroy()` + decrypt-buffer zeroization retained (L-16).
- Example/production configs + CONFIGURATION-GUIDE updated to reference `oidc-admin gen-key` and document the requirement.
- Tests updated to use valid base64 keys; new `key_format_test.go` covers accept/reject cases and `Destroy`.

## Migration
Generate a key and set it:
```
oidc-admin gen-key   # or: openssl rand -base64 32
```
No data migration needed (in-memory token store; sessions re-auth after restart).

## Verification
Full non-PAM suite + vet pass; gofmt clean. Closes #95.