### PR TITLE
fix(security): complete the device flow in the Go client path too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Critical (#121): the Go client path also treated device-flow initiation as
+  authentication success.** `PAMModule.AuthenticateUser` returned nil as soon as
+  the broker replied `success: true`, which it does the moment it *starts* the
+  device flow, and `oidc-pam-helper` exited 0 on that — so `pam_exec`-style
+  integrations granted the login before the user had proved anything, exactly as
+  the C module did (#120). It now waits for the flow to complete and returns
+  `*PAMAuthFailure` on refusal and on an exhausted timeout.
+- **(#121)** New `internal/brokerclient`: the broker IPC protocol and the
+  device-flow completion logic in one **pure-Go, cgo-free** package, so the
+  wait/poll/deny behaviour is covered by `go test` on every platform rather than
+  living only in C that a developer laptop cannot compile. It dials per request
+  (the broker serves one request per connection), polls `check_session` with
+  `user_id`, honours `metadata.polling_interval` clamped to [1, 60] s, never
+  overshoots its budget, and distinguishes a broker *decision* (`DenialError`,
+  `TimeoutError`) from a failure to reach one (transport/parse errors → only
+  these become `PAM_AUTHINFO_UNAVAIL`).
+- **(#121)** The C module and the Go client disagreed on login-type
+  classification, so the broker could apply different per-login-type policy to
+  the same login depending on which client ran: the C side matched
+  `gdm`/`lightdm` as substrings, never matched `sddm`, and tested the TTY before
+  the service (classifying a display manager on `tty1` as `console`). The
+  classification is now a single documented function pinned to `GetLoginType` by
+  a test.
 - **Critical (#120): `pam_oidc.so` granted `PAM_SUCCESS` before device
   authorization completed.** `Broker.Authenticate` returns `success: true`
   *together with* `requires_device: true` when it has merely started the device
@@ -66,6 +89,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep working.
 
 ### Added
+- **(#121)** `oidc-pam-helper -timeout` now bounds the device-flow wait rather
+  than only arming a watchdog (default 90 s, matching the PAM module's
+  `timeout=`); the outer watchdog fires 10 s later so an authentication that runs
+  out of budget reports a denial instead of being killed. `PAMModule.AuthTimeout`
+  exposes the same budget to embedders.
 - **(#120)** `timeout=<seconds>` module argument bounding the wait for device
   authorization (default 90, range 10–900). The default sits below sshd's
   default `LoginGraceTime` of 120 s so an expired flow is reported as a denial

--- a/cmd/pam-helper/main.go
+++ b/cmd/pam-helper/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/scttfrdmn/oidc-pam/internal/brokerclient"
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
 	"github.com/scttfrdmn/oidc-pam/pkg/pam"
 )
@@ -23,6 +24,10 @@ var (
 
 const (
 	Name = "oidc-pam-helper"
+
+	// watchdogGrace is how much longer than the authentication timeout the
+	// outer watchdog waits before giving up on AuthenticateUser.
+	watchdogGrace = 10 * time.Second
 )
 
 func main() {
@@ -36,7 +41,7 @@ func main() {
 		debug       = flag.Bool("debug", false, "Enable debug logging")
 		showVersion = flag.Bool("version", false, "Show version information")
 		socketPath  = flag.String("socket", "/var/run/oidc-auth/broker.sock", "Path to broker socket")
-		timeout     = flag.Duration("timeout", 30*time.Second, "Authentication timeout")
+		timeout     = flag.Duration("timeout", brokerclient.DefaultAuthTimeout, "How long to wait for the user to complete the device authorization flow")
 		_           = flag.Bool("interactive", false, "Interactive mode (prompt for user input)")
 	)
 	flag.Parse()
@@ -102,6 +107,7 @@ func main() {
 
 	// Create PAM module
 	pamModule := pam.NewPAMModule(finalSocketPath, *debug)
+	pamModule.AuthTimeout = *timeout
 
 	// Set up signal handling
 	sigChan := make(chan os.Signal, 1)
@@ -141,7 +147,10 @@ func main() {
 			Msg("Authentication successful")
 		os.Exit(0)
 
-	case <-time.After(*timeout):
+	// A watchdog, not the authentication timeout: AuthenticateUser enforces
+	// *timeout itself and reports the expiry as a denial. The extra grace lets
+	// that specific error win the race, so the log says why the login failed.
+	case <-time.After(*timeout + watchdogGrace):
 		log.Error().
 			Dur("timeout", *timeout).
 			Msg("Authentication timed out")

--- a/internal/brokerclient/client.go
+++ b/internal/brokerclient/client.go
@@ -1,0 +1,324 @@
+// Package brokerclient speaks the broker's Unix-socket IPC protocol from Go.
+//
+// It exists so the device authorization flow has one Go implementation that can
+// actually be tested: the PAM module's copy is in C, unbuildable on a developer
+// laptop without PAM headers, and reachable only through cgo. Everything here is
+// standard library, so `go test` covers it everywhere.
+//
+// The request and response types are deliberately a local copy of the ones in
+// internal/ipc rather than an import: internal/ipc pulls in the whole broker
+// (pkg/auth and its OIDC, policy and audit dependencies), which has no business
+// being linked into a client that runs as part of a login.
+package brokerclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+const (
+	// DefaultDialTimeout bounds connecting to the broker socket.
+	DefaultDialTimeout = 5 * time.Second
+
+	// DefaultRequestTimeout bounds a single request/response exchange.
+	DefaultRequestTimeout = 30 * time.Second
+
+	// DefaultAuthTimeout bounds the wait for the user to complete the device
+	// flow. It matches DEFAULT_AUTH_TIMEOUT in pkg/pam/cgo_bridge.h and stays
+	// below sshd's default LoginGraceTime of 120s.
+	DefaultAuthTimeout = 90 * time.Second
+
+	// Bounds on the poll interval the broker asks for in
+	// metadata.polling_interval. The broker already clamps what it sends to
+	// [5, 3600]s; these keep a missing or malformed value from becoming a busy
+	// loop or an unbounded wait. They match the C module's bounds.
+	DefaultPollInterval = 5 * time.Second
+	MinPollInterval     = 1 * time.Second
+	MaxPollInterval     = 60 * time.Second
+)
+
+// Request is an IPC request. It mirrors ipc.Request.
+type Request struct {
+	Type       string                 `json:"type"`
+	UserID     string                 `json:"user_id,omitempty"`
+	SourceIP   string                 `json:"source_ip,omitempty"`
+	UserAgent  string                 `json:"user_agent,omitempty"`
+	TargetHost string                 `json:"target_host,omitempty"`
+	LoginType  string                 `json:"login_type,omitempty"`
+	DeviceID   string                 `json:"device_id,omitempty"`
+	SessionID  string                 `json:"session_id,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// Response is an IPC response. It mirrors ipc.Response.
+type Response struct {
+	Success          bool                   `json:"success"`
+	UserID           string                 `json:"user_id,omitempty"`
+	Email            string                 `json:"email,omitempty"`
+	Groups           []string               `json:"groups,omitempty"`
+	SessionID        string                 `json:"session_id,omitempty"`
+	DeviceCode       string                 `json:"device_code,omitempty"`
+	DeviceURL        string                 `json:"device_url,omitempty"`
+	QRCode           string                 `json:"qr_code,omitempty"`
+	ExpiresAt        time.Time              `json:"expires_at,omitempty"`
+	SSHPublicKey     string                 `json:"ssh_public_key,omitempty"`
+	RequiresDevice   bool                   `json:"requires_device,omitempty"`
+	RequiresApproval bool                   `json:"requires_approval,omitempty"`
+	ErrorCode        string                 `json:"error_code,omitempty"`
+	ErrorMessage     string                 `json:"error_message,omitempty"`
+	Instructions     string                 `json:"instructions,omitempty"`
+	RiskScore        int                    `json:"risk_score,omitempty"`
+	Metadata         map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// DenialError reports that the broker refused the authentication. It is a
+// decision, not a failure to obtain one: callers must treat it as a denial.
+//
+// A poll answered with SESSION_NOT_FOUND, SESSION_EXPIRED or FORBIDDEN is also a
+// denial, because the broker deletes the session when identity binding fails,
+// when require_groups rejects the user, when polling the IdP fails, and when the
+// session expires.
+type DenialError struct {
+	ErrorCode string
+	Message   string
+}
+
+func (e *DenialError) Error() string {
+	msg := e.Message
+	if msg == "" {
+		msg = "authentication denied by broker"
+	}
+	if e.ErrorCode == "" {
+		return msg
+	}
+	return fmt.Sprintf("%s (%s)", msg, e.ErrorCode)
+}
+
+// TimeoutError reports that the user did not complete the device flow in time.
+// Like DenialError it is a denial: an unfinished flow is never a success.
+type TimeoutError struct {
+	Waited time.Duration
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("device authorization not completed within %s", e.Waited)
+}
+
+// Client talks to the broker over its Unix socket.
+//
+// The broker serves exactly one request per connection and then closes it, so
+// each call here dials its own connection.
+type Client struct {
+	SocketPath string
+
+	// DialTimeout bounds connecting; RequestTimeout bounds one exchange.
+	DialTimeout    time.Duration
+	RequestTimeout time.Duration
+
+	// OnDeviceFlow, if set, is called once with the initiation response when the
+	// broker asks for device authorization — that is where the verification URL
+	// and user code are shown to the user.
+	OnDeviceFlow func(*Response)
+
+	// now and sleep are injectable so the polling loop can be tested without
+	// spending real time.
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+}
+
+// New returns a Client for the broker listening on socketPath.
+func New(socketPath string) *Client {
+	return &Client{
+		SocketPath:     socketPath,
+		DialTimeout:    DefaultDialTimeout,
+		RequestTimeout: DefaultRequestTimeout,
+	}
+}
+
+func (c *Client) clock() func() time.Time {
+	if c.now != nil {
+		return c.now
+	}
+	return time.Now
+}
+
+func (c *Client) wait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	if c.sleep != nil {
+		return c.sleep(ctx, d)
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// Do performs one request/response exchange on its own connection.
+func (c *Client) Do(ctx context.Context, req *Request) (*Response, error) {
+	dialTimeout := c.DialTimeout
+	if dialTimeout <= 0 {
+		dialTimeout = DefaultDialTimeout
+	}
+	requestTimeout := c.RequestTimeout
+	if requestTimeout <= 0 {
+		requestTimeout = DefaultRequestTimeout
+	}
+
+	dialer := net.Dialer{Timeout: dialTimeout}
+	conn, err := dialer.DialContext(ctx, "unix", c.SocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("connect to broker at %s: %w", c.SocketPath, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Real clock, not c.clock(): this is an OS-level deadline on a real socket.
+	// c.clock() is the virtual clock the polling loop is measured against.
+	if err := conn.SetDeadline(time.Now().Add(requestTimeout)); err != nil {
+		return nil, fmt.Errorf("set broker connection deadline: %w", err)
+	}
+
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		return nil, fmt.Errorf("send %s request: %w", req.Type, err)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("read response to %s request: %w", req.Type, err)
+	}
+
+	return &resp, nil
+}
+
+// Authenticate starts an authentication and returns the broker's first
+// response. A response with RequiresDevice set means the device flow has begun
+// and is *not* a successful authentication — see AuthenticateAndWait.
+func (c *Client) Authenticate(ctx context.Context, req *Request) (*Response, error) {
+	authRequest := *req
+	authRequest.Type = "authenticate"
+	return c.Do(ctx, &authRequest)
+}
+
+// CheckSession asks the broker for the state of a session. userID is required:
+// the broker compares it against the session owner and answers FORBIDDEN when
+// they differ.
+func (c *Client) CheckSession(ctx context.Context, sessionID, userID string) (*Response, error) {
+	return c.Do(ctx, &Request{
+		Type:      "check_session",
+		SessionID: sessionID,
+		UserID:    userID,
+	})
+}
+
+// AuthenticateAndWait authenticates and, if the broker starts a device flow,
+// polls until it completes or timeout expires.
+//
+// It returns the granting response, or an error. The error is a *DenialError or
+// *TimeoutError when the broker (or the clock) refused the login, and an
+// ordinary error when the broker could not be reached or understood — callers
+// that map to PAM codes should return PAM_AUTHINFO_UNAVAIL only for the latter.
+//
+// A response is treated as a grant only when Success is set *and* RequiresDevice
+// is not: the broker reports Success together with RequiresDevice while the flow
+// is merely pending, and identity binding and require_groups are enforced after
+// that point.
+func (c *Client) AuthenticateAndWait(ctx context.Context, req *Request, timeout time.Duration) (*Response, error) {
+	if timeout <= 0 {
+		timeout = DefaultAuthTimeout
+	}
+
+	resp, err := c.Authenticate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.RequiresDevice {
+		if !resp.Success {
+			return nil, &DenialError{ErrorCode: resp.ErrorCode, Message: resp.ErrorMessage}
+		}
+		return resp, nil
+	}
+	if !resp.Success {
+		// A refusal that also happens to set requires_device is still a refusal.
+		return nil, &DenialError{ErrorCode: resp.ErrorCode, Message: resp.ErrorMessage}
+	}
+	if resp.SessionID == "" {
+		return nil, fmt.Errorf("broker requires device authorization but returned no session_id")
+	}
+
+	if c.OnDeviceFlow != nil {
+		c.OnDeviceFlow(resp)
+	}
+
+	interval := pollInterval(resp)
+	now := c.clock()
+	start := now()
+	deadline := start.Add(timeout)
+	userID := req.UserID
+	sessionID := resp.SessionID
+
+	for {
+		remaining := deadline.Sub(now())
+		delay := interval
+		if remaining < delay {
+			delay = remaining
+		}
+		// Wait before polling: the broker has only just issued the device code,
+		// so an immediate poll can only report "pending".
+		if err := c.wait(ctx, delay); err != nil {
+			return nil, err
+		}
+
+		resp, err := c.CheckSession(ctx, sessionID, userID)
+		if err != nil {
+			return nil, err
+		}
+		if !resp.Success {
+			return nil, &DenialError{ErrorCode: resp.ErrorCode, Message: resp.ErrorMessage}
+		}
+		if !resp.RequiresDevice {
+			return resp, nil
+		}
+
+		if !now().Before(deadline) {
+			return nil, &TimeoutError{Waited: timeout}
+		}
+	}
+}
+
+// pollInterval reads metadata.polling_interval (seconds) from a response,
+// clamped to [MinPollInterval, MaxPollInterval].
+func pollInterval(resp *Response) time.Duration {
+	raw, ok := resp.Metadata["polling_interval"]
+	if !ok {
+		return DefaultPollInterval
+	}
+
+	var seconds float64
+	switch v := raw.(type) {
+	case float64: // JSON numbers
+		seconds = v
+	case int:
+		seconds = float64(v)
+	default:
+		return DefaultPollInterval
+	}
+
+	interval := time.Duration(seconds * float64(time.Second))
+	if interval < MinPollInterval {
+		return MinPollInterval
+	}
+	if interval > MaxPollInterval {
+		return MaxPollInterval
+	}
+	return interval
+}

--- a/internal/brokerclient/client_test.go
+++ b/internal/brokerclient/client_test.go
@@ -1,0 +1,470 @@
+package brokerclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeBroker stands in for internal/ipc.Server. Like the real broker it serves
+// exactly one newline-delimited JSON request per connection and then closes, so a
+// client that fails to reconnect between polls cannot pass these tests.
+type fakeBroker struct {
+	socketPath string
+
+	mu       sync.Mutex
+	requests []Request
+}
+
+// newFakeBroker starts a broker whose reply to the n-th request (1-based) is
+// whatever handler returns: a *Response is JSON-encoded, a string is written
+// verbatim so malformed replies can be tested, and nil closes without replying.
+func newFakeBroker(t *testing.T, handler func(reqNum int, req Request) interface{}) *fakeBroker {
+	t.Helper()
+
+	b := &fakeBroker{socketPath: tempSocketPath(t)}
+	ln, err := net.Listen("unix", b.socketPath)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", b.socketPath, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed by cleanup
+			}
+			b.serve(conn, handler)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+
+	return b
+}
+
+// tempSocketPath returns a short-enough path for a Unix socket. Not
+// t.TempDir(): it embeds the test name, and the result routinely exceeds
+// sockaddr_un.sun_path (104 bytes on macOS), which fails with EINVAL at bind.
+func tempSocketPath(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "oidcbc")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "b.sock")
+}
+
+func (b *fakeBroker) serve(conn net.Conn, handler func(int, Request) interface{}) {
+	defer func() { _ = conn.Close() }()
+
+	var req Request
+	if err := json.NewDecoder(conn).Decode(&req); err != nil {
+		return
+	}
+
+	b.mu.Lock()
+	b.requests = append(b.requests, req)
+	n := len(b.requests)
+	b.mu.Unlock()
+
+	switch reply := handler(n, req).(type) {
+	case nil:
+	case string:
+		_, _ = conn.Write([]byte(reply))
+	default:
+		_ = json.NewEncoder(conn).Encode(reply)
+	}
+}
+
+func (b *fakeBroker) received() []Request {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]Request, len(b.requests))
+	copy(out, b.requests)
+	return out
+}
+
+// testClient returns a client whose clock is virtual: sleeps advance a fake
+// "now" instead of taking real time, so the polling loop runs at full speed and
+// the elapsed time it observes is exactly what it asked for.
+func testClient(t *testing.T, socketPath string) (*Client, func() time.Time) {
+	t.Helper()
+
+	var mu sync.Mutex
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	read := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	c := New(socketPath)
+	c.now = read
+	c.sleep = func(ctx context.Context, d time.Duration) error {
+		mu.Lock()
+		now = now.Add(d)
+		mu.Unlock()
+		return ctx.Err()
+	}
+	return c, read
+}
+
+func deviceStarted(sessionID string, pollSeconds float64) *Response {
+	return &Response{
+		Success:        true,
+		SessionID:      sessionID,
+		DeviceCode:     "WDJB-MJHT",
+		DeviceURL:      "https://idp.example.com/device",
+		RequiresDevice: true,
+		Instructions:   "Visit https://idp.example.com/device and enter WDJB-MJHT",
+		Metadata: map[string]interface{}{
+			"provider":         "test",
+			"polling_interval": pollSeconds,
+		},
+	}
+}
+
+func devicePending(sessionID string) *Response {
+	return &Response{
+		Success:        true,
+		SessionID:      sessionID,
+		RequiresDevice: true,
+		Metadata:       map[string]interface{}{"status": "pending"},
+	}
+}
+
+func authenticated(sessionID string) *Response {
+	return &Response{Success: true, SessionID: sessionID, UserID: "testuser"}
+}
+
+func denied(errorCode string) *Response {
+	return &Response{Success: false, ErrorCode: errorCode, ErrorMessage: "denied by test"}
+}
+
+func authRequest() *Request {
+	return &Request{UserID: "testuser", TargetHost: "10.0.0.1", LoginType: "ssh"}
+}
+
+// The headline regression test: the broker reports Success together with
+// RequiresDevice as soon as the flow starts, and identity binding and
+// require_groups are only enforced afterwards. Treating that as success grants
+// the login before the user has proved anything.
+func TestAuthenticateAndWaitDeniesWhenDeviceFlowNeverCompletes(t *testing.T) {
+	broker := newFakeBroker(t, func(_ int, req Request) interface{} {
+		if req.Type == "authenticate" {
+			return deviceStarted("sess-never", 5)
+		}
+		return devicePending("sess-never")
+	})
+
+	client, _ := testClient(t, broker.socketPath)
+	resp, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+	if resp != nil {
+		t.Fatalf("expected no response, got %+v", resp)
+	}
+
+	var timeout *TimeoutError
+	if !errors.As(err, &timeout) {
+		t.Fatalf("expected *TimeoutError, got %T: %v", err, err)
+	}
+	if timeout.Waited != 30*time.Second {
+		t.Errorf("TimeoutError.Waited = %s, want 30s", timeout.Waited)
+	}
+
+	// 30s budget at a 5s interval: one authenticate plus six polls.
+	if n := len(broker.received()); n != 7 {
+		t.Errorf("expected 1 authenticate + 6 polls, got %d requests", n)
+	}
+}
+
+func TestAuthenticateAndWaitSucceedsAfterDeviceApproval(t *testing.T) {
+	broker := newFakeBroker(t, func(n int, _ Request) interface{} {
+		switch n {
+		case 1:
+			return deviceStarted("sess-ok", 5)
+		case 2:
+			return devicePending("sess-ok")
+		default:
+			return authenticated("sess-ok")
+		}
+	})
+
+	client, _ := testClient(t, broker.socketPath)
+
+	var shown *Response
+	client.OnDeviceFlow = func(resp *Response) { shown = resp }
+
+	resp, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("AuthenticateAndWait: %v", err)
+	}
+	if !resp.Success || resp.RequiresDevice {
+		t.Fatalf("unexpected granting response: %+v", resp)
+	}
+
+	if shown == nil || shown.DeviceURL == "" {
+		t.Error("OnDeviceFlow was not called with the verification details")
+	}
+
+	requests := broker.received()
+	if len(requests) != 3 {
+		t.Fatalf("expected 3 requests (authenticate + 2 polls), got %d", len(requests))
+	}
+	if requests[0].Type != "authenticate" {
+		t.Errorf("first request type = %q, want authenticate", requests[0].Type)
+	}
+	for i, req := range requests[1:] {
+		if req.Type != "check_session" {
+			t.Errorf("poll %d: type = %q, want check_session", i+1, req.Type)
+		}
+		if req.SessionID != "sess-ok" {
+			t.Errorf("poll %d: session_id = %q, want sess-ok", i+1, req.SessionID)
+		}
+		// The broker answers FORBIDDEN when user_id does not match the session
+		// owner, so the poll has to carry it.
+		if req.UserID != "testuser" {
+			t.Errorf("poll %d: user_id = %q, want testuser", i+1, req.UserID)
+		}
+	}
+}
+
+func TestAuthenticateAndWaitDeniesOnTerminalPollErrors(t *testing.T) {
+	// The broker deletes the session on identity mismatch, group denial, poll
+	// failure and expiry, so these are decisions, not transient errors.
+	for _, code := range []string{"SESSION_NOT_FOUND", "SESSION_EXPIRED", "FORBIDDEN", "DEVICE_FLOW_FAILED", "POLICY_DENIED"} {
+		t.Run(code, func(t *testing.T) {
+			broker := newFakeBroker(t, func(n int, _ Request) interface{} {
+				if n == 1 {
+					return deviceStarted("sess-gone", 5)
+				}
+				return denied(code)
+			})
+
+			client, _ := testClient(t, broker.socketPath)
+			_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+
+			var denial *DenialError
+			if !errors.As(err, &denial) {
+				t.Fatalf("expected *DenialError, got %T: %v", err, err)
+			}
+			if denial.ErrorCode != code {
+				t.Errorf("DenialError.ErrorCode = %q, want %q", denial.ErrorCode, code)
+			}
+			if n := len(broker.received()); n != 2 {
+				t.Errorf("expected polling to stop at the first terminal answer, got %d requests", n)
+			}
+		})
+	}
+}
+
+func TestAuthenticateAndWaitGrantsActiveSessionWithoutPolling(t *testing.T) {
+	broker := newFakeBroker(t, func(_ int, _ Request) interface{} {
+		return authenticated("sess-active")
+	})
+
+	client, _ := testClient(t, broker.socketPath)
+	resp, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("AuthenticateAndWait: %v", err)
+	}
+	if resp.SessionID != "sess-active" {
+		t.Errorf("session_id = %q, want sess-active", resp.SessionID)
+	}
+	if n := len(broker.received()); n != 1 {
+		t.Errorf("expected exactly 1 request, got %d", n)
+	}
+}
+
+func TestAuthenticateAndWaitDeniesUpFront(t *testing.T) {
+	for _, code := range []string{"NO_PROVIDER", "POLICY_DENIED", "RATE_LIMITED", "AUTHENTICATION_FAILED", ""} {
+		name := code
+		if name == "" {
+			name = "no_error_code"
+		}
+		t.Run(name, func(t *testing.T) {
+			broker := newFakeBroker(t, func(_ int, _ Request) interface{} {
+				return denied(code)
+			})
+
+			client, _ := testClient(t, broker.socketPath)
+			_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+
+			var denial *DenialError
+			if !errors.As(err, &denial) {
+				t.Fatalf("expected *DenialError, got %T: %v", err, err)
+			}
+			if n := len(broker.received()); n != 1 {
+				t.Errorf("a refusal must not be polled: got %d requests", n)
+			}
+		})
+	}
+}
+
+// A refusal that also sets requires_device is still a refusal.
+func TestAuthenticateAndWaitDeniesRefusalWithRequiresDevice(t *testing.T) {
+	broker := newFakeBroker(t, func(_ int, _ Request) interface{} {
+		return &Response{Success: false, RequiresDevice: true, ErrorCode: "RATE_LIMITED"}
+	})
+
+	client, _ := testClient(t, broker.socketPath)
+	_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+
+	var denial *DenialError
+	if !errors.As(err, &denial) {
+		t.Fatalf("expected *DenialError, got %T: %v", err, err)
+	}
+}
+
+// Failing to reach an opinion must be distinguishable from a denial: callers
+// return PAM_AUTHINFO_UNAVAIL for these and PAM_AUTH_ERR for denials.
+func TestAuthenticateAndWaitTransportFailuresAreNotDenials(t *testing.T) {
+	assertPlainError := func(t *testing.T, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		var denial *DenialError
+		var timeout *TimeoutError
+		if errors.As(err, &denial) || errors.As(err, &timeout) {
+			t.Fatalf("transport failure reported as a decision: %T: %v", err, err)
+		}
+	}
+
+	t.Run("no broker listening", func(t *testing.T) {
+		client := New(tempSocketPath(t))
+		_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+		assertPlainError(t, err)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		broker := newFakeBroker(t, func(_ int, _ Request) interface{} { return `{"success":` })
+		client, _ := testClient(t, broker.socketPath)
+		_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+		assertPlainError(t, err)
+	})
+
+	t.Run("closed without a reply", func(t *testing.T) {
+		broker := newFakeBroker(t, func(_ int, _ Request) interface{} { return nil })
+		client, _ := testClient(t, broker.socketPath)
+		_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+		assertPlainError(t, err)
+	})
+
+	t.Run("device flow without a session_id", func(t *testing.T) {
+		broker := newFakeBroker(t, func(_ int, _ Request) interface{} {
+			return &Response{Success: true, RequiresDevice: true}
+		})
+		client, _ := testClient(t, broker.socketPath)
+		_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+		assertPlainError(t, err)
+	})
+
+	t.Run("poll cannot reach the broker", func(t *testing.T) {
+		// Reply to the authenticate, then stop listening entirely.
+		socketPath := tempSocketPath(t)
+		ln, err := net.Listen("unix", socketPath)
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		go func() {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req Request
+			_ = json.NewDecoder(conn).Decode(&req)
+			_ = json.NewEncoder(conn).Encode(deviceStarted("sess-1", 5))
+			_ = conn.Close()
+			_ = ln.Close()
+			_ = os.Remove(socketPath)
+		}()
+
+		client, _ := testClient(t, socketPath)
+		_, err = client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+		assertPlainError(t, err)
+	})
+}
+
+func TestAuthenticateAndWaitHonorsContextCancellation(t *testing.T) {
+	broker := newFakeBroker(t, func(n int, _ Request) interface{} {
+		if n == 1 {
+			return deviceStarted("sess-1", 5)
+		}
+		return devicePending("sess-1")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client, _ := testClient(t, broker.socketPath)
+	// The virtual clock returns ctx.Err() from sleep, so cancelling before the
+	// first wait ends the loop immediately.
+	cancel()
+
+	_, err := client.AuthenticateAndWait(ctx, authRequest(), 30*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %T: %v", err, err)
+	}
+}
+
+func TestPollIntervalClamping(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]interface{}
+		want time.Duration
+	}{
+		{"absent metadata", nil, DefaultPollInterval},
+		{"absent key", map[string]interface{}{"provider": "test"}, DefaultPollInterval},
+		{"non-numeric", map[string]interface{}{"polling_interval": "5"}, DefaultPollInterval},
+		{"in range", map[string]interface{}{"polling_interval": float64(7)}, 7 * time.Second},
+		{"zero clamps up", map[string]interface{}{"polling_interval": float64(0)}, MinPollInterval},
+		{"negative clamps up", map[string]interface{}{"polling_interval": float64(-10)}, MinPollInterval},
+		{"huge clamps down", map[string]interface{}{"polling_interval": float64(3600)}, MaxPollInterval},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pollInterval(&Response{Metadata: tt.meta}); got != tt.want {
+				t.Errorf("pollInterval = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// The wait must not overshoot the budget: the last sleep is shortened to what
+// remains rather than sleeping a whole interval past the deadline.
+func TestAuthenticateAndWaitDoesNotOvershootTheBudget(t *testing.T) {
+	broker := newFakeBroker(t, func(n int, _ Request) interface{} {
+		if n == 1 {
+			return deviceStarted("sess-1", 20)
+		}
+		return devicePending("sess-1")
+	})
+
+	client, now := testClient(t, broker.socketPath)
+	start := now()
+
+	_, err := client.AuthenticateAndWait(context.Background(), authRequest(), 30*time.Second)
+	var timeout *TimeoutError
+	if !errors.As(err, &timeout) {
+		t.Fatalf("expected *TimeoutError, got %T: %v", err, err)
+	}
+
+	if elapsed := now().Sub(start); elapsed != 30*time.Second {
+		t.Errorf("waited %s, want exactly the 30s budget", elapsed)
+	}
+}

--- a/pkg/pam/cgo_auth.go
+++ b/pkg/pam/cgo_auth.go
@@ -36,3 +36,18 @@ func performAuthentication(socketPath, username, service, rhost, tty string, tim
 	return PAMResultCode(C.perform_authentication(nil, cSocketPath, cUsername, cService, cRhost, cTTY,
 		C.int(timeoutSeconds)))
 }
+
+// classifyLoginTypeC exposes the C module's login-type classification so a Go
+// test can assert it agrees with GetLoginType. The two must match: the broker
+// applies per-login-type policy, and the C module and the Go client would
+// otherwise get different answers for the same login.
+func classifyLoginTypeC(service, tty string) string {
+	cService := C.CString(service)
+	cTTY := C.CString(tty)
+	defer func() {
+		C.free(unsafe.Pointer(cService))
+		C.free(unsafe.Pointer(cTTY))
+	}()
+
+	return C.GoString(C.classify_login_type(cService, cTTY))
+}

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -115,6 +115,31 @@ int get_user_info(pam_handle_t *pamh, const char **username, const char **servic
     return PAM_SUCCESS;
 }
 
+// Classify the login for the broker's per-login-type policies. This must agree
+// with GetLoginType in cgo_wrapper.go: the C module and the Go client would
+// otherwise select different policies for the same login. See
+// TestLoginTypeClassificationMatchesGo.
+const char *classify_login_type(const char *service, const char *tty) {
+    if (service == NULL) {
+        service = "";
+    }
+    if (tty == NULL) {
+        tty = "";
+    }
+
+    if (strcmp(service, "sshd") == 0) {
+        return "ssh";
+    }
+    if (strcmp(service, "gdm") == 0 || strcmp(service, "lightdm") == 0 ||
+        strcmp(service, "sddm") == 0) {
+        return "gui";
+    }
+    if (strncmp(tty, "tty", 3) == 0) {
+        return "console";
+    }
+    return "unknown";
+}
+
 // Send authentication request to broker
 int send_auth_request(int sock, const char *username, const char *service, const char *rhost, const char *tty) {
     json_object *request = json_object_new_object();
@@ -125,15 +150,7 @@ int send_auth_request(int sock, const char *username, const char *service, const
     json_object *service_obj = json_object_new_string(service);
     json_object *tty_obj = json_object_new_string(tty);
 
-    // Determine login type based on service and TTY.
-    const char *login_type_str = "unknown";
-    if (strcmp(service, "sshd") == 0) {
-        login_type_str = "ssh";
-    } else if (strstr(tty, "tty") != NULL) {
-        login_type_str = "console";
-    } else if (strstr(service, "gdm") != NULL || strstr(service, "lightdm") != NULL) {
-        login_type_str = "gui";
-    }
+    const char *login_type_str = classify_login_type(service, tty);
 
     // Add metadata
     json_object_object_add(metadata, "service", service_obj);

--- a/pkg/pam/cgo_bridge.h
+++ b/pkg/pam/cgo_bridge.h
@@ -60,6 +60,7 @@ void log_pam_message(int priority, const char *format, ...);
 void log_pam_message_string(int priority, const char *message);
 int connect_to_broker(const char *socket_path);
 int get_user_info(pam_handle_t *pamh, const char **username, const char **service, const char **rhost, const char **tty);
+const char *classify_login_type(const char *service, const char *tty);
 int send_auth_request(int sock, const char *username, const char *service, const char *rhost, const char *tty);
 int send_check_session_request(int sock, const char *session_id, const char *username);
 int receive_auth_response(int sock, char *response, size_t response_size);

--- a/pkg/pam/device_flow_test.go
+++ b/pkg/pam/device_flow_test.go
@@ -371,3 +371,42 @@ func TestPerformAuthenticationRejectsOverlongSessionID(t *testing.T) {
 		t.Fatalf("expected no polling, got %d requests", n)
 	}
 }
+
+// TestLoginTypeClassificationMatchesGo pins the C module's login-type
+// classification to GetLoginType's. The broker applies per-login-type policy, so
+// if pam_oidc.so and the Go client disagreed, the same login would be evaluated
+// against different rules depending on which client handled it. The C side used
+// to differ on both counts covered here: it matched "gdm"/"lightdm" as
+// substrings but not "sddm" at all, and it tested the TTY before the service, so
+// a display manager on tty1 was classified "console".
+func TestLoginTypeClassificationMatchesGo(t *testing.T) {
+	cases := []struct {
+		service string
+		tty     string
+	}{
+		{"sshd", "pts/0"},
+		{"sshd", "tty1"},
+		{"gdm", "tty1"},
+		{"lightdm", "tty7"},
+		{"sddm", "tty1"},
+		{"gdm3", "tty1"},
+		{"login", "tty1"},
+		{"login", "tty"},
+		{"login", "tty12"},
+		{"login", "pts/0"},
+		{"su", "unknown"},
+		{"sudo", ""},
+		{"", ""},
+		{"SSHD", "pts/0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.service+"/"+tc.tty, func(t *testing.T) {
+			want := GetLoginType(tc.service, tc.tty)
+			if got := classifyLoginTypeC(tc.service, tc.tty); got != want {
+				t.Errorf("C classify_login_type(%q, %q) = %q, Go GetLoginType = %q",
+					tc.service, tc.tty, got, want)
+			}
+		})
+	}
+}

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -7,10 +7,16 @@ package pam
 */
 import "C"
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"sync/atomic"
+	"time"
 	"unsafe"
+
+	"github.com/scttfrdmn/oidc-pam/internal/brokerclient"
 )
 
 // PAMResultCode is a PAM result code.
@@ -68,96 +74,120 @@ func errorCodeToPAMResult(errorCode string) PAMResultCode {
 	}
 }
 
+// syslog priorities, as syslog.h defines them. The C bridge takes the raw int.
+const (
+	logErr    = 3 // LOG_ERR
+	logNotice = 5 // LOG_NOTICE
+	logInfo   = 6 // LOG_INFO
+)
+
 // PAMModule represents the PAM module interface
 type PAMModule struct {
 	socketPath string
 	debug      atomic.Bool
+
+	// AuthTimeout bounds the wait for the user to complete the device flow.
+	// Zero means brokerclient.DefaultAuthTimeout.
+	AuthTimeout time.Duration
 }
 
 // NewPAMModule creates a new PAM module instance
 func NewPAMModule(socketPath string, debug bool) *PAMModule {
-	m := &PAMModule{socketPath: socketPath}
+	m := &PAMModule{socketPath: socketPath, AuthTimeout: brokerclient.DefaultAuthTimeout}
 	m.debug.Store(debug)
 	return m
 }
 
-// AuthenticateUser handles user authentication through the broker
+// AuthenticateUser handles user authentication through the broker, waiting for
+// the device authorization flow to complete.
+//
+// A nil return means the user authenticated. A *PAMAuthFailure means the login
+// was refused — including when the user simply never completed the device flow —
+// and carries the PAM result code the caller should return. Any other error means
+// the broker could not be reached or understood, which is PAM_AUTHINFO_UNAVAIL
+// territory: no opinion, rather than a grant.
 func (p *PAMModule) AuthenticateUser(username, service, rhost, tty string) error {
-	// Convert Go strings to C strings
-	cUsername := C.CString(username)
-	cService := C.CString(service)
-	cRhost := C.CString(rhost)
-	cTTY := C.CString(tty)
-	cSocketPath := C.CString(p.socketPath)
+	return p.AuthenticateUserContext(context.Background(), username, service, rhost, tty)
+}
 
-	// Ensure C strings are freed
-	defer C.free(unsafe.Pointer(cUsername))
-	defer C.free(unsafe.Pointer(cService))
-	defer C.free(unsafe.Pointer(cRhost))
-	defer C.free(unsafe.Pointer(cTTY))
-	defer C.free(unsafe.Pointer(cSocketPath))
+// AuthenticateUserContext is AuthenticateUser with a caller-supplied context;
+// cancelling it abandons the wait for device authorization.
+func (p *PAMModule) AuthenticateUserContext(ctx context.Context, username, service, rhost, tty string) error {
+	client := brokerclient.New(p.socketPath)
 
-	// Connect to broker
-	sock := C.connect_to_broker(cSocketPath)
-	if sock == -1 {
-		return fmt.Errorf("failed to connect to authentication broker")
-	}
-	defer C.close(sock)
-
-	// Send authentication request
-	if C.send_auth_request(sock, cUsername, cService, cRhost, cTTY) != 0 {
-		return fmt.Errorf("failed to send authentication request")
+	// Surface the verification URL and user code. This is the only chance the
+	// user gets to learn where to authenticate, so it goes to syslog at
+	// LOG_NOTICE regardless of debug mode.
+	client.OnDeviceFlow = func(resp *brokerclient.Response) {
+		if resp.Instructions != "" {
+			p.LogMessage(logNotice, resp.Instructions)
+		}
+		if resp.DeviceURL != "" {
+			p.LogMessage(logNotice, fmt.Sprintf("OIDC authentication: visit %s", resp.DeviceURL))
+		}
+		if resp.DeviceCode != "" {
+			p.LogMessage(logNotice, fmt.Sprintf("OIDC authentication: enter code %s", resp.DeviceCode))
+		}
 	}
 
-	// Receive and parse the broker response. Buffer matches the C module's
-	// MAX_RESPONSE_SIZE (8192) so large success responses are not truncated.
-	var response [8192]C.char
-	if C.receive_auth_response(sock, &response[0], C.size_t(len(response))) != 0 {
-		return fmt.Errorf("failed to receive authentication response")
+	timeout := p.AuthTimeout
+	if timeout <= 0 {
+		timeout = brokerclient.DefaultAuthTimeout
 	}
 
-	authResp, err := ParseBrokerResponse(C.GoString(&response[0]))
+	resp, err := client.AuthenticateAndWait(ctx, &brokerclient.Request{
+		UserID:     username,
+		TargetHost: rhost,
+		LoginType:  GetLoginType(service, tty),
+		Metadata: map[string]interface{}{
+			"service": service,
+			"tty":     tty,
+			"pid":     os.Getpid(),
+		},
+	}, timeout)
 	if err != nil {
-		return fmt.Errorf("failed to parse broker response: %w", err)
+		return p.authFailure(err)
 	}
 
-	// When device flow is required, surface the device URL and user code so
-	// the user knows where to authenticate. Messages are sent to syslog and
-	// (where supported) to the PAM conversation.
-	if authResp.RequiresDevice {
-		if authResp.DeviceURL != "" {
-			p.LogMessage(5 /* LOG_NOTICE */, fmt.Sprintf("OIDC authentication: visit %s", authResp.DeviceURL))
-		}
-		if authResp.DeviceCode != "" {
-			p.LogMessage(5 /* LOG_NOTICE */, fmt.Sprintf("OIDC authentication: enter code %s", authResp.DeviceCode))
-		}
-		// Device flow initiated; the PAM stack will poll via check_session.
-		return nil
+	if resp.Instructions != "" {
+		p.LogMessage(logInfo, resp.Instructions)
 	}
+	return nil
+}
 
-	if !authResp.Success {
-		msg := authResp.ErrorMessage
+// authFailure turns a brokerclient error into the error contract described on
+// AuthenticateUser, logging it on the way out.
+func (p *PAMModule) authFailure(err error) error {
+	var denial *brokerclient.DenialError
+	if errors.As(err, &denial) {
+		msg := denial.Message
 		if msg == "" {
 			msg = "authentication failed"
 		}
-		// Log the error so it appears in system logs; include error code in
-		// debug mode to aid troubleshooting.
-		if p.debug.Load() && authResp.ErrorCode != "" {
-			p.LogMessage(3 /* LOG_ERR */, fmt.Sprintf("OIDC authentication failed: %s (%s)", msg, authResp.ErrorCode))
+		if p.debug.Load() && denial.ErrorCode != "" {
+			p.LogMessage(logErr, fmt.Sprintf("OIDC authentication failed: %s (%s)", msg, denial.ErrorCode))
 		} else {
-			p.LogMessage(3 /* LOG_ERR */, fmt.Sprintf("OIDC authentication failed: %s", msg))
+			p.LogMessage(logErr, fmt.Sprintf("OIDC authentication failed: %s", msg))
 		}
 		return &PAMAuthFailure{
-			Code:    errorCodeToPAMResult(authResp.ErrorCode),
+			Code:    errorCodeToPAMResult(denial.ErrorCode),
 			Message: msg,
 		}
 	}
 
-	if authResp.Instructions != "" {
-		p.LogMessage(6 /* LOG_INFO */, authResp.Instructions)
+	var timeout *brokerclient.TimeoutError
+	if errors.As(err, &timeout) {
+		p.LogMessage(logErr, fmt.Sprintf("OIDC authentication failed: %s", timeout))
+		return &PAMAuthFailure{
+			Code:    PAMAuthError,
+			Message: timeout.Error(),
+		}
 	}
 
-	return nil
+	// Could not reach an opinion: leave it to the caller to translate into
+	// PAM_AUTHINFO_UNAVAIL rather than reporting a denial we did not observe.
+	p.LogMessage(logErr, fmt.Sprintf("OIDC authentication unavailable: %v", err))
+	return err
 }
 
 // LogMessage logs a message through the PAM logging system


### PR DESCRIPTION
Fixes #121

**Stacked on #131** (base is `fix/pam-device-flow-bypass`, not `main`). Review that one first; this PR's diff is only its own commit.

## The bug

`PAMModule.AuthenticateUser` returned nil as soon as the broker answered `success: true` — which `Broker.Authenticate` does the moment it *starts* the device authorization flow, alongside `requires_device: true`. Nothing waited for the user to visit the verification URL, and nothing waited for identity binding (`username_claim`) or `require_groups`, both of which run afterwards in a background goroutine. `cmd/pam-helper` then exited 0, so a `pam_exec`-style integration granted the login on an identity nobody had proved.

This is #120 on the other client path. #131 fixed the C module; without this, the Go path is still open.

## What changed

**New `internal/brokerclient`** — the broker IPC protocol and the device-flow completion logic in one place, **pure Go, no cgo**. That is the point: the equivalent logic in `cgo_bridge.c` can only be compiled and tested on a machine with PAM headers, so it went five releases without a test. This package is exercised by `go test` on every platform.

- dials per request, because the broker serves exactly one request per connection and then closes — a client that reuses the connection cannot pass the tests
- polls `check_session` carrying `user_id` (the broker answers `FORBIDDEN` when it does not match the session owner)
- honours `metadata.polling_interval`, clamped to [1, 60] s so a missing or malformed value is neither a busy loop nor an unbounded wait
- shortens the final sleep to whatever remains, so the wait never overshoots its budget
- distinguishes a broker **decision** (`DenialError`, `TimeoutError` — both denials) from a **failure to obtain one** (transport/parse errors). Only the latter becomes `PAM_AUTHINFO_UNAVAIL`; an unfinished flow is never a success.

**`pkg/pam/pam.go`** — `AuthenticateUser` delegates to it (via a new `AuthenticateUserContext`), logging the verification URL and code through the existing syslog bindings, and returns `*PAMAuthFailure` on refusal and on an exhausted timeout.

**`cmd/pam-helper/main.go`** — `-timeout` now bounds the authentication itself (default 90 s, matching the module's `timeout=`); the outer watchdog fires 10 s later, so running out of budget is reported as a denial rather than the process being killed mid-flow.

**Login-type classification** — the C module and the Go client disagreed, so the broker could apply different per-login-type policy to the same login depending on which client ran. C matched `gdm`/`lightdm` as *substrings*, never matched `sddm`, and tested the TTY before the service (so a display manager on `tty1` came out `console`). It is now one documented function, pinned to `GetLoginType` by a test over 14 service/TTY pairs.

## Tests

`internal/brokerclient/client_test.go` runs a fake broker on a Unix socket with a **virtual clock**, so a 30 s polling budget costs no wall-clock time and the elapsed time the loop observes is exactly what it asked for:

- **never completes → `*TimeoutError`, after exactly 7 requests** (1 authenticate + 6 polls at 5 s) — the headline regression test
- succeeds after approval; asserts `OnDeviceFlow` fired and every poll carried `type`, `session_id` and `user_id`
- terminal poll errors (`SESSION_NOT_FOUND`, `SESSION_EXPIRED`, `FORBIDDEN`, `DEVICE_FLOW_FAILED`, `POLICY_DENIED`) → denial, stopping at the first one
- an already-active session grants without polling
- five up-front refusals deny without a single poll; a refusal that *also* sets `requires_device` is still a refusal
- five transport failures (no broker, malformed JSON, closed without a reply, device flow with no `session_id`, broker gone by poll time) are **not** reported as denials
- context cancellation, poll-interval clamping (7 cases), and no budget overshoot (elapsed == exactly 30 s)

## Verification

`make verify-linux` (vet + `go test -race` + golangci-lint on `./...`, in the container, since the cgo packages cannot build on macOS):

```
ok  github.com/scttfrdmn/oidc-pam/pkg/pam               33.060s
ok  github.com/scttfrdmn/oidc-pam/internal/brokerclient  1.018s
...
0 issues.
```
