### PR TITLE
fix(pam): correct the broker socket path and honor module arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (BREAKING for PAM configs)
+- **(#119) `pam_oidc.so` connected to the wrong socket and ignored its module
+  arguments.** The compiled-in `SOCKET_PATH` was
+  `/var/run/oidc-auth-broker.sock` while the broker listens on
+  `/var/run/oidc-auth/broker.sock`, so a default install could never reach the
+  broker and every authentication returned `PAM_AUTHINFO_UNAVAIL`. The default
+  is now derived from, and matches, the broker's `server.socket_path` default.
+- **(#119)** Added the `socket=<path>` module argument for non-default
+  deployments. It must be absolute and must fit in `sockaddr_un.sun_path`;
+  anything else is rejected with a log line and the default is kept, rather than
+  being silently truncated to a path naming a different socket. `MAX_SOCKET_PATH`
+  is now taken from the platform's `sun_path` (108 on Linux, 104 on Darwin)
+  instead of being hardcoded.
+- **(#119)** Unrecognized module arguments are now logged at `LOG_WARNING`
+  instead of being silently dropped. **The example configs previously passed
+  `config=`, `operation=` and `target_user=`, none of which the module has ever
+  implemented** (and PAM does not expand `%u` in module arguments, so
+  `target_user=%u` was always literal). These have been removed from
+  `configs/pam/*`, `configs/pam/common-auth`, QUICK-START.md, DEPLOYMENT.md and
+  the ssh-server test project; `configs/pam/README.md` now documents the two
+  arguments that do exist (`debug`, `socket=`) and explicitly lists the ones that
+  never did. `config=` is still accepted, with a warning, so existing PAM stacks
+  keep working.
+
 ### Added
 - **(#118) CI coverage for the PAM/cgo packages.** A new `PAM (cgo)` job installs
   `libpam0g-dev`/`libjson-c-dev` and runs `go vet ./pkg/pam ./cmd/pam-module

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -345,16 +345,16 @@ monitoring:
 #### SSH Configuration (`/etc/pam.d/ssh`)
 ```bash
 # Production SSH PAM configuration
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml service=ssh
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass
 
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session required    pam_systemd.so
 session optional    pam_env.so
 ```
@@ -362,17 +362,17 @@ session optional    pam_env.so
 #### Sudo Configuration (`/etc/pam.d/sudo`)
 ```bash
 # Production sudo PAM configuration
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml operation=sudo target_user=%u
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass
 
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
 
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session optional    pam_systemd.so
 ```
 

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -149,17 +149,17 @@ For SSH authentication, edit `/etc/pam.d/ssh`:
 
 ```
 # OIDC authentication
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml service=ssh
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass
 
 # Account management
-account required    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account required    pam_oidc.so
 account required    pam_unix.so
 
 # Session management
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 ```
 
 ### 3. SSH Configuration
@@ -285,7 +285,7 @@ logging:
 
 Add debug to PAM configuration:
 ```
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml debug
+auth    sufficient  pam_oidc.so debug
 ```
 
 ## Next Steps

--- a/configs/pam/README.md
+++ b/configs/pam/README.md
@@ -70,39 +70,52 @@ ssh -i ~/.ssh/id_rsa root@localhost
 
 ### Basic OIDC Authentication
 ```
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+auth    sufficient  pam_oidc.so
 auth    required    pam_unix.so try_first_pass
 ```
 
 ### OIDC-Only Authentication
 ```
-auth    required    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+auth    required    pam_oidc.so
 ```
 
 ### Unix-First with OIDC Fallback
 ```
 auth    sufficient  pam_unix.so
-auth    required    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+auth    required    pam_oidc.so
 ```
 
 ### Debug Mode
 ```
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml debug
+auth    sufficient  pam_oidc.so debug
 ```
 
 ## PAM Module Parameters
 
-### Common Parameters
-- `config=/path/to/config.yaml` - Path to OIDC broker configuration
-- `debug` - Enable debug logging
-- `operation=operation_name` - Specify operation type (ssh, sudo, su, etc.)
-- `target_user=%u` - Pass target username for authorization
+`pam_oidc.so` accepts exactly two arguments:
 
-### Service-Specific Parameters
-- **SSH**: `service=ssh`
-- **Sudo**: `operation=sudo target_user=%u`
-- **Su**: `operation=su target_user=%u`
-- **Login**: `service=login`
+| Argument | Meaning |
+|---|---|
+| `debug` | Log at `LOG_DEBUG` to syslog (`LOG_AUTHPRIV`). Remove in production. |
+| `socket=<path>` | Absolute path to the broker's Unix socket. Defaults to `/var/run/oidc-auth/broker.sock`, matching the broker's own default for `server.socket_path`. Only needed if you changed that. |
+
+Anything else is ignored and logged at `LOG_WARNING`, so a typo shows up in
+`/var/log/auth.log` instead of silently doing nothing.
+
+### Arguments that do *not* exist
+
+Earlier versions of these example configs passed parameters the module has never
+implemented. They were silently discarded; they are now logged as unrecognized:
+
+- `config=/path/to/broker.yaml` — the module reads no configuration file. It
+  talks to the broker over the socket, and the broker reads `broker.yaml`
+  itself. Still accepted (with a warning) so existing PAM stacks keep working.
+- `operation=sudo`, `target_user=%u`, `service=ssh` — no such authorization
+  knobs exist in the module. Note also that PAM does **not** expand `%u` in
+  module arguments; it would have been passed through literally. The service
+  name and target user already reach the broker: the module reads them from
+  `PAM_SERVICE` and `pam_get_user()` and sends them in the request. Configure
+  per-service policy in `broker.yaml`, not in the PAM line.
 
 ## Security Considerations
 
@@ -180,7 +193,7 @@ sudo pam-config --check /etc/pam.d/ssh
 #### 4. Debug Authentication Flow
 ```bash
 # Enable debug mode
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml debug
+auth    sufficient  pam_oidc.so debug
 
 # Check detailed logs
 sudo journalctl -f | grep pam_oidc

--- a/configs/pam/common-auth
+++ b/configs/pam/common-auth
@@ -9,7 +9,7 @@
 # Test thoroughly and maintain emergency access methods.
 
 # Primary authentication stack
-auth    [success=2 default=ignore]     pam_oidc.so config=/etc/oidc-auth/broker.yaml
+auth    [success=2 default=ignore]     pam_oidc.so
 auth    [success=1 default=ignore]     pam_unix.so nullok_secure try_first_pass
 auth    requisite                      pam_deny.so
 auth    required                       pam_permit.so
@@ -24,7 +24,7 @@ auth    required                       pam_permit.so
 # ALTERNATIVE CONFIGURATION (OIDC-only):
 # For OIDC-only authentication without Unix fallback:
 # 
-# auth    required    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+# auth    required    pam_oidc.so
 # auth    requisite   pam_deny.so
 # auth    required    pam_permit.so
 
@@ -32,7 +32,7 @@ auth    required                       pam_permit.so
 # For Unix authentication first, then OIDC fallback:
 # 
 # auth    [success=2 default=ignore]     pam_unix.so nullok_secure
-# auth    [success=1 default=ignore]     pam_oidc.so config=/etc/oidc-auth/broker.yaml
+# auth    [success=1 default=ignore]     pam_oidc.so
 # auth    requisite                      pam_deny.so
 # auth    required                       pam_permit.so
 

--- a/configs/pam/login
+++ b/configs/pam/login
@@ -8,13 +8,13 @@
 # Always maintain console or SSH access for emergency recovery.
 
 # Authentication stack
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml debug
+auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_nologin.so
 auth    required    pam_unix.so try_first_pass nullok_secure
 auth    optional    pam_group.so
 
 # Account management
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_nologin.so
@@ -22,14 +22,14 @@ account required    pam_time.so
 
 # Session management
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session optional    pam_systemd.so
 session optional    pam_lastlog.so
 session optional    pam_motd.so
 session optional    pam_mail.so standard
 
 # Password management (disabled for OIDC)
-password sufficient pam_oidc.so config=/etc/oidc-auth/broker.yaml
+password sufficient pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:

--- a/configs/pam/ssh
+++ b/configs/pam/ssh
@@ -8,23 +8,23 @@
 # Always maintain a backup authentication method for emergency access.
 
 # Authentication stack
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml debug
+auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass nullok_secure
 
 # Account management
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 
 # Session management
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session optional    pam_systemd.so
 session optional    pam_lastlog.so
 
 # Password management (disabled for OIDC)
-password sufficient pam_oidc.so config=/etc/oidc-auth/broker.yaml
+password sufficient pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:

--- a/configs/pam/su
+++ b/configs/pam/su
@@ -9,33 +9,34 @@
 
 # Authentication stack
 auth    sufficient  pam_rootok.so
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml target_user=%u
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass nullok_secure
 auth    optional    pam_group.so
 
 # Account management
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
 
 # Session management
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session optional    pam_systemd.so
 session optional    pam_env.so
 session optional    pam_limits.so
 
 # Password management (disabled for OIDC)
-password sufficient pam_oidc.so config=/etc/oidc-auth/broker.yaml
+password sufficient pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:
 # 1. pam_rootok.so allows root to switch to any user without authentication
-# 2. The 'target_user=%u' parameter passes the target username to the OIDC module
-# 3. This allows for user-specific authorization policies
-# 4. Consider the security implications of allowing OIDC for privilege escalation
+# 2. The module takes no authorization parameters. It reads the target user from
+#    pam_get_user() and the service name from PAM_SERVICE and sends both to the
+#    broker; configure per-service policy in /etc/oidc-auth/broker.yaml
+# 3. Consider the security implications of allowing OIDC for privilege escalation
 
 # SU POLICY CONFIGURATION:
 # Configure additional policies in /etc/oidc-auth/broker.yaml:

--- a/configs/pam/sudo
+++ b/configs/pam/sudo
@@ -8,33 +8,33 @@
 # Keep a root session open and test with non-privileged users first.
 
 # Authentication stack
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml operation=sudo target_user=%u
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass
 auth    optional    pam_group.so
 
 # Account management
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
 
 # Session management
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session optional    pam_systemd.so
 session optional    pam_env.so
 session optional    pam_limits.so
 
 # Password management (disabled for OIDC)
-password sufficient pam_oidc.so config=/etc/oidc-auth/broker.yaml
+password sufficient pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:
-# 1. The 'operation=sudo' parameter tells the OIDC module this is a sudo operation
-# 2. The 'target_user=%u' parameter passes the target username for authorization
-# 3. This allows for command-specific and user-specific authorization policies
-# 4. Consider the security implications of OIDC for privilege escalation
+# 1. The module takes no authorization parameters. It reads the target user from
+#    pam_get_user() and the service name ("sudo") from PAM_SERVICE and sends both
+#    to the broker; configure per-service policy in /etc/oidc-auth/broker.yaml
+# 2. Consider the security implications of OIDC for privilege escalation
 
 # SUDO POLICY CONFIGURATION:
 # Configure sudo-specific policies in /etc/oidc-auth/broker.yaml:

--- a/pkg/pam/cgo_args.go
+++ b/pkg/pam/cgo_args.go
@@ -1,0 +1,44 @@
+package pam
+
+/*
+#cgo CFLAGS: -I${SRCDIR} -I/usr/include/security -Wall -Wextra
+#cgo LDFLAGS: -lpam -ljson-c
+#include <stdlib.h>
+#include "cgo_bridge.h"
+*/
+import "C"
+
+import "unsafe"
+
+// maxSocketPath is the platform's sockaddr_un.sun_path size (108 on Linux, 104
+// on Darwin/BSD) — the longest broker socket path the module can use.
+const maxSocketPath = int(C.MAX_SOCKET_PATH)
+
+// parseModuleArgs runs the C parse_arguments() over args — the module arguments
+// as PAM would pass them from /etc/pam.d/<service> — and returns the broker
+// socket path it settled on.
+//
+// The module's argument handling lives in C because that is where PAM enters the
+// module; this wrapper exists so it can be tested from Go (cgo is not permitted
+// in _test.go files).
+func parseModuleArgs(args []string) string {
+	var opts C.pam_oidc_options
+
+	argv := make([]*C.char, len(args))
+	for i, a := range args {
+		argv[i] = C.CString(a)
+	}
+	defer func() {
+		for _, p := range argv {
+			C.free(unsafe.Pointer(p))
+		}
+	}()
+
+	var argvPtr **C.char
+	if len(argv) > 0 {
+		argvPtr = (**C.char)(unsafe.Pointer(&argv[0]))
+	}
+	C.parse_arguments(C.int(len(args)), argvPtr, &opts)
+
+	return C.GoString(&opts.socket_path[0])
+}

--- a/pkg/pam/cgo_args_test.go
+++ b/pkg/pam/cgo_args_test.go
@@ -1,0 +1,89 @@
+package pam
+
+import (
+	"strings"
+	"testing"
+)
+
+// defaultSocketPath is the compiled-in SOCKET_PATH. It must match the broker's
+// own default for server.socket_path (pkg/config/config.go).
+const defaultSocketPath = "/var/run/oidc-auth/broker.sock"
+
+func TestParseModuleArgsDefaultSocketPath(t *testing.T) {
+	if got := parseModuleArgs(nil); got != defaultSocketPath {
+		t.Errorf("with no arguments: socket path = %q, want %q", got, defaultSocketPath)
+	}
+}
+
+func TestParseModuleArgsSocketOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "absolute path is accepted",
+			args: []string{"socket=/run/oidc/test.sock"},
+			want: "/run/oidc/test.sock",
+		},
+		{
+			name: "override alongside other arguments",
+			args: []string{"debug", "socket=/tmp/broker.sock"},
+			want: "/tmp/broker.sock",
+		},
+		{
+			name: "last override wins",
+			args: []string{"socket=/tmp/first.sock", "socket=/tmp/second.sock"},
+			want: "/tmp/second.sock",
+		},
+		{
+			name: "relative path is rejected, default retained",
+			args: []string{"socket=relative/broker.sock"},
+			want: defaultSocketPath,
+		},
+		{
+			name: "empty value is rejected, default retained",
+			args: []string{"socket="},
+			want: defaultSocketPath,
+		},
+		{
+			name: "overlong path is rejected, default retained",
+			args: []string{"socket=/" + strings.Repeat("x", 200)},
+			want: defaultSocketPath,
+		},
+		{
+			// The shipped su/sudo configs passed these; the module never
+			// implemented any of them. They must not affect anything.
+			name: "unknown arguments do not disturb the default",
+			args: []string{"operation=sudo", "target_user=%u", "service=sshd"},
+			want: defaultSocketPath,
+		},
+		{
+			name: "config= is accepted but ignored",
+			args: []string{"config=/etc/oidc-auth/broker.yaml"},
+			want: defaultSocketPath,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseModuleArgs(tt.args); got != tt.want {
+				t.Errorf("parse_arguments(%q): socket path = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// A path one byte too long for sun_path must be rejected rather than truncated:
+// a truncated path names a different socket.
+func TestParseModuleArgsSunPathLimit(t *testing.T) {
+	atLimit := "/" + strings.Repeat("x", maxSocketPath-2) // maxSocketPath-1 bytes + NUL
+	if got := parseModuleArgs([]string{"socket=" + atLimit}); got != atLimit {
+		t.Errorf("path of %d bytes should be accepted, got %q", len(atLimit), got)
+	}
+
+	tooLong := "/" + strings.Repeat("x", maxSocketPath-1) // maxSocketPath bytes + NUL
+	if got := parseModuleArgs([]string{"socket=" + tooLong}); got != defaultSocketPath {
+		t.Errorf("path of %d bytes should be rejected, got %q", len(tooLong), got)
+	}
+}

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -10,7 +10,11 @@
 
 // Global variables
 static int debug_enabled = 0;
-static char config_path[256] = "/etc/oidc-auth/pam.conf";
+
+// The compiled-in default must fit in pam_oidc_options.socket_path, which is
+// itself sized to the platform's sockaddr_un.sun_path.
+_Static_assert(sizeof(SOCKET_PATH) <= MAX_SOCKET_PATH,
+               "default SOCKET_PATH does not fit in pam_oidc_options.socket_path");
 
 // Helper function to log messages
 void log_pam_message(int priority, const char *format, ...) {
@@ -43,19 +47,28 @@ void log_pam_message_string(int priority, const char *message) {
 int connect_to_broker(const char *socket_path) {
     int sock;
     struct sockaddr_un addr;
-    
+    size_t path_len;
+
     log_pam_message(LOG_DEBUG, "Connecting to broker at %s", socket_path);
-    
+
+    // Refuse rather than silently truncate: a truncated path would connect to
+    // the wrong socket, or to none at all with a confusing error.
+    path_len = strlen(socket_path);
+    if (path_len == 0 || path_len >= sizeof(addr.sun_path)) {
+        log_pam_message(LOG_ERR, "Invalid broker socket path length: %zu", path_len);
+        return -1;
+    }
+
     sock = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock == -1) {
         log_pam_message(LOG_ERR, "Failed to create socket: %s", strerror(errno));
         return -1;
     }
-    
+
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
-    
+    memcpy(addr.sun_path, socket_path, path_len + 1);
+
     if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
         log_pam_message(LOG_ERR, "Failed to connect to broker: %s", strerror(errno));
         close(sock);
@@ -297,17 +310,53 @@ int prompt_user(pam_handle_t *pamh, const char *prompt, char *response, size_t r
 }
 
 // Parse module arguments
-static void parse_arguments(int argc, const char **argv) {
+// Parse the module arguments from /etc/pam.d/<service> into opts, which is
+// always fully initialized to the defaults first.
+//
+// These arguments come from a root-owned PAM configuration file and are
+// therefore trusted, unlike oidc-pam-helper's argv, which may come from an
+// unprivileged caller (see L-6). Recognized arguments:
+//
+//   debug          Log at LOG_DEBUG to syslog.
+//   socket=<path>  Absolute path to the broker's Unix socket. Defaults to
+//                  SOCKET_PATH, which matches the broker's own default for
+//                  server.socket_path.
+//
+// Anything else is ignored with a warning, so a typo or a stale argument shows
+// up in the log instead of silently doing nothing.
+void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
     int i;
-    
+
+    // Defaults first, so a caller can rely on opts being complete even when
+    // argc is 0 or an argument is rejected below.
+    memset(opts, 0, sizeof(*opts));
+    memcpy(opts->socket_path, SOCKET_PATH, sizeof(SOCKET_PATH));
+
     for (i = 0; i < argc; i++) {
         if (strcmp(argv[i], "debug") == 0) {
             debug_enabled = 1;
             log_pam_message(LOG_DEBUG, "Debug mode enabled");
+        } else if (strncmp(argv[i], "socket=", 7) == 0) {
+            const char *path = argv[i] + 7;
+            size_t len = strlen(path);
+
+            if (path[0] != '/') {
+                log_pam_message(LOG_ERR, "Ignoring socket= argument: path must be absolute (got '%s'); using %s",
+                                path, opts->socket_path);
+            } else if (len >= sizeof(opts->socket_path)) {
+                log_pam_message(LOG_ERR, "Ignoring socket= argument: path is %zu bytes, limit is %zu; using %s",
+                                len, sizeof(opts->socket_path) - 1, opts->socket_path);
+            } else {
+                memcpy(opts->socket_path, path, len + 1);
+                log_pam_message(LOG_DEBUG, "Using broker socket: %s", opts->socket_path);
+            }
         } else if (strncmp(argv[i], "config=", 7) == 0) {
-            strncpy(config_path, argv[i] + 7, sizeof(config_path) - 1);
-            config_path[sizeof(config_path) - 1] = '\0';
-            log_pam_message(LOG_DEBUG, "Using config file: %s", config_path);
+            // Accepted for compatibility with configs shipped before v0.4.3.
+            // This module reads no configuration file of its own; everything
+            // comes from the broker over the socket.
+            log_pam_message(LOG_WARNING, "Ignoring config=%s: pam_oidc reads no configuration file", argv[i] + 7);
+        } else {
+            log_pam_message(LOG_WARNING, "Ignoring unrecognized module argument: %s", argv[i]);
         }
     }
 }
@@ -326,18 +375,19 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     log_pam_message(LOG_INFO, "OIDC PAM authentication started (version %s)", PAM_MODULE_VERSION);
     
     // Parse module arguments
-    parse_arguments(argc, argv);
-    
+    pam_oidc_options opts;
+    parse_arguments(argc, argv, &opts);
+
     // Get user information
     retval = get_user_info(pamh, &username, &service, &rhost, &tty);
     if (retval != PAM_SUCCESS) {
         return retval;
     }
-    
+
     log_pam_message(LOG_INFO, "Authenticating user: %s", username);
-    
+
     // Connect to broker
-    sock = connect_to_broker(SOCKET_PATH);
+    sock = connect_to_broker(opts.socket_path);
     if (sock == -1) {
         log_pam_message(LOG_ERR, "Failed to connect to authentication broker");
         return PAM_AUTHINFO_UNAVAIL;
@@ -413,7 +463,8 @@ PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const cha
     log_pam_message(LOG_DEBUG, "pam_sm_setcred called with flags: %d", flags);
     
     // Parse arguments
-    parse_arguments(argc, argv);
+    pam_oidc_options opts;
+    parse_arguments(argc, argv, &opts);
     
     // For OIDC authentication, we don't need to set traditional credentials
     // The broker handles token management
@@ -428,7 +479,8 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const c
     log_pam_message(LOG_DEBUG, "pam_sm_acct_mgmt called with flags: %d", flags);
     
     // Parse arguments
-    parse_arguments(argc, argv);
+    pam_oidc_options opts;
+    parse_arguments(argc, argv, &opts);
     
     // Get username
     retval = pam_get_user(pamh, &username, NULL);
@@ -455,7 +507,8 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, cons
     log_pam_message(LOG_DEBUG, "pam_sm_open_session called with flags: %d", flags);
     
     // Parse arguments
-    parse_arguments(argc, argv);
+    pam_oidc_options opts;
+    parse_arguments(argc, argv, &opts);
     
     // Get username
     retval = pam_get_user(pamh, &username, NULL);
@@ -482,7 +535,8 @@ PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, con
     log_pam_message(LOG_DEBUG, "pam_sm_close_session called with flags: %d", flags);
     
     // Parse arguments
-    parse_arguments(argc, argv);
+    pam_oidc_options opts;
+    parse_arguments(argc, argv, &opts);
     
     // Get username
     retval = pam_get_user(pamh, &username, NULL);
@@ -508,7 +562,8 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const c
     log_pam_message(LOG_DEBUG, "pam_sm_chauthtok called with flags: %d", flags);
     
     // Parse arguments
-    parse_arguments(argc, argv);
+    pam_oidc_options opts;
+    parse_arguments(argc, argv, &opts);
     
     // OIDC authentication doesn't support password changes through PAM
     // Password changes should be done through the identity provider

--- a/pkg/pam/cgo_bridge.h
+++ b/pkg/pam/cgo_bridge.h
@@ -19,12 +19,22 @@
 // Maximum buffer sizes
 #define MAX_BUFFER_SIZE 8192
 #define MAX_RESPONSE_SIZE 8192
-#define MAX_SOCKET_PATH 108
+// Longest usable Unix socket path, taken from the platform's sockaddr_un
+// (108 bytes on Linux, 104 on Darwin/BSD) so it can never disagree with it.
+#define MAX_SOCKET_PATH (sizeof(((struct sockaddr_un *)0)->sun_path))
 
-// Default socket path for OIDC broker
-#define SOCKET_PATH "/var/run/oidc-auth-broker.sock"
+// Default socket path for the OIDC broker. Must match the default of
+// server.socket_path in pkg/config/config.go; override per-service with the
+// `socket=<path>` module argument in /etc/pam.d/<service>.
+#define SOCKET_PATH "/var/run/oidc-auth/broker.sock"
+
+// Options parsed from the module arguments in /etc/pam.d/<service>.
+typedef struct {
+    char socket_path[MAX_SOCKET_PATH];
+} pam_oidc_options;
 
 // Function prototypes
+void parse_arguments(int argc, const char **argv, pam_oidc_options *opts);
 void log_pam_message(int priority, const char *format, ...);
 void log_pam_message_string(int priority, const char *message);
 int connect_to_broker(const char *socket_path);

--- a/test-projects/ssh-server/README.md
+++ b/test-projects/ssh-server/README.md
@@ -101,16 +101,16 @@ The SSH server is configured with:
 
 ```bash
 # /etc/pam.d/sshd
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml service=ssh debug
+auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass
 
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session required    pam_systemd.so
 ```
 

--- a/test-projects/ssh-server/docker/ssh-server/pam.d/sshd
+++ b/test-projects/ssh-server/docker/ssh-server/pam.d/sshd
@@ -2,13 +2,13 @@
 # This configuration enables OIDC authentication via the PAM module
 
 # Authentication stack
-auth    sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml service=ssh debug
+auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_deny.so
 auth    required    pam_unix.so try_first_pass nullok_secure
 auth    optional    pam_group.so
 
 # Account management
-account sufficient  pam_oidc.so config=/etc/oidc-auth/broker.yaml
+account sufficient  pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
@@ -18,7 +18,7 @@ account required    pam_permit.so
 session required    pam_selinux.so close
 session required    pam_loginuid.so
 session required    pam_unix.so
-session optional    pam_oidc.so config=/etc/oidc-auth/broker.yaml
+session optional    pam_oidc.so
 session required    pam_selinux.so open env_params
 session required    pam_systemd.so
 session optional    pam_keyinit.so force revoke
@@ -29,5 +29,5 @@ session optional    pam_motd.so
 session optional    pam_mail.so standard
 
 # Password management (disabled for OIDC)
-password sufficient pam_oidc.so config=/etc/oidc-auth/broker.yaml
+password sufficient pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok


### PR DESCRIPTION
Fixes #119

> **Stacked on #128** — base is `ci/pam-package-coverage`. Merge #128 first; GitHub will retarget this to `main`.

`pam_oidc.so` has never been able to reach the broker in a default install:

| | path |
|---|---|
| module (`pkg/pam/cgo_bridge.h:25`) | `/var/run/oidc-auth-broker.sock` |
| broker (`pkg/config/config.go:407`) | `/var/run/oidc-auth/broker.sock` |

Every authentication therefore returned `PAM_AUTHINFO_UNAVAIL`. That mismatch is also what has been masking the `PAM_SUCCESS` bypass in #120 — which is why this PR must land *before* that one is fixed, not after.

## Changes

- `SOCKET_PATH` now matches the broker's default, with a comment tying the two together.
- **New `socket=<path>` module argument** for non-default deployments. Validated: must be absolute and must fit in `sockaddr_un.sun_path`, otherwise it is refused with a log line and the default is kept. Silently truncating would connect to a *different* socket.
- `MAX_SOCKET_PATH` is derived from the platform's `sun_path` (108 on Linux, 104 on Darwin/BSD) instead of being hardcoded to 108, with a `_Static_assert` that the compiled-in default fits.
- `connect_to_broker` refuses an empty or overlong path instead of `strncpy`-truncating it.
- `parse_arguments` takes an out-parameter (`pam_oidc_options`) rather than writing globals, and is no longer `static`, so it can be tested.
- **Unrecognized arguments are logged at `LOG_WARNING`.**

## The arguments that never existed

Turning on that warning exposed the fact that the shipped example configs pass parameters the module has never implemented:

- `config=/etc/oidc-auth/broker.yaml` — the module reads no config file; it only talks to the broker. (Also note `broker.yaml` is the *broker's* root-owned config.) Still accepted with a warning so existing PAM stacks keep working.
- `operation=sudo`, `target_user=%u`, `service=ssh` — no such knobs. PAM does not expand `%u` in module arguments either, so `target_user=%u` was passed through literally. The target user and service name already reach the broker via `pam_get_user()` and `PAM_SERVICE`.

Removed from `configs/pam/{ssh,login,su,sudo,common-auth}`, `QUICK-START.md`, `DEPLOYMENT.md`, and `test-projects/ssh-server`. `configs/pam/README.md` now has a table of the two real arguments plus an explicit "arguments that do *not* exist" section, replacing its old list which documented all four of the fake ones.

## Tests

New `pkg/pam/cgo_args_test.go` drives the real C `parse_arguments` through a thin cgo wrapper (cgo is not allowed in `_test.go` files, hence `cgo_args.go`): default path, override, last-wins, relative rejected, empty rejected, overlong rejected, unknown args inert, and a boundary test at exactly `sun_path`-1 vs `sun_path` bytes.

Verified with `make verify-linux`: vet clean, `pkg/pam` tests pass, `golangci-lint run ./...` reports 0 issues.

## Not included

`configs/pam/ssh` still documents `ChallengeResponseAuthentication` (renamed to `KbdInteractiveAuthentication` in OpenSSH 8.7) and still claims `pam_unix.so` is a working fallback when the `auth requisite pam_deny.so` above it makes that unreachable. Those are tracked in #127 and #122.