### PR TITLE
ci: automate version stamping on release (fix README/CHANGELOG drift)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,40 @@ permissions:
   contents: write
 
 jobs:
+  verify-version:
+    name: Verify version sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check README badge and CHANGELOG match the tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          fail=0
+
+          # README version badge must equal the tag.
+          badge=$(grep -oE 'badge/Version-[^-]+(\.[^-]+)*-blue' README.md | sed -E 's#badge/Version-(.*)-blue#\1#' | head -1)
+          if [ "$badge" != "$VERSION" ]; then
+            echo "::error::README version badge is '$badge' but the tag is '$VERSION'. Use scripts/release.sh to cut releases."
+            fail=1
+          fi
+
+          # CHANGELOG must have a section header for this version.
+          if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Use scripts/release.sh to cut releases."
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "Version $VERSION is consistent across the tag, README badge, and CHANGELOG."
+
   build:
     name: Build (${{ matrix.arch }})
     runs-on: ${{ matrix.runs_on }}
+    needs: verify-version
 
     strategy:
       fail-fast: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,15 +233,31 @@ This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 - **Release Candidate**: Production-ready candidates (0.x.x-rc.x)
 - **Stable**: Production releases (x.x.x)
 
+### Cutting a release
+
+Use the release script — it is the single source of truth and keeps the README
+version badge and CHANGELOG in sync with the tag automatically:
+
+```bash
+# 1. Land all changes for the release on main, with entries under
+#    "## [Unreleased]" in CHANGELOG.md.
+# 2. From a clean checkout of main:
+scripts/release.sh 0.4.2        # leading 'v' optional
+```
+
+The script stamps the README badge, rolls `## [Unreleased]` into a dated
+`## [0.4.2]` section, commits `chore(release): v0.4.2`, creates the annotated tag,
+and (after confirmation) pushes both. Pushing the tag triggers the Release
+workflow, which **verifies** the tag, README badge, and CHANGELOG agree before
+building and publishing multi-arch artifacts. A manual tag whose docs are out of
+sync will fail that check.
+
 ### Release Checklist
 
-- [ ] All tests pass
-- [ ] Documentation updated
-- [ ] CHANGELOG.md updated
-- [ ] Version bumped in relevant files
-- [ ] Git tag created
-- [ ] GitHub release created
-- [ ] Artifacts built and published
+- [ ] All changes merged to `main` with entries under `## [Unreleased]`
+- [ ] All tests pass on `main`
+- [ ] `scripts/release.sh <version>` run (stamps README + CHANGELOG, tags, pushes)
+- [ ] Release workflow green; GitHub release and artifacts published
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go Version](https://img.shields.io/badge/Go-%3E%3D%201.25-blue)](https://golang.org/)
-[![Version](https://img.shields.io/badge/Version-0.4.0-blue)](https://github.com/scttfrdmn/oidc-pam/releases)
+[![Version](https://img.shields.io/badge/Version-0.4.1-blue)](https://github.com/scttfrdmn/oidc-pam/releases)
 
 A comprehensive Linux authentication solution using OpenID Connect (OIDC) that modernizes SSH, console, and GUI logins with passkey support, automatic SSH key management, and enterprise-grade audit capabilities.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Cut a release: stamp the README version badge and the CHANGELOG, commit, create
+# an annotated tag, and push. Tagging this way guarantees the README/CHANGELOG in
+# the tagged commit always match the version (no manual sync drift).
+#
+# Usage:
+#   scripts/release.sh <version>
+# Example:
+#   scripts/release.sh 0.4.2          # leading 'v' optional
+#
+# Preconditions: clean working tree on the default branch, a "## [Unreleased]"
+# section in CHANGELOG.md with content, and push access.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <version>   (e.g. $0 0.4.2)" >&2
+  exit 2
+fi
+
+# Normalize: accept "0.4.2" or "v0.4.2"; VER has no 'v', TAG has the 'v'.
+VER="${1#v}"
+TAG="v${VER}"
+
+if ! [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: '$VER' is not a valid semver version" >&2
+  exit 2
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# --- preconditions -----------------------------------------------------------
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is not clean; commit or stash first" >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "error: tag ${TAG} already exists" >&2
+  exit 1
+fi
+
+if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+  echo "error: no '## [Unreleased]' section in CHANGELOG.md" >&2
+  exit 1
+fi
+
+# The Unreleased section must contain at least one bullet (don't release nothing).
+UNRELEASED_BODY="$(awk '/^## \[Unreleased\]/{f=1;next} /^## /{f=0} f' CHANGELOG.md | grep -c '^- ' || true)"
+if [[ "$UNRELEASED_BODY" -eq 0 ]]; then
+  echo "error: '## [Unreleased]' has no entries to release" >&2
+  exit 1
+fi
+
+TODAY="$(date -u +%Y-%m-%d)"
+
+# --- stamp README version badge ---------------------------------------------
+# Matches: ...badge/Version-<anything>-blue...
+if ! grep -q 'badge/Version-' README.md; then
+  echo "error: could not find version badge in README.md" >&2
+  exit 1
+fi
+perl -0pi -e "s{badge/Version-[^-]*(?:-[^-]*)*?-blue}{badge/Version-${VER}-blue}g" README.md
+# Simpler, robust replacement of just the version token between 'Version-' and '-blue':
+perl -0pi -e "s{(badge/Version-)([^)]*?)(-blue)}{\${1}${VER}\${3}}g" README.md
+
+# --- roll CHANGELOG: insert a new version section below [Unreleased] ---------
+# Turn:
+#   ## [Unreleased]
+#   <entries>
+# into:
+#   ## [Unreleased]
+#
+#   ## [<ver>] - <date>
+#   <entries>
+awk -v ver="$VER" -v date="$TODAY" '
+  /^## \[Unreleased\]/ && !done {
+    print
+    print ""
+    print "## [" ver "] - " date
+    done=1
+    next
+  }
+  { print }
+' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+
+# --- commit, tag, push -------------------------------------------------------
+git add README.md CHANGELOG.md
+git commit -m "chore(release): ${TAG}"
+git tag -a "${TAG}" -m "oidc-pam ${TAG}"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+echo
+echo "Prepared ${TAG} on branch '${BRANCH}':"
+git --no-pager show --stat --oneline HEAD | head -20
+echo
+read -r -p "Push commit and tag to origin? [y/N] " ans
+if [[ "${ans:-}" =~ ^[Yy]$ ]]; then
+  git push origin "${BRANCH}"
+  git push origin "${TAG}"
+  echo "Pushed ${TAG}. The release workflow will build artifacts and publish the GitHub release."
+else
+  echo "Not pushed. To undo locally: git tag -d ${TAG} && git reset --hard HEAD~1"
+fi


### PR DESCRIPTION
Addresses the recurring problem that the README version badge and CHANGELOG drift from the released tag because they were updated by hand (e.g. the badge sat at 0.4.0 while v0.4.1 shipped).

Makes **tagging the single source of truth**:

- **`scripts/release.sh <version>`** — stamps the README version badge, rolls `## [Unreleased]` into a dated `## [<version>]` section, commits `chore(release): v<version>`, creates the annotated tag, and pushes (after a confirmation prompt). The tagged commit's docs therefore always match the version. Includes preconditions: clean tree, tag doesn't exist, non-empty Unreleased section.
- **`release.yml` `verify-version` job** — runs before build on every tag push and **fails the release** if the tag, README badge, and CHANGELOG section don't agree. Backstop for anyone who tags manually.
- **CONTRIBUTING.md** — documents the script as the release process.
- **README** — bump the stale 0.4.0 badge to the current 0.4.1.

After this lands, the flow is: merge work to main → `scripts/release.sh X.Y.Z` → done.