### PR TITLE
ci: cover the PAM/cgo packages in vet, lint, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,43 @@ jobs:
 
       - name: Run go vet
         run: |
-          # Vet all non-PAM packages (PAM packages require CGO and PAM headers)
-          # Note: cmd/pam-helper imports pkg/pam so it's also excluded
-          go vet ./pkg/auth ./pkg/config ./pkg/policy ./pkg/security ./pkg/ssh ./internal/ipc ./cmd/broker ./cmd/oidc-admin
+          # PAM/cgo packages are vetted and tested in the separate `pam` job,
+          # which installs the PAM and json-c development headers.
+          go vet ./pkg/auth ./pkg/config ./pkg/metrics ./pkg/policy ./pkg/security ./pkg/ssh ./internal/ipc ./cmd/broker ./cmd/oidc-admin
 
       - name: Run tests
         run: |
-          # Run all non-PAM tests (PAM tests require Linux PAM libraries)
           go test -race -coverprofile=coverage.out -covermode=atomic \
-            ./pkg/auth ./pkg/config ./pkg/policy ./pkg/security ./pkg/ssh ./internal/ipc
+            ./pkg/auth ./pkg/config ./pkg/metrics ./pkg/policy ./pkg/security ./pkg/ssh ./internal/ipc
 
       - name: Check test coverage
         run: |
           go tool cover -func=coverage.out
+
+  pam:
+    name: PAM (cgo)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25.12'
+          cache: true
+
+      - name: Install PAM development libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpam0g-dev libjson-c-dev
+
+      - name: Run go vet
+        run: go vet ./pkg/pam ./cmd/pam-module ./cmd/pam-helper
+
+      - name: Run tests
+        run: go test -race ./pkg/pam/...
 
   build:
     name: Build
@@ -90,12 +114,17 @@ jobs:
           go-version: '1.25.12'
           cache: true
 
+      - name: Install PAM development libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpam0g-dev libjson-c-dev
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
-          # Lint only non-PAM packages (PAM packages require CGO and PAM development libraries)
-          args: --timeout=5m ./pkg/auth/... ./pkg/config/... ./pkg/policy/... ./pkg/security/... ./pkg/ssh/... ./internal/... ./cmd/broker/... ./cmd/oidc-admin/...
+          # Every package, including the cgo/PAM ones (hence the headers above).
+          args: --timeout=5m ./...
 
   validate:
     name: Validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **(#118) CI coverage for the PAM/cgo packages.** A new `PAM (cgo)` job installs
+  `libpam0g-dev`/`libjson-c-dev` and runs `go vet ./pkg/pam ./cmd/pam-module
+  ./cmd/pam-helper` plus `go test -race ./pkg/pam/...`; the `Lint` job now lints
+  `./...` (every package, PAM included) instead of an allowlist that omitted
+  `pkg/pam`, `cmd/pam-module`, `cmd/pam-helper` and `pkg/metrics`. Previously the
+  security-critical PAM module was never vetted, linted, or tested by CI.
+- `make verify-linux` plus `test/docker/Dockerfile.verify`: runs the full
+  vet/test/lint sweep — including the cgo packages, which cannot compile on
+  macOS — in a Linux container. Documented in CONTRIBUTING.md.
+- `-Wall -Wextra` on the cgo `CFLAGS` for `pkg/pam` and `cmd/pam-module`, and
+  `(void)` markers on the genuinely unused PAM entry-point parameters so the C
+  bridge compiles warning-free.
+
+### Fixed
+- **(#118)** `oidc-pam-helper -version` now prints the build date and git commit
+  (the `buildDate`/`gitCommit` ldflags targets were set by the Makefile but never
+  read, which is what surfaced them as `unused` once linting covered the package).
+- **(#118)** `TestServerInvalidSocketPath` no longer depends on the test process
+  being unprivileged: it points the socket inside a regular file (`ENOTDIR`)
+  rather than at a merely absent directory, which root would simply create.
+- **(#118)** `test/integration` used a raw passphrase for
+  `security.token_encryption_key`, invalid since the v0.4.0 breaking change; it
+  now uses a base64 32-byte test key.
+
 ## [0.4.2] - 2026-07-09
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,10 +62,10 @@ Enhancement suggestions are welcome! Please:
 
 ### Prerequisites
 
-- Go 1.21 or higher
-- PAM development libraries
+- Go 1.25 or higher
+- PAM development libraries (`libpam0g-dev libjson-c-dev`, or `pam-devel json-c-devel`)
 - systemd (for service management)
-- Docker (for integration tests)
+- Docker (for integration tests, and for `make verify-linux` on macOS)
 
 ### Local Development
 
@@ -92,6 +92,21 @@ make lint
 # Install development version
 sudo make install-dev
 ```
+
+### Verifying the PAM/cgo packages
+
+`pkg/pam`, `cmd/pam-module` and `cmd/pam-helper` are cgo packages that need
+`<security/pam_ext.h>` and `<json-c/json.h>`, so they cannot be built on macOS —
+`go build ./...` fails there with `'security/pam_ext.h' file not found`. Run the
+same vet/test/lint sweep CI runs inside a Linux container instead:
+
+```bash
+make verify-linux
+```
+
+This builds `test/docker/Dockerfile.verify` and runs `go vet ./...`,
+`go test -race ./pkg/... ./internal/...` and `golangci-lint run ./...` — which
+includes the PAM packages. CI covers them in the `PAM (cgo)` and `Lint` jobs.
 
 ### Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test install clean lint fmt vet tidy help
+.PHONY: build test install clean lint fmt vet tidy verify-linux help
 
 # Build variables
 BINARY_DIR := bin
@@ -65,6 +65,22 @@ test-integration:
 test-e2e:
 	@echo "Running end-to-end tests..."
 	go test $(GO_TEST_FLAGS) ./test/e2e/...
+
+## Verify everything (vet + test + lint, all packages) in a Linux container.
+## The cgo/PAM packages cannot be built on macOS, so this is the only way to
+## reproduce CI's `pam` and `lint` jobs locally.
+verify-linux:
+	@echo "Building verification image..."
+	docker build -t oidc-pam-verify -f test/docker/Dockerfile.verify test/docker
+	@echo "Running vet, tests and lint in Linux container..."
+	docker run --rm \
+		-v "$(CURDIR)":/src \
+		-v oidc-pam-gomod:/go/pkg/mod \
+		-v oidc-pam-gocache:/root/.cache \
+		-w /src oidc-pam-verify \
+		sh -c 'go vet ./... \
+			&& go test -race ./pkg/... ./internal/... \
+			&& golangci-lint run --timeout=5m ./...'
 
 ## Install binaries to system locations
 install: build
@@ -173,6 +189,7 @@ help:
 	@echo "  test-unit       Run unit tests only"
 	@echo "  test-integration Run integration tests"
 	@echo "  test-e2e        Run end-to-end tests"
+	@echo "  verify-linux    Run vet+test+lint for ALL packages (incl. cgo/PAM) in Docker"
 	@echo "  install         Install binaries to system"
 	@echo "  install-dev     Install development version"
 	@echo "  clean           Clean build artifacts"

--- a/cmd/pam-helper/main.go
+++ b/cmd/pam-helper/main.go
@@ -44,6 +44,8 @@ func main() {
 	// Show version information
 	if *showVersion {
 		fmt.Printf("%s version %s\n", Name, version)
+		fmt.Printf("  Build date: %s\n", buildDate)
+		fmt.Printf("  Git commit: %s\n", gitCommit)
 		os.Exit(0)
 	}
 

--- a/cmd/pam-module/main.go
+++ b/cmd/pam-module/main.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/../../pkg/pam -I/usr/include/security
+#cgo CFLAGS: -I${SRCDIR}/../../pkg/pam -I/usr/include/security -Wall -Wextra
 #cgo LDFLAGS: -lpam -ljson-c
 #include "cgo_bridge.h"
 */

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -187,8 +187,15 @@ func TestServerMultipleConnections(t *testing.T) {
 }
 
 func TestServerInvalidSocketPath(t *testing.T) {
-	// Test with invalid socket path
-	invalidPath := "/invalid/path/that/does/not/exist/test.sock"
+	// Use a path whose parent is a regular file: MkdirAll then fails with
+	// ENOTDIR for any uid. A merely non-existent directory is not enough —
+	// running as root (as the container-based `make verify-linux` does) it
+	// would simply be created.
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatalf("Failed to create blocking file: %v", err)
+	}
+	invalidPath := filepath.Join(blocker, "test.sock")
 	broker := createTestBroker(t)
 	server, err := NewServer(invalidPath, broker, 0660, "", false, 0, 0)
 	if err != nil {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -263,7 +263,7 @@ func TestMetricsHTTPEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /metrics: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected 200, got %d", resp.StatusCode)

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -320,7 +320,9 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     json_object *response_obj, *success_obj, *instructions_obj, *requires_device_obj;
     const char *instructions;
     int success, requires_device;
-    
+
+    (void)flags; // PAM_SILENT / PAM_DISALLOW_NULL_AUTHTOK are not honored
+
     log_pam_message(LOG_INFO, "OIDC PAM authentication started (version %s)", PAM_MODULE_VERSION);
     
     // Parse module arguments
@@ -406,6 +408,8 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 
 // PAM credential setting function
 PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+    (void)pamh; // no PAM items are read or set in this phase
+
     log_pam_message(LOG_DEBUG, "pam_sm_setcred called with flags: %d", flags);
     
     // Parse arguments
@@ -499,6 +503,8 @@ PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, con
 
 // PAM password change function
 PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+    (void)pamh; // password changes are not supported; nothing is read from PAM
+
     log_pam_message(LOG_DEBUG, "pam_sm_chauthtok called with flags: %d", flags);
     
     // Parse arguments

--- a/pkg/pam/cgo_wrapper.go
+++ b/pkg/pam/cgo_wrapper.go
@@ -1,7 +1,7 @@
 package pam
 
 /*
-#cgo CFLAGS: -I${SRCDIR} -I/usr/include/security
+#cgo CFLAGS: -I${SRCDIR} -I/usr/include/security -Wall -Wextra
 #cgo LDFLAGS: -lpam -ljson-c
 #include "cgo_bridge.h"
 */

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -1,7 +1,7 @@
 package pam
 
 /*
-#cgo CFLAGS: -I${SRCDIR} -I/usr/include/security
+#cgo CFLAGS: -I${SRCDIR} -I/usr/include/security -Wall -Wextra
 #cgo LDFLAGS: -lpam -ljson-c
 #include "cgo_bridge.h"
 */

--- a/test/docker/Dockerfile.verify
+++ b/test/docker/Dockerfile.verify
@@ -1,0 +1,21 @@
+# Linux toolchain image for verifying the cgo/PAM packages.
+#
+# pkg/pam, cmd/pam-module and cmd/pam-helper need <security/pam_ext.h> and
+# <json-c/json.h>, which do not exist on macOS, so `go vet ./...` and
+# `go test ./...` cannot run on a developer's Mac. `make verify-linux` builds
+# this image and runs the full vet/test/lint sweep inside it, matching what the
+# `pam` and `lint` jobs in .github/workflows/ci.yml do.
+FROM golang:1.25
+
+ARG GOLANGCI_LINT_VERSION=v2.12.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpam0g-dev \
+        libjson-c-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+        | sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
+
+WORKDIR /src

--- a/test/integration/broker_test.go
+++ b/test/integration/broker_test.go
@@ -184,7 +184,10 @@ func createTestConfig(testDir string) *config.Config {
 			MaxConcurrentSessions: 10,
 		},
 		Security: config.SecurityConfig{
-			TokenEncryptionKey: "test-encryption-key-32-bytes-long!",
+			// base64 of "0123456789abcdef0123456789abcdef" — since v0.4.0 the
+			// key must decode to exactly 32 bytes, so a raw passphrase is
+			// rejected at broker construction.
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 			AuditEnabled:       true,
 		},
 		Audit: config.AuditConfig{


### PR DESCRIPTION
Fixes #118

CI excluded every PAM/cgo package from `go vet`, `go test` and `golangci-lint`, so the security-critical C module (`pkg/pam/cgo_bridge.c`) and its Go bindings were never checked by any job. That exclusion is the reason the defects in #119–#122 survived.

## Changes

- **New `PAM (cgo)` job** — installs `libpam0g-dev libjson-c-dev`, runs `go vet ./pkg/pam ./cmd/pam-module ./cmd/pam-helper` and `go test -race ./pkg/pam/...` (the existing 752-line `pkg/pam/pam_test.go` had never run in CI).
- **`Lint` job now lints `./...`** instead of an allowlist. Besides the PAM packages, the old list also silently omitted `pkg/metrics`. The job installs the PAM headers so golangci-lint can typecheck the cgo packages.
- **`pkg/metrics` added** to the `test` job's vet and test lists.
- **`-Wall -Wextra`** on the cgo `CFLAGS` in `pkg/pam` and `cmd/pam-module`; the three genuinely-unused PAM entry-point parameters get `(void)` markers so the bridge compiles warning-free.
- **`make verify-linux`** + `test/docker/Dockerfile.verify` — runs `go vet ./...`, `go test -race ./pkg/... ./internal/...` and `golangci-lint run ./...` in a Linux container. The cgo packages cannot compile on macOS (`'security/pam_ext.h' file not found`), so this is the only way to reproduce the PAM jobs locally. Documented in CONTRIBUTING.md, whose prerequisites also still said "Go 1.21".

## Fallout fixed

Turning the checks on surfaced four real problems:

- `oidc-pam-helper -version` never printed `buildDate`/`gitCommit`, even though the Makefile sets both via `-ldflags`. Now printed, matching `cmd/broker`.
- `pkg/metrics/metrics_test.go` had an unchecked `resp.Body.Close()` (errcheck).
- `TestServerInvalidSocketPath` only passed as an unprivileged user: it asserted that binding under a *non-existent* directory fails, but `Server.Start` calls `MkdirAll`, which root simply succeeds at. It now points the socket inside a regular file, so it fails with `ENOTDIR` for any uid.
- `test/integration` set `token_encryption_key` to a raw passphrase, invalid since the v0.4.0 breaking change.

## Known gap (follow-up)

`test/integration` still does not run anywhere: after the key fix, all three tests fail on `mock://test-provider/.well-known/openid-configuration` — the suite was written against an issuer scheme no HTTP client can fetch. `test/Dockerfile.integration` is also pinned to `golang:1.21-alpine` against a `go 1.25.12` module. Both need a real mock OIDC provider rather than a one-line fix, so they are left out of this PR and tracked separately.

## Verification

`make verify-linux` — vet clean over all packages including cgo, `go test -race ./pkg/... ./internal/...` green, `golangci-lint run ./...` reports 0 issues, and `make build-pam build-helper` compiles with no warnings under `-Wall -Wextra`.