### PR TITLE
fix(pam)!: complete the device flow instead of granting PAM_SUCCESS at initiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Critical (#120): `pam_oidc.so` granted `PAM_SUCCESS` before device
+  authorization completed.** `Broker.Authenticate` returns `success: true`
+  *together with* `requires_device: true` when it has merely started the device
+  flow, and `pam_sm_authenticate` tested `success` before it looked at
+  `requires_device` — so with the shipped `auth sufficient pam_oidc.so` the auth
+  stack was short-circuited and login granted the moment the broker replied,
+  before the user visited the verification URL and before the broker performed
+  identity binding (`username_claim`) and `require_groups`, which run afterwards
+  in a background goroutine. `requires_device` is now checked first, and
+  `success` alone is no longer treated as a grant.
+- **(#120)** The module now completes the device flow instead of abandoning it.
+  It displays the verification instructions, then polls `check_session` —
+  reconnecting per attempt, since the broker serves one request per connection —
+  at the interval the broker asks for in `metadata.polling_interval` (clamped to
+  [1, 60] s) until the flow completes or the budget expires. Nothing called
+  `check_session` before, so the device flow had no completion path at all.
+- **(#120) Every non-success outcome now fails closed.** A refusal, a session the
+  broker no longer has (`SESSION_NOT_FOUND`/`SESSION_EXPIRED`/`FORBIDDEN` — the
+  broker deletes the session on identity mismatch, group denial and expiry), or
+  an exhausted timeout all deny; broker error codes are mapped to PAM codes
+  mirroring `errorCodeToPAMResult`. Only failing to reach an opinion at all
+  (broker unreachable, unparseable response) returns `PAM_AUTHINFO_UNAVAIL`.
+- **(#120)** `internal/ipc` now *requires* `user_id` on `check_session`,
+  `refresh_session` and `revoke_session`. The broker compares it against the
+  session owner to reject cross-user access, but the validator neither required
+  nor validated it, so an absent `user_id` was compared as the empty string.
+- **(#120)** `PAMMaxTries` was `24`, which is not a Linux-PAM result code
+  (`PAM_MAXTRIES` is 11); returning it would have turned a deliberate
+  rate-limit denial into an unrecognized error. The `PAMResultCode` constants are
+  now taken from the PAM headers the module is compiled against instead of being
+  copied by hand, since the values are not portable between Linux-PAM and
+  OpenPAM.
+
 ### Fixed (BREAKING for PAM configs)
 - **(#119) `pam_oidc.so` connected to the wrong socket and ignored its module
   arguments.** The compiled-in `SOCKET_PATH` was
@@ -32,6 +66,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep working.
 
 ### Added
+- **(#120)** `timeout=<seconds>` module argument bounding the wait for device
+  authorization (default 90, range 10–900). The default sits below sshd's
+  default `LoginGraceTime` of 120 s so an expired flow is reported as a denial
+  rather than sshd dropping the connection; documented in
+  `configs/pam/README.md`.
 - **(#118) CI coverage for the PAM/cgo packages.** A new `PAM (cgo)` job installs
   `libpam0g-dev`/`libjson-c-dev` and runs `go vet ./pkg/pam ./cmd/pam-module
   ./cmd/pam-helper` plus `go test -race ./pkg/pam/...`; the `Lint` job now lints

--- a/configs/pam/README.md
+++ b/configs/pam/README.md
@@ -92,15 +92,36 @@ auth    sufficient  pam_oidc.so debug
 
 ## PAM Module Parameters
 
-`pam_oidc.so` accepts exactly two arguments:
+`pam_oidc.so` accepts exactly three arguments:
 
 | Argument | Meaning |
 |---|---|
 | `debug` | Log at `LOG_DEBUG` to syslog (`LOG_AUTHPRIV`). Remove in production. |
 | `socket=<path>` | Absolute path to the broker's Unix socket. Defaults to `/var/run/oidc-auth/broker.sock`, matching the broker's own default for `server.socket_path`. Only needed if you changed that. |
+| `timeout=<seconds>` | How long to wait for the user to finish the device flow before refusing the login. Default `90`, accepted range `10`–`900`. |
 
 Anything else is ignored and logged at `LOG_WARNING`, so a typo shows up in
 `/var/log/auth.log` instead of silently doing nothing.
+
+### How the wait works
+
+The module prompts with the verification URL and user code, then polls the broker
+until the flow completes, is refused, or `timeout` expires. **The login is
+refused when the timeout expires** — an unfinished device flow is never a
+success.
+
+The default `timeout` of 90 s is deliberately below sshd's default
+`LoginGraceTime` of 120 s: sshd kills the connection when the grace time runs
+out, which would look like a hang rather than a denial. If you raise `timeout`,
+raise `LoginGraceTime` in `/etc/ssh/sshd_config` to match:
+
+```
+# /etc/pam.d/sshd
+auth    sufficient  pam_oidc.so timeout=300
+
+# /etc/ssh/sshd_config
+LoginGraceTime 330
+```
 
 ### Arguments that do *not* exist
 

--- a/internal/ipc/validate.go
+++ b/internal/ipc/validate.go
@@ -77,7 +77,17 @@ func validateRequest(req *Request) error {
 		if req.SessionID == "" {
 			return fmt.Errorf("session_id is required for %s requests", req.Type)
 		}
-		return validateSessionID(req.SessionID)
+		if err := validateSessionID(req.SessionID); err != nil {
+			return err
+		}
+		// user_id is what the broker compares against the session owner to
+		// reject cross-user session access, so it is required rather than
+		// optional: an absent user_id would otherwise be checked against the
+		// owner as the empty string.
+		if req.UserID == "" {
+			return fmt.Errorf("user_id is required for %s requests", req.Type)
+		}
+		return validateUserID(req.UserID)
 
 	default:
 		// Unknown types are handled by handleRequest; no validation needed here.

--- a/internal/ipc/validate_test.go
+++ b/internal/ipc/validate_test.go
@@ -180,13 +180,32 @@ func TestValidateRequest(t *testing.T) {
 			req: Request{
 				Type:      "check_session",
 				SessionID: "valid-session-123",
+				UserID:    "testuser",
 			},
 			wantErr: false,
 		},
 		{
+			name: "check_session missing user_id",
+			req: Request{
+				Type:      "check_session",
+				SessionID: "valid-session-123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "check_session invalid user_id",
+			req: Request{
+				Type:      "check_session",
+				SessionID: "valid-session-123",
+				UserID:    "root; rm -rf /",
+			},
+			wantErr: true,
+		},
+		{
 			name: "check_session missing session_id",
 			req: Request{
-				Type: "check_session",
+				Type:   "check_session",
+				UserID: "testuser",
 			},
 			wantErr: true,
 		},
@@ -195,13 +214,32 @@ func TestValidateRequest(t *testing.T) {
 			req: Request{
 				Type:      "refresh_session",
 				SessionID: "valid-session-123",
+				UserID:    "testuser",
 			},
 			wantErr: false,
 		},
 		{
+			name: "refresh_session missing user_id",
+			req: Request{
+				Type:      "refresh_session",
+				SessionID: "valid-session-123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "refresh_session invalid user_id",
+			req: Request{
+				Type:      "refresh_session",
+				SessionID: "valid-session-123",
+				UserID:    "root; rm -rf /",
+			},
+			wantErr: true,
+		},
+		{
 			name: "refresh_session missing session_id",
 			req: Request{
-				Type: "refresh_session",
+				Type:   "refresh_session",
+				UserID: "testuser",
 			},
 			wantErr: true,
 		},
@@ -210,13 +248,32 @@ func TestValidateRequest(t *testing.T) {
 			req: Request{
 				Type:      "revoke_session",
 				SessionID: "valid-session-123",
+				UserID:    "testuser",
 			},
 			wantErr: false,
 		},
 		{
+			name: "revoke_session missing user_id",
+			req: Request{
+				Type:      "revoke_session",
+				SessionID: "valid-session-123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "revoke_session invalid user_id",
+			req: Request{
+				Type:      "revoke_session",
+				SessionID: "valid-session-123",
+				UserID:    "root; rm -rf /",
+			},
+			wantErr: true,
+		},
+		{
 			name: "revoke_session missing session_id",
 			req: Request{
-				Type: "revoke_session",
+				Type:   "revoke_session",
+				UserID: "testuser",
 			},
 			wantErr: true,
 		},

--- a/pkg/pam/cgo_args.go
+++ b/pkg/pam/cgo_args.go
@@ -14,14 +14,20 @@ import "unsafe"
 // on Darwin/BSD) — the longest broker socket path the module can use.
 const maxSocketPath = int(C.MAX_SOCKET_PATH)
 
+// moduleArgs is the Go view of pam_oidc_options.
+type moduleArgs struct {
+	socketPath     string
+	timeoutSeconds int
+}
+
 // parseModuleArgs runs the C parse_arguments() over args — the module arguments
-// as PAM would pass them from /etc/pam.d/<service> — and returns the broker
-// socket path it settled on.
+// as PAM would pass them from /etc/pam.d/<service> — and returns the options it
+// settled on.
 //
 // The module's argument handling lives in C because that is where PAM enters the
 // module; this wrapper exists so it can be tested from Go (cgo is not permitted
 // in _test.go files).
-func parseModuleArgs(args []string) string {
+func parseModuleArgs(args []string) moduleArgs {
 	var opts C.pam_oidc_options
 
 	argv := make([]*C.char, len(args))
@@ -40,5 +46,8 @@ func parseModuleArgs(args []string) string {
 	}
 	C.parse_arguments(C.int(len(args)), argvPtr, &opts)
 
-	return C.GoString(&opts.socket_path[0])
+	return moduleArgs{
+		socketPath:     C.GoString(&opts.socket_path[0]),
+		timeoutSeconds: int(opts.timeout_s),
+	}
 }

--- a/pkg/pam/cgo_args_test.go
+++ b/pkg/pam/cgo_args_test.go
@@ -9,9 +9,53 @@ import (
 // own default for server.socket_path (pkg/config/config.go).
 const defaultSocketPath = "/var/run/oidc-auth/broker.sock"
 
-func TestParseModuleArgsDefaultSocketPath(t *testing.T) {
-	if got := parseModuleArgs(nil); got != defaultSocketPath {
-		t.Errorf("with no arguments: socket path = %q, want %q", got, defaultSocketPath)
+// defaultAuthTimeout is the compiled-in DEFAULT_AUTH_TIMEOUT, in seconds. It
+// must stay below sshd's default LoginGraceTime of 120s.
+const defaultAuthTimeout = 90
+
+func TestParseModuleArgsDefaults(t *testing.T) {
+	got := parseModuleArgs(nil)
+	if got.socketPath != defaultSocketPath {
+		t.Errorf("with no arguments: socket path = %q, want %q", got.socketPath, defaultSocketPath)
+	}
+	if got.timeoutSeconds != defaultAuthTimeout {
+		t.Errorf("with no arguments: timeout = %ds, want %ds", got.timeoutSeconds, defaultAuthTimeout)
+	}
+	if got.timeoutSeconds >= 120 {
+		t.Errorf("default timeout of %ds is not below sshd's default LoginGraceTime of 120s", got.timeoutSeconds)
+	}
+}
+
+func TestParseModuleArgsTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"in-range value is accepted", []string{"timeout=300"}, 300},
+		{"lower bound is accepted", []string{"timeout=10"}, 10},
+		{"upper bound is accepted", []string{"timeout=900"}, 900},
+		{"below the lower bound is rejected", []string{"timeout=1"}, defaultAuthTimeout},
+		{"above the upper bound is rejected", []string{"timeout=901"}, defaultAuthTimeout},
+		{"zero is rejected", []string{"timeout=0"}, defaultAuthTimeout},
+		{"negative is rejected", []string{"timeout=-30"}, defaultAuthTimeout},
+		{"non-numeric is rejected", []string{"timeout=soon"}, defaultAuthTimeout},
+		{"trailing junk is rejected", []string{"timeout=30s"}, defaultAuthTimeout},
+		{"empty value is rejected", []string{"timeout="}, defaultAuthTimeout},
+		{"last override wins", []string{"timeout=30", "timeout=60"}, 60},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseModuleArgs(tt.args)
+			if got.timeoutSeconds != tt.want {
+				t.Errorf("parse_arguments(%q): timeout = %ds, want %ds", tt.args, got.timeoutSeconds, tt.want)
+			}
+			if got.socketPath != defaultSocketPath {
+				t.Errorf("parse_arguments(%q): socket path = %q, want the default %q",
+					tt.args, got.socketPath, defaultSocketPath)
+			}
+		})
 	}
 }
 
@@ -67,7 +111,7 @@ func TestParseModuleArgsSocketOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseModuleArgs(tt.args); got != tt.want {
+			if got := parseModuleArgs(tt.args).socketPath; got != tt.want {
 				t.Errorf("parse_arguments(%q): socket path = %q, want %q", tt.args, got, tt.want)
 			}
 		})
@@ -78,12 +122,12 @@ func TestParseModuleArgsSocketOverride(t *testing.T) {
 // a truncated path names a different socket.
 func TestParseModuleArgsSunPathLimit(t *testing.T) {
 	atLimit := "/" + strings.Repeat("x", maxSocketPath-2) // maxSocketPath-1 bytes + NUL
-	if got := parseModuleArgs([]string{"socket=" + atLimit}); got != atLimit {
+	if got := parseModuleArgs([]string{"socket=" + atLimit}).socketPath; got != atLimit {
 		t.Errorf("path of %d bytes should be accepted, got %q", len(atLimit), got)
 	}
 
 	tooLong := "/" + strings.Repeat("x", maxSocketPath-1) // maxSocketPath bytes + NUL
-	if got := parseModuleArgs([]string{"socket=" + tooLong}); got != defaultSocketPath {
+	if got := parseModuleArgs([]string{"socket=" + tooLong}).socketPath; got != defaultSocketPath {
 		t.Errorf("path of %d bytes should be rejected, got %q", len(tooLong), got)
 	}
 }

--- a/pkg/pam/cgo_auth.go
+++ b/pkg/pam/cgo_auth.go
@@ -1,0 +1,38 @@
+package pam
+
+/*
+#cgo CFLAGS: -I${SRCDIR} -I/usr/include/security -Wall -Wextra
+#cgo LDFLAGS: -lpam -ljson-c
+#include <stdlib.h>
+#include "cgo_bridge.h"
+*/
+import "C"
+
+import "unsafe"
+
+// performAuthentication runs the C module's auth phase — the same code path
+// pam_sm_authenticate takes — against the broker listening on socketPath, and
+// returns the PAM result code it produced.
+//
+// The PAM handle is NULL, so no conversation messages are shown; everything else
+// (the initial authenticate request, the device-flow polling loop, and the
+// terminal-state mapping) behaves exactly as it does under a real PAM stack.
+// This wrapper lives in a normal .go file because cgo is not permitted in
+// _test.go files.
+func performAuthentication(socketPath, username, service, rhost, tty string, timeoutSeconds int) PAMResultCode {
+	cSocketPath := C.CString(socketPath)
+	cUsername := C.CString(username)
+	cService := C.CString(service)
+	cRhost := C.CString(rhost)
+	cTTY := C.CString(tty)
+	defer func() {
+		C.free(unsafe.Pointer(cSocketPath))
+		C.free(unsafe.Pointer(cUsername))
+		C.free(unsafe.Pointer(cService))
+		C.free(unsafe.Pointer(cRhost))
+		C.free(unsafe.Pointer(cTTY))
+	}()
+
+	return PAMResultCode(C.perform_authentication(nil, cSocketPath, cUsername, cService, cRhost, cTTY,
+		C.int(timeoutSeconds)))
+}

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -171,6 +171,38 @@ int send_auth_request(int sock, const char *username, const char *service, const
     return 0;
 }
 
+// Send a session-status request to the broker.
+//
+// user_id is required as well as session_id: Broker.CheckSession rejects a
+// session whose owner does not match the requesting user with FORBIDDEN, so
+// omitting it would make every poll fail.
+int send_check_session_request(int sock, const char *session_id, const char *username) {
+    json_object *request = json_object_new_object();
+
+    json_object_object_add(request, "type", json_object_new_string("check_session"));
+    json_object_object_add(request, "session_id", json_object_new_string(session_id));
+    json_object_object_add(request, "user_id", json_object_new_string(username));
+
+    const char *request_str = json_object_to_json_string(request);
+    size_t request_len = strlen(request_str);
+
+    log_pam_message(LOG_DEBUG, "Sending session check request: %s", request_str);
+
+    ssize_t total_sent = 0;
+    while (total_sent < (ssize_t)request_len) {
+        ssize_t sent = send(sock, request_str + total_sent, request_len - total_sent, 0);
+        if (sent == -1) {
+            log_pam_message(LOG_ERR, "Failed to send session check request: %s", strerror(errno));
+            json_object_put(request);
+            return -1;
+        }
+        total_sent += sent;
+    }
+
+    json_object_put(request);
+    return 0;
+}
+
 // Receive authentication response from broker.
 //
 // The broker writes a single newline-delimited JSON object (json.Encoder.Encode
@@ -317,10 +349,15 @@ int prompt_user(pam_handle_t *pamh, const char *prompt, char *response, size_t r
 // therefore trusted, unlike oidc-pam-helper's argv, which may come from an
 // unprivileged caller (see L-6). Recognized arguments:
 //
-//   debug          Log at LOG_DEBUG to syslog.
-//   socket=<path>  Absolute path to the broker's Unix socket. Defaults to
-//                  SOCKET_PATH, which matches the broker's own default for
-//                  server.socket_path.
+//   debug             Log at LOG_DEBUG to syslog.
+//   socket=<path>     Absolute path to the broker's Unix socket. Defaults to
+//                     SOCKET_PATH, which matches the broker's own default for
+//                     server.socket_path.
+//   timeout=<seconds> How long to wait for the user to complete the device
+//                     authorization flow. Clamped to
+//                     [MIN_AUTH_TIMEOUT, MAX_AUTH_TIMEOUT]; this is the only
+//                     place that bound is applied, so perform_authentication
+//                     can be driven with a short budget from tests.
 //
 // Anything else is ignored with a warning, so a typo or a stale argument shows
 // up in the log instead of silently doing nothing.
@@ -331,6 +368,7 @@ void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
     // argc is 0 or an argument is rejected below.
     memset(opts, 0, sizeof(*opts));
     memcpy(opts->socket_path, SOCKET_PATH, sizeof(SOCKET_PATH));
+    opts->timeout_s = DEFAULT_AUTH_TIMEOUT;
 
     for (i = 0; i < argc; i++) {
         if (strcmp(argv[i], "debug") == 0) {
@@ -350,6 +388,23 @@ void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
                 memcpy(opts->socket_path, path, len + 1);
                 log_pam_message(LOG_DEBUG, "Using broker socket: %s", opts->socket_path);
             }
+        } else if (strncmp(argv[i], "timeout=", 8) == 0) {
+            const char *value = argv[i] + 8;
+            char *end = NULL;
+            long seconds;
+
+            errno = 0;
+            seconds = strtol(value, &end, 10);
+            if (errno != 0 || end == value || *end != '\0') {
+                log_pam_message(LOG_ERR, "Ignoring timeout= argument: '%s' is not a number; using %d",
+                                value, opts->timeout_s);
+            } else if (seconds < MIN_AUTH_TIMEOUT || seconds > MAX_AUTH_TIMEOUT) {
+                log_pam_message(LOG_ERR, "Ignoring timeout=%ld: outside [%d, %d]; using %d",
+                                seconds, MIN_AUTH_TIMEOUT, MAX_AUTH_TIMEOUT, opts->timeout_s);
+            } else {
+                opts->timeout_s = (int)seconds;
+                log_pam_message(LOG_DEBUG, "Device authorization timeout: %d seconds", opts->timeout_s);
+            }
         } else if (strncmp(argv[i], "config=", 7) == 0) {
             // Accepted for compatibility with configs shipped before v0.4.3.
             // This module reads no configuration file of its own; everything
@@ -361,24 +416,306 @@ void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
     }
 }
 
+// Sentinel returned by classify_response for a device flow that has been started
+// but not yet completed. Every PAM_* return code is non-negative, so a negative
+// value cannot collide with one.
+#define BROKER_PENDING (-1)
+
+// Read a string field, or NULL if it is absent or JSON null. The result points
+// into obj and is only valid while obj is alive.
+static const char *json_get_string(json_object *obj, const char *key) {
+    json_object *field = NULL;
+
+    if (!json_object_object_get_ex(obj, key, &field) || field == NULL) {
+        return NULL;
+    }
+    return json_object_get_string(field);
+}
+
+// Read a boolean field, or fallback if it is absent.
+static int json_get_bool(json_object *obj, const char *key, int fallback) {
+    json_object *field = NULL;
+
+    if (!json_object_object_get_ex(obj, key, &field) || field == NULL) {
+        return fallback;
+    }
+    return json_object_get_boolean(field);
+}
+
+// Read the poll interval the broker asked for, clamped into a sane range. An
+// absent, non-numeric or out-of-range value falls back to DEFAULT_POLL_INTERVAL
+// rather than being trusted.
+static int response_poll_interval(json_object *obj) {
+    json_object *metadata = NULL, *field = NULL;
+    int interval;
+
+    if (!json_object_object_get_ex(obj, "metadata", &metadata) || metadata == NULL) {
+        return DEFAULT_POLL_INTERVAL;
+    }
+    if (!json_object_object_get_ex(metadata, "polling_interval", &field) || field == NULL) {
+        return DEFAULT_POLL_INTERVAL;
+    }
+
+    interval = json_object_get_int(field);
+    if (interval < MIN_POLL_INTERVAL) {
+        return MIN_POLL_INTERVAL;
+    }
+    if (interval > MAX_POLL_INTERVAL) {
+        return MAX_POLL_INTERVAL;
+    }
+    return interval;
+}
+
+// Map a broker error_code onto a PAM result. This mirrors errorCodeToPAMResult
+// in pam.go; keep the two in step.
+//
+// SESSION_NOT_FOUND, SESSION_EXPIRED and FORBIDDEN are denials, not transient
+// failures: the broker deletes the session when identity binding fails, when
+// require_groups rejects the user, when device-flow polling fails, and when the
+// session expires, so a poll that can no longer find its session means the
+// authentication was refused.
+static int map_error_code(const char *error_code) {
+    if (error_code == NULL) {
+        return PAM_AUTH_ERR;
+    }
+    if (strcmp(error_code, "RATE_LIMIT_EXCEEDED") == 0 ||
+        strcmp(error_code, "RATE_LIMITED") == 0 ||
+        strcmp(error_code, "TOO_MANY_CONCURRENT_AUTHS") == 0) {
+        return PAM_MAXTRIES;
+    }
+    if (strcmp(error_code, "TOO_MANY_SESSIONS") == 0 ||
+        strcmp(error_code, "POLICY_DENIED") == 0 ||
+        strcmp(error_code, "NO_PROVIDER") == 0) {
+        return PAM_PERM_DENIED;
+    }
+    return PAM_AUTH_ERR;
+}
+
+// Decide what a broker response means: a PAM result code, or BROKER_PENDING if
+// the device flow is still in progress.
+static int classify_response(json_object *obj) {
+    json_object *success_obj = NULL;
+
+    // A response we cannot interpret is not a grant.
+    if (!json_object_object_get_ex(obj, "success", &success_obj)) {
+        log_pam_message(LOG_ERR, "Broker response has no success field");
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    if (!json_object_get_boolean(success_obj)) {
+        const char *code = json_get_string(obj, "error_code");
+        const char *message = json_get_string(obj, "error_message");
+
+        log_pam_message(LOG_INFO, "Broker refused authentication (error_code=%s): %s",
+                        code != NULL ? code : "(none)",
+                        message != NULL ? message : "(no message)");
+        return map_error_code(code);
+    }
+
+    // success=true is not on its own a grant. The broker sets it *together with*
+    // requires_device=true when it has merely started the device flow: the user
+    // has not visited the device URL yet, and identity binding and
+    // require_groups are still checked afterwards, in a background goroutine.
+    // requires_device must therefore be tested before success is honored, or
+    // `auth sufficient pam_oidc.so` short-circuits the auth stack and grants
+    // login to anyone who can reach the broker.
+    if (json_get_bool(obj, "requires_device", 0)) {
+        return BROKER_PENDING;
+    }
+
+    return PAM_SUCCESS;
+}
+
+// Show a message to the user, tolerating a NULL handle so the authentication
+// flow can be driven from tests without a PAM conversation.
+static void show_message(pam_handle_t *pamh, const char *message) {
+    if (pamh == NULL || message == NULL || message[0] == '\0') {
+        return;
+    }
+    display_message(pamh, message);
+}
+
+// Seconds on a monotonic clock, so a wall-clock adjustment mid-login cannot
+// extend or collapse the authentication budget.
+static long monotonic_seconds(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        // Should not happen; degrade to the realtime clock rather than spinning.
+        return (long)time(NULL);
+    }
+    return (long)ts.tv_sec;
+}
+
+static void sleep_seconds(long seconds) {
+    struct timespec remaining;
+
+    if (seconds <= 0) {
+        return;
+    }
+    remaining.tv_sec = (time_t)seconds;
+    remaining.tv_nsec = 0;
+
+    while (nanosleep(&remaining, &remaining) == -1 && errno == EINTR) {
+        // Interrupted by a signal; finish the remaining time.
+    }
+}
+
+// The broker serves exactly one request per connection and then closes it, so
+// every attempt — the initial authenticate and each poll — needs its own
+// connection.
+static int broker_recv_and_close(int sock, char *response, size_t response_size) {
+    int rc = receive_auth_response(sock, response, response_size);
+    close(sock);
+    return rc;
+}
+
+static int broker_authenticate_once(const char *socket_path, const char *username, const char *service,
+                                    const char *rhost, const char *tty,
+                                    char *response, size_t response_size) {
+    int sock = connect_to_broker(socket_path);
+    if (sock == -1) {
+        log_pam_message(LOG_ERR, "Failed to connect to authentication broker");
+        return -1;
+    }
+    if (send_auth_request(sock, username, service, rhost, tty) != 0) {
+        close(sock);
+        return -1;
+    }
+    return broker_recv_and_close(sock, response, response_size);
+}
+
+static int broker_check_session_once(const char *socket_path, const char *session_id, const char *username,
+                                     char *response, size_t response_size) {
+    int sock = connect_to_broker(socket_path);
+    if (sock == -1) {
+        log_pam_message(LOG_ERR, "Failed to reconnect to authentication broker while polling");
+        return -1;
+    }
+    if (send_check_session_request(sock, session_id, username) != 0) {
+        close(sock);
+        return -1;
+    }
+    return broker_recv_and_close(sock, response, response_size);
+}
+
+// Run one full authentication against the broker and return a PAM result code.
+//
+// This is the whole of the auth phase, factored out of pam_sm_authenticate so it
+// can be exercised against a fake broker from Go tests. pamh may be NULL, in
+// which case no messages are shown to the user.
+//
+// timeout_s bounds the wait for the user to complete the device flow. It is
+// clamped to [MIN_AUTH_TIMEOUT, MAX_AUTH_TIMEOUT] by parse_arguments, which is
+// how pam_sm_authenticate always obtains it; a non-positive value here means
+// "poll once, then give up".
+//
+// Only a transport or parse failure returns PAM_AUTHINFO_UNAVAIL ("I could not
+// reach an opinion"). Everything else — a refusal, a vanished session, an
+// exhausted budget — is a denial, so the auth stack fails closed.
+int perform_authentication(pam_handle_t *pamh, const char *socket_path, const char *username,
+                           const char *service, const char *rhost, const char *tty, int timeout_s) {
+    char response[MAX_BUFFER_SIZE];
+    char session_id[MAX_SESSION_ID_SIZE];
+    json_object *response_obj;
+    const char *session;
+    int poll_interval;
+    long deadline;
+    int result;
+
+    if (broker_authenticate_once(socket_path, username, service, rhost, tty,
+                                 response, sizeof(response)) != 0) {
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    response_obj = json_tokener_parse(response);
+    if (response_obj == NULL) {
+        log_pam_message(LOG_ERR, "Failed to parse broker response");
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    result = classify_response(response_obj);
+    if (result != BROKER_PENDING) {
+        if (result == PAM_SUCCESS) {
+            log_pam_message(LOG_INFO, "Authentication successful for user: %s", username);
+        }
+        json_object_put(response_obj);
+        return result;
+    }
+
+    // Device authorization started. Remember the session so we can poll it, then
+    // tell the user where to go.
+    session = json_get_string(response_obj, "session_id");
+    if (session == NULL || session[0] == '\0') {
+        log_pam_message(LOG_ERR, "Broker requires device authorization but returned no session_id");
+        json_object_put(response_obj);
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+    if (strlen(session) >= sizeof(session_id)) {
+        log_pam_message(LOG_ERR, "Broker returned an over-long session_id (%zu bytes)", strlen(session));
+        json_object_put(response_obj);
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+    memcpy(session_id, session, strlen(session) + 1);
+
+    poll_interval = response_poll_interval(response_obj);
+    show_message(pamh, json_get_string(response_obj, "instructions"));
+    json_object_put(response_obj);
+
+    log_pam_message(LOG_INFO, "Waiting up to %ds for device authorization by user %s (session %s)",
+                    timeout_s, username, session_id);
+
+    deadline = monotonic_seconds() + (timeout_s > 0 ? timeout_s : 0);
+
+    for (;;) {
+        long now = monotonic_seconds();
+        long remaining = deadline - now;
+
+        // Wait before polling: the broker has only just handed out the device
+        // code, so an immediate poll can only ever report "pending".
+        sleep_seconds(remaining < poll_interval ? remaining : poll_interval);
+
+        if (broker_check_session_once(socket_path, session_id, username,
+                                      response, sizeof(response)) != 0) {
+            return PAM_AUTHINFO_UNAVAIL;
+        }
+
+        response_obj = json_tokener_parse(response);
+        if (response_obj == NULL) {
+            log_pam_message(LOG_ERR, "Failed to parse broker session-check response");
+            return PAM_AUTHINFO_UNAVAIL;
+        }
+
+        result = classify_response(response_obj);
+        json_object_put(response_obj);
+
+        if (result != BROKER_PENDING) {
+            if (result == PAM_SUCCESS) {
+                log_pam_message(LOG_INFO, "Device authorization completed for user: %s", username);
+            }
+            return result;
+        }
+
+        if (monotonic_seconds() >= deadline) {
+            log_pam_message(LOG_NOTICE, "Device authorization not completed within %ds for user %s; denying",
+                            timeout_s, username);
+            return PAM_AUTH_ERR;
+        }
+    }
+}
+
 // PAM authentication function
 PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv) {
     const char *username, *service, *rhost, *tty;
-    char response[MAX_BUFFER_SIZE];
-    int sock, retval;
-    json_object *response_obj, *success_obj, *instructions_obj, *requires_device_obj;
-    const char *instructions;
-    int success, requires_device;
+    pam_oidc_options opts;
+    int retval;
 
     (void)flags; // PAM_SILENT / PAM_DISALLOW_NULL_AUTHTOK are not honored
 
     log_pam_message(LOG_INFO, "OIDC PAM authentication started (version %s)", PAM_MODULE_VERSION);
-    
-    // Parse module arguments
-    pam_oidc_options opts;
+
     parse_arguments(argc, argv, &opts);
 
-    // Get user information
     retval = get_user_info(pamh, &username, &service, &rhost, &tty);
     if (retval != PAM_SUCCESS) {
         return retval;
@@ -386,74 +723,11 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 
     log_pam_message(LOG_INFO, "Authenticating user: %s", username);
 
-    // Connect to broker
-    sock = connect_to_broker(opts.socket_path);
-    if (sock == -1) {
-        log_pam_message(LOG_ERR, "Failed to connect to authentication broker");
-        return PAM_AUTHINFO_UNAVAIL;
+    retval = perform_authentication(pamh, opts.socket_path, username, service, rhost, tty, opts.timeout_s);
+    if (retval != PAM_SUCCESS) {
+        log_pam_message(LOG_INFO, "Authentication failed for user: %s (pam result %d)", username, retval);
     }
-    
-    // Send authentication request
-    if (send_auth_request(sock, username, service, rhost, tty) != 0) {
-        close(sock);
-        return PAM_AUTHINFO_UNAVAIL;
-    }
-    
-    // Receive response
-    if (receive_auth_response(sock, response, sizeof(response)) != 0) {
-        close(sock);
-        return PAM_AUTHINFO_UNAVAIL;
-    }
-    
-    close(sock);
-    
-    // Parse JSON response
-    response_obj = json_tokener_parse(response);
-    if (!response_obj) {
-        log_pam_message(LOG_ERR, "Failed to parse JSON response");
-        return PAM_AUTHINFO_UNAVAIL;
-    }
-    
-    // Check if authentication was successful
-    if (!json_object_object_get_ex(response_obj, "success", &success_obj)) {
-        log_pam_message(LOG_ERR, "No success field in response");
-        json_object_put(response_obj);
-        return PAM_AUTHINFO_UNAVAIL;
-    }
-    
-    success = json_object_get_boolean(success_obj);
-    
-    if (success) {
-        log_pam_message(LOG_INFO, "Authentication successful for user: %s", username);
-        json_object_put(response_obj);
-        return PAM_SUCCESS;
-    }
-    
-    // Check if device authentication is required
-    if (json_object_object_get_ex(response_obj, "requires_device", &requires_device_obj)) {
-        requires_device = json_object_get_boolean(requires_device_obj);
-        
-        if (requires_device) {
-            // Display instructions to user
-            if (json_object_object_get_ex(response_obj, "instructions", &instructions_obj)) {
-                instructions = json_object_get_string(instructions_obj);
-                if (instructions != NULL) {
-                    display_message(pamh, instructions);
-                }
-                
-                // For device flow, we need to poll for completion
-                // This is a simplified implementation - in practice, we'd need
-                // to implement proper polling with timeouts
-                log_pam_message(LOG_INFO, "Device authentication required for user: %s", username);
-                json_object_put(response_obj);
-                return PAM_AUTHINFO_UNAVAIL; // For now, require manual retry
-            }
-        }
-    }
-    
-    log_pam_message(LOG_INFO, "Authentication failed for user: %s", username);
-    json_object_put(response_obj);
-    return PAM_AUTH_ERR;
+    return retval;
 }
 
 // PAM credential setting function

--- a/pkg/pam/cgo_bridge.h
+++ b/pkg/pam/cgo_bridge.h
@@ -23,14 +23,35 @@
 // (108 bytes on Linux, 104 on Darwin/BSD) so it can never disagree with it.
 #define MAX_SOCKET_PATH (sizeof(((struct sockaddr_un *)0)->sun_path))
 
+// Longest session ID the module will accept from the broker, matching
+// maxSessionIDLen in internal/ipc/validate.go (plus the NUL).
+#define MAX_SESSION_ID_SIZE 129
+
 // Default socket path for the OIDC broker. Must match the default of
 // server.socket_path in pkg/config/config.go; override per-service with the
 // `socket=<path>` module argument in /etc/pam.d/<service>.
 #define SOCKET_PATH "/var/run/oidc-auth/broker.sock"
 
+// How long, in seconds, pam_sm_authenticate will wait for the user to complete
+// the device authorization flow before failing closed. The default stays below
+// sshd's default LoginGraceTime (120 s) so sshd does not tear the session down
+// mid-prompt; raising `timeout=` past that needs a matching LoginGraceTime.
+#define DEFAULT_AUTH_TIMEOUT 90
+#define MIN_AUTH_TIMEOUT 10
+#define MAX_AUTH_TIMEOUT 900
+
+// Bounds on the poll interval the broker asks for via metadata.polling_interval.
+// The broker already clamps what it sends to [5, 3600] (pkg/auth/device_flow.go),
+// so these exist only to keep a missing or malformed value from turning the
+// polling loop into a busy loop or an unbounded wait.
+#define DEFAULT_POLL_INTERVAL 5
+#define MIN_POLL_INTERVAL 1
+#define MAX_POLL_INTERVAL 60
+
 // Options parsed from the module arguments in /etc/pam.d/<service>.
 typedef struct {
     char socket_path[MAX_SOCKET_PATH];
+    int timeout_s;
 } pam_oidc_options;
 
 // Function prototypes
@@ -40,7 +61,10 @@ void log_pam_message_string(int priority, const char *message);
 int connect_to_broker(const char *socket_path);
 int get_user_info(pam_handle_t *pamh, const char **username, const char **service, const char **rhost, const char **tty);
 int send_auth_request(int sock, const char *username, const char *service, const char *rhost, const char *tty);
+int send_check_session_request(int sock, const char *session_id, const char *username);
 int receive_auth_response(int sock, char *response, size_t response_size);
+int perform_authentication(pam_handle_t *pamh, const char *socket_path, const char *username,
+                           const char *service, const char *rhost, const char *tty, int timeout_s);
 int display_message(pam_handle_t *pamh, const char *message);
 int prompt_user(pam_handle_t *pamh, const char *prompt, char *response, size_t response_size);
 

--- a/pkg/pam/device_flow_test.go
+++ b/pkg/pam/device_flow_test.go
@@ -1,0 +1,373 @@
+package pam
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// fakeBroker is a minimal stand-in for internal/ipc.Server. Like the real
+// broker it serves exactly one newline-delimited JSON request per connection and
+// then closes, so a module that fails to reconnect between polls cannot pass
+// these tests.
+type fakeBroker struct {
+	socketPath string
+
+	mu       sync.Mutex
+	requests []map[string]interface{}
+}
+
+// newFakeBroker starts a broker whose reply to the n-th request (1-based) is
+// whatever handler returns: a map/struct is JSON-encoded, a string is written
+// verbatim so malformed responses can be tested.
+func newFakeBroker(t *testing.T, handler func(reqNum int, req map[string]interface{}) interface{}) *fakeBroker {
+	t.Helper()
+
+	// Not t.TempDir(): the socket path has to fit in sockaddr_un.sun_path, and
+	// the temp directory named after the test can be long.
+	dir, err := os.MkdirTemp("", "oidcpam")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+
+	b := &fakeBroker{socketPath: filepath.Join(dir, "b.sock")}
+	ln, err := net.Listen("unix", b.socketPath)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", b.socketPath, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed by cleanup
+			}
+			b.serve(conn, handler)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+		_ = os.RemoveAll(dir)
+	})
+
+	return b
+}
+
+func (b *fakeBroker) serve(conn net.Conn, handler func(int, map[string]interface{}) interface{}) {
+	defer func() { _ = conn.Close() }()
+
+	var req map[string]interface{}
+	if err := json.NewDecoder(conn).Decode(&req); err != nil {
+		return
+	}
+
+	b.mu.Lock()
+	b.requests = append(b.requests, req)
+	n := len(b.requests)
+	b.mu.Unlock()
+
+	switch reply := handler(n, req).(type) {
+	case nil:
+		// Close without replying.
+	case string:
+		_, _ = conn.Write([]byte(reply))
+	default:
+		_ = json.NewEncoder(conn).Encode(reply)
+	}
+}
+
+func (b *fakeBroker) received() []map[string]interface{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]map[string]interface{}, len(b.requests))
+	copy(out, b.requests)
+	return out
+}
+
+// deviceStarted is what the broker returns when it has only just started the
+// device flow: success=true *and* requires_device=true. The user has not
+// authenticated yet at this point.
+func deviceStarted(sessionID string) map[string]interface{} {
+	return map[string]interface{}{
+		"success":         true,
+		"session_id":      sessionID,
+		"device_code":     "WDJB-MJHT",
+		"device_url":      "https://idp.example.com/device",
+		"requires_device": true,
+		"instructions":    "Visit https://idp.example.com/device and enter WDJB-MJHT",
+		"metadata": map[string]interface{}{
+			"provider":         "test",
+			"polling_interval": 1,
+		},
+	}
+}
+
+// devicePending is CheckSession's reply while the user has not finished: also
+// success=true with requires_device=true.
+func devicePending(sessionID string) map[string]interface{} {
+	return map[string]interface{}{
+		"success":         true,
+		"session_id":      sessionID,
+		"requires_device": true,
+		"metadata":        map[string]interface{}{"status": "pending"},
+	}
+}
+
+func authenticated(sessionID string) map[string]interface{} {
+	return map[string]interface{}{
+		"success":    true,
+		"session_id": sessionID,
+		"user_id":    "testuser",
+		"email":      "testuser@example.com",
+	}
+}
+
+func denied(errorCode string) map[string]interface{} {
+	return map[string]interface{}{
+		"success":       false,
+		"error_code":    errorCode,
+		"error_message": "denied by test",
+	}
+}
+
+// The headline regression test: the broker reports success=true together with
+// requires_device=true as soon as the device flow starts, and the identity
+// binding and require_groups checks only happen afterwards. If the module reads
+// success before requires_device it returns PAM_SUCCESS here, and with the
+// shipped `auth sufficient pam_oidc.so` that grants login to anyone who can
+// reach the broker without them ever visiting the device URL.
+func TestPerformAuthenticationDeniesWhenDeviceFlowNeverCompletes(t *testing.T) {
+	t.Parallel()
+
+	broker := newFakeBroker(t, func(_ int, req map[string]interface{}) interface{} {
+		if req["type"] == "authenticate" {
+			return deviceStarted("sess-never")
+		}
+		return devicePending("sess-never")
+	})
+
+	if got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 2); got != PAMAuthError {
+		t.Fatalf("unfinished device flow: got PAM result %d, want PAMAuthError (%d)", got, PAMAuthError)
+	}
+
+	// One authenticate plus at least one poll: the module must actually wait for
+	// the user rather than deciding on the initiation response alone.
+	if n := len(broker.received()); n < 2 {
+		t.Fatalf("expected the module to poll the broker, got %d request(s)", n)
+	}
+}
+
+func TestPerformAuthenticationSucceedsAfterDeviceApproval(t *testing.T) {
+	t.Parallel()
+
+	broker := newFakeBroker(t, func(n int, _ map[string]interface{}) interface{} {
+		switch n {
+		case 1:
+			return deviceStarted("sess-ok")
+		case 2:
+			return devicePending("sess-ok")
+		default:
+			return authenticated("sess-ok")
+		}
+	})
+
+	if got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30); got != PAMSuccess {
+		t.Fatalf("completed device flow: got PAM result %d, want PAMSuccess", got)
+	}
+
+	requests := broker.received()
+	if len(requests) != 3 {
+		t.Fatalf("expected 3 requests (authenticate + 2 polls), got %d: %v", len(requests), requests)
+	}
+	if requests[0]["type"] != "authenticate" {
+		t.Errorf("first request type = %v, want authenticate", requests[0]["type"])
+	}
+	for i, req := range requests[1:] {
+		if req["type"] != "check_session" {
+			t.Errorf("poll %d: type = %v, want check_session", i+1, req["type"])
+		}
+		if req["session_id"] != "sess-ok" {
+			t.Errorf("poll %d: session_id = %v, want sess-ok", i+1, req["session_id"])
+		}
+		// Broker.CheckSession answers FORBIDDEN when user_id does not match the
+		// session owner, so the poll has to carry it.
+		if req["user_id"] != "testuser" {
+			t.Errorf("poll %d: user_id = %v, want testuser", i+1, req["user_id"])
+		}
+	}
+}
+
+// The broker deletes the session when identity binding fails, when
+// require_groups rejects the user, when polling the IdP fails, and when the
+// session expires. A poll that can no longer find its session is therefore a
+// denial, not a transient error.
+func TestPerformAuthenticationDeniesOnTerminalPollErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		errorCode string
+		want      PAMResultCode
+	}{
+		{"SESSION_NOT_FOUND", PAMAuthError},
+		{"SESSION_EXPIRED", PAMAuthError},
+		{"FORBIDDEN", PAMAuthError},
+		{"DEVICE_FLOW_FAILED", PAMAuthError},
+		{"POLICY_DENIED", PAMPermDenied},
+		{"TOO_MANY_SESSIONS", PAMPermDenied},
+		{"RATE_LIMITED", PAMMaxTries},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.errorCode, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(n int, _ map[string]interface{}) interface{} {
+				if n == 1 {
+					return deviceStarted("sess-gone")
+				}
+				return denied(tt.errorCode)
+			})
+
+			if got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30); got != tt.want {
+				t.Fatalf("poll answered %s: got PAM result %d, want %d", tt.errorCode, got, tt.want)
+			}
+		})
+	}
+}
+
+// A session already active on the broker (no device step) is granted from the
+// first response, without polling.
+func TestPerformAuthenticationSucceedsWithoutDeviceStep(t *testing.T) {
+	t.Parallel()
+
+	broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+		return authenticated("sess-active")
+	})
+
+	if got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30); got != PAMSuccess {
+		t.Fatalf("active session: got PAM result %d, want PAMSuccess", got)
+	}
+	if n := len(broker.received()); n != 1 {
+		t.Fatalf("expected exactly 1 request, got %d", n)
+	}
+}
+
+func TestPerformAuthenticationDeniesUpFront(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		errorCode string
+		want      PAMResultCode
+	}{
+		{"NO_PROVIDER", PAMPermDenied},
+		{"POLICY_DENIED", PAMPermDenied},
+		{"TOO_MANY_CONCURRENT_AUTHS", PAMMaxTries},
+		{"RATE_LIMIT_EXCEEDED", PAMMaxTries},
+		{"AUTHENTICATION_FAILED", PAMAuthError},
+		{"", PAMAuthError},
+	}
+
+	for _, tt := range tests {
+		name := tt.errorCode
+		if name == "" {
+			name = "no_error_code"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return denied(tt.errorCode)
+			})
+
+			if got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30); got != tt.want {
+				t.Fatalf("broker returned %s: got PAM result %d, want %d", tt.errorCode, got, tt.want)
+			}
+			if n := len(broker.received()); n != 1 {
+				t.Fatalf("a refusal must not be polled: got %d requests", n)
+			}
+		})
+	}
+}
+
+// Only being unable to reach an opinion — no broker, an unreadable response —
+// may return PAM_AUTHINFO_UNAVAIL. Everything else has to fail closed.
+func TestPerformAuthenticationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no broker listening", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "oidcpam")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(dir) }()
+
+		got := performAuthentication(filepath.Join(dir, "absent.sock"), "testuser", "sshd", "10.0.0.1", "ssh", 30)
+		if got != PAMAuthInfoUnavail {
+			t.Fatalf("absent broker: got PAM result %d, want PAMAuthInfoUnavail (%d)", got, PAMAuthInfoUnavail)
+		}
+	})
+
+	unreadable := []struct {
+		name  string
+		reply interface{}
+	}{
+		{"malformed JSON", `{"success":`},
+		{"no success field", map[string]interface{}{"session_id": "sess-1"}},
+		{"connection closed without a reply", nil},
+		{
+			name: "device flow without a session_id",
+			reply: map[string]interface{}{
+				"success":         true,
+				"requires_device": true,
+			},
+		},
+	}
+
+	for _, tt := range unreadable {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return tt.reply
+			})
+
+			got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+			if got != PAMAuthInfoUnavail {
+				t.Fatalf("got PAM result %d, want PAMAuthInfoUnavail (%d)", got, PAMAuthInfoUnavail)
+			}
+		})
+	}
+}
+
+// An over-long session_id would not survive the round trip (the broker's own
+// validator caps it at 128 bytes), so it is refused rather than truncated.
+func TestPerformAuthenticationRejectsOverlongSessionID(t *testing.T) {
+	t.Parallel()
+
+	long := make([]byte, 200)
+	for i := range long {
+		long[i] = 'a'
+	}
+
+	broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+		return deviceStarted(string(long))
+	})
+
+	got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+	if got != PAMAuthInfoUnavail {
+		t.Fatalf("over-long session_id: got PAM result %d, want PAMAuthInfoUnavail (%d)", got, PAMAuthInfoUnavail)
+	}
+	if n := len(broker.received()); n != 1 {
+		t.Fatalf("expected no polling, got %d requests", n)
+	}
+}

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -13,16 +13,23 @@ import (
 	"unsafe"
 )
 
-// PAMResultCode mirrors the PAM result code constants from
-// /usr/include/security/_pam_types.h.
+// PAMResultCode is a PAM result code.
+//
+// The values are taken from the PAM headers the module is compiled against
+// rather than being copied by hand: they are not portable between
+// implementations (Linux-PAM and OpenPAM disagree on almost everything past
+// PAM_BUF_ERR), and a hand-copied value that libpam does not recognize turns a
+// deliberate denial into an unknown error. PAMMaxTries was 24 before this was
+// derived, which is not a Linux-PAM code at all.
 type PAMResultCode int
 
 const (
-	PAMSuccess     PAMResultCode = 0  // PAM_SUCCESS
-	PAMSystemError PAMResultCode = 4  // PAM_SYSTEM_ERR
-	PAMPermDenied  PAMResultCode = 6  // PAM_PERM_DENIED
-	PAMAuthError   PAMResultCode = 7  // PAM_AUTH_ERR
-	PAMMaxTries    PAMResultCode = 24 // PAM_MAXTRIES
+	PAMSuccess         PAMResultCode = C.PAM_SUCCESS
+	PAMSystemError     PAMResultCode = C.PAM_SYSTEM_ERR
+	PAMPermDenied      PAMResultCode = C.PAM_PERM_DENIED
+	PAMAuthError       PAMResultCode = C.PAM_AUTH_ERR
+	PAMAuthInfoUnavail PAMResultCode = C.PAM_AUTHINFO_UNAVAIL
+	PAMMaxTries        PAMResultCode = C.PAM_MAXTRIES
 )
 
 // PAMAuthFailure is returned by AuthenticateUser when the broker reports a

--- a/pkg/pam/pam_test.go
+++ b/pkg/pam/pam_test.go
@@ -332,7 +332,7 @@ func TestPAMAuthFailureError(t *testing.T) {
 // TestPAMAuthFailureCodesAreDistinct checks that the PAM result code constants
 // are not accidentally aliased.
 func TestPAMAuthFailureCodesAreDistinct(t *testing.T) {
-	codes := []PAMResultCode{PAMSuccess, PAMSystemError, PAMPermDenied, PAMAuthError, PAMMaxTries}
+	codes := []PAMResultCode{PAMSuccess, PAMSystemError, PAMPermDenied, PAMAuthError, PAMAuthInfoUnavail, PAMMaxTries}
 	seen := make(map[PAMResultCode]bool)
 	for _, c := range codes {
 		if seen[c] {


### PR DESCRIPTION
Fixes #120. **Stacked on #130** (base `fix/pam-socket-path`) — review/merge #128 → #130 → this. The socket-path fix has to land first or the bypass this PR closes is unreachable in a default install (the module was connecting to a socket the broker never listens on, which is what has been masking it).

## The bypass

`Broker.Authenticate` returns `success: true` **together with** `requires_device: true` when it has merely *started* the device flow (`pkg/auth/broker.go:394`), and `pam_sm_authenticate` tested `success` before it looked at `requires_device`:

```c
success = json_object_get_boolean(success_obj);
if (success) {
    return PAM_SUCCESS;          // <-- before the requires_device check below
}
```

With the shipped `auth sufficient pam_oidc.so`, `PAM_SUCCESS` short-circuits the auth stack. So login was granted the moment the broker replied:

- before the user ever visited the verification URL — no proof of identity at all;
- before the broker bound the OIDC identity to the requested local username (`username_claim`) and enforced `require_groups`, both of which run *afterwards*, in the `pollDeviceAuthorization` goroutine (`pkg/auth/broker.go:738-786`).

The `requires_device` branch below it was therefore unreachable dead code, and it only returned `PAM_AUTHINFO_UNAVAIL` with a `// For now, require manual retry` comment. Nothing in the tree called `check_session`, so the device flow had no completion path in the first place.

## What changed

**`pkg/pam/cgo_bridge.c`**

- The auth phase is extracted into `perform_authentication()`; `pam_sm_authenticate` is now argument parsing + `get_user_info` + a call. It tolerates a `NULL` `pam_handle_t` (no conversation messages), which is what makes it testable from Go.
- `requires_device` is checked **before** `success` is honored, in one `classify_response()` used for both the initial reply and every poll.
- When device authorization is required: display the instructions once, then poll `check_session` until a terminal state. Each attempt opens its own connection, because the broker serves exactly one request per connection and closes. The interval comes from `metadata.polling_interval`, clamped to [1, 60] s (the broker already clamps what it sends to [5, 3600]; this bound only stops a missing or malformed value becoming a busy loop or an unbounded wait).
- `send_check_session_request()` sends `user_id` as well as `session_id` — `Broker.CheckSession` answers `FORBIDDEN` when they disagree, so a poll without it could never succeed.
- **Fail closed.** Refusals, a session the broker no longer has (`SESSION_NOT_FOUND` / `SESSION_EXPIRED` / `FORBIDDEN` — how the broker reports identity mismatch, group denial, poll failure and expiry), and an exhausted budget all deny, with `error_code` mapped to PAM codes mirroring `errorCodeToPAMResult`. Only *failing to reach an opinion* — unreachable broker, unparseable response, missing `session_id` — returns `PAM_AUTHINFO_UNAVAIL`. `json_object_put` on every path.
- New `timeout=<seconds>` argument (default 90, range 10–900). The default sits below sshd's default `LoginGraceTime` of 120 s, so an expired flow is reported as a denial rather than sshd tearing down the connection mid-prompt. Documented in `configs/pam/README.md`, including the "raise both together" case.

**`internal/ipc/validate.go`** — `user_id` is now **required and validated** on `check_session`, `refresh_session` and `revoke_session`. The broker compares it against the session owner to reject cross-user session access, but the validator neither required nor validated it, so an absent `user_id` was compared as the empty string. No production caller sent these before, so nothing breaks.

**`pkg/pam/pam.go`** — the `PAMResultCode` constants are now taken from the PAM headers the module compiles against instead of being copied by hand. `PAMMaxTries` was `24`, which is not a Linux-PAM code at all (`PAM_MAXTRIES` is 11) — returning it would have turned a deliberate rate-limit denial into an unrecognized error. This surfaced because the new tests compare the C module's return value against the Go constant.

## Tests

`pkg/pam/device_flow_test.go` drives `perform_authentication` against a fake broker on a Unix socket that, like the real one, serves one request per connection and then closes — so a module that failed to reconnect between polls could not pass:

- **`TestPerformAuthenticationDeniesWhenDeviceFlowNeverCompletes`** — the bypass regression test. The broker replies `success: true, requires_device: true` and then stays pending; the module must poll and then deny, not grant.
- device flow completed after two polls → `PAM_SUCCESS`, with the poll requests asserted to carry `type`, `session_id` **and** `user_id`.
- each terminal poll error → its mapped PAM code (7 cases).
- already-active session with no device step → `PAM_SUCCESS` from one request, no polling.
- up-front refusals → mapped codes, and never polled (6 cases).
- `PAM_AUTHINFO_UNAVAIL` only for: no broker listening, malformed JSON, no `success` field, connection closed without a reply, `requires_device` without a `session_id`.
- over-long `session_id` refused rather than truncated.

Plus `timeout=` parsing (11 cases, including the assertion that the default stays under `LoginGraceTime`).

## Verification

`make verify-linux` (added in #128) — `go vet ./...`, `go test -race ./pkg/... ./internal/...`, and `golangci-lint run ./...` all green, cgo packages included. `pkg/pam` now takes ~33 s, dominated by the deliberate polling waits in these tests.

Not covered here: the end-to-end sshd path. Scenarios 1–2 of #129 are the container version of the regression test above.
