### PR TITLE
fix(security): bump Go to 1.25.11 (GO-2026-5039, GO-2026-5037)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Verify dependencies
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Install PAM development libraries
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: golangci-lint
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Install build dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Initialize CodeQL
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Run Gosec Security Scanner
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
           cache: true
 
       - name: Install PAM development libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Bumped Go toolchain pin from 1.25.10 to 1.25.11, resolving two Go standard-library advisories reported by govulncheck: GO-2026-5039 (net/textproto) and GO-2026-5037 (crypto/x509).
+
 ## [0.4.0] - 2026-05-30
 
 ### Changed (BREAKING)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scttfrdmn/oidc-pam
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0


### PR DESCRIPTION
## Why
govulncheck is failing on `main` (and on all four open Dependabot PRs) due to two new Go standard-library advisories, both fixed in **go1.25.11**:
- **GO-2026-5039** — net/textproto (found in go1.25.10, fixed in go1.25.11)
- **GO-2026-5037** — crypto/x509 (found in go1.25.10, fixed in go1.25.11)

These are unrelated to the dependency bumps in #101–#104 — those PRs fail only on this shared stdlib finding. Bumping the toolchain clears it everywhere at once.

## Change
- `go.mod`: `go 1.25.10` → `1.25.11` (verified `go mod tidy` produces exactly this, so the tidiness check passes).
- All `go-version` pins in `ci.yml`, `security.yml`, `release.yml`: `1.25.10` → `1.25.11`.

Once merged, the Dependabot PRs should go green on rebase.