### PR TITLE
fix(security): pam_sm_acct_mgmt has no opinion; stop rubber-stamping the account stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **High (#122): `pam_sm_acct_mgmt` rubber-stamped the account stack.** It
+  returned `PAM_SUCCESS` while performing no account-phase authorization at all,
+  and the shipped configs listed it as `account sufficient pam_oidc.so`. A
+  `sufficient` module that succeeds ends the phase, so that combination silently
+  disabled every account check after it — `pam_time`, `pam_nologin`,
+  `pam_access`, account expiry, `pam_unix`'s shadow checks — for every user. It
+  now returns `PAM_IGNORE`: PAM does not count an ignored module toward the
+  stack's result, so the modules after it decide, and a stack where *every*
+  module ignores yields `PAM_PERM_DENIED` rather than admitting everyone.
 - **Critical (#121): the Go client path also treated device-flow initiation as
   authentication success.** `PAMModule.AuthenticateUser` returned nil as soon as
   the broker replied `success: true`, which it does the moment it *starts* the
@@ -65,6 +74,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OpenPAM.
 
 ### Fixed (BREAKING for PAM configs)
+- **(#122)** The example configs (`configs/pam/{ssh,login,su,sudo}`, the
+  DEPLOYMENT.md snippets, `test-projects/ssh-server`) now use `account optional
+  pam_oidc.so` and `password optional pam_oidc.so`. **Existing `/etc/pam.d/*`
+  files that say `account sufficient pam_oidc.so` should be changed to
+  `optional`**: with the `PAM_IGNORE` fix above such a line no longer
+  short-circuits, but as written it still advertises an authorization the module
+  does not perform. `password` is `optional` because `pam_sm_chauthtok` returns
+  `PAM_AUTHTOK_ERR` (change passwords at the IdP) and as `required` would block
+  password changes for local accounts too.
+- **(#122)** Removed unreachable `auth required pam_unix.so` / `auth optional
+  pam_group.so` lines that followed `auth requisite pam_deny.so` in the `ssh`,
+  `su`, `sudo` and ssh-server-test configs, and corrected the comments — in
+  several places the docs described that dead line as the emergency Unix
+  fallback. `requisite` returns to the application immediately, so nothing after
+  `pam_deny.so` ever runs: those stacks are OIDC-only. `configs/pam/README.md`
+  and DEPLOYMENT.md now explain the phase semantics, how to enable a real
+  fallback and what it costs, and why SSH public keys are the usual break-glass
+  path.
 - **(#119) `pam_oidc.so` connected to the wrong socket and ignored its module
   arguments.** The compiled-in `SOCKET_PATH` was
   `/var/run/oidc-auth-broker.sock` while the broker listens on

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -344,12 +344,13 @@ monitoring:
 
 #### SSH Configuration (`/etc/pam.d/ssh`)
 ```bash
-# Production SSH PAM configuration
+# Production SSH PAM configuration.
+# Nothing may follow `requisite pam_deny.so`: it returns immediately, so this
+# stack is OIDC-only. See "PAM stack semantics" below before changing it.
 auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass
 
-account sufficient  pam_oidc.so
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 
@@ -364,9 +365,8 @@ session optional    pam_env.so
 # Production sudo PAM configuration
 auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass
 
-account sufficient  pam_oidc.so
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
@@ -375,6 +375,43 @@ session required    pam_unix.so
 session optional    pam_oidc.so
 session optional    pam_systemd.so
 ```
+
+#### PAM stack semantics
+
+**All authorization happens in the `auth` phase.** `pam_sm_authenticate` is where
+the module talks to the broker, and the broker is where identity binding
+(`username_claim`), `require_groups`, risk policy and session limits are
+enforced. If the auth phase returns success, the user is authorized.
+
+**`pam_oidc.so` has no `account`-phase opinion** and returns `PAM_IGNORE` there —
+PAM does not count an ignored module toward the stack's result, so the account
+modules after it decide. Two consequences:
+
+- Use **`account optional pam_oidc.so`**, never `account sufficient`. A
+  `sufficient` module that returns success short-circuits the rest of the account
+  stack; earlier versions of this module returned `PAM_SUCCESS`, so `account
+  sufficient pam_oidc.so` silently disabled every account check after it —
+  `pam_time`, `pam_nologin`, `pam_access`, account expiry, `pam_unix`'s shadow
+  checks. If your `/etc/pam.d/*` still says `account sufficient pam_oidc.so`,
+  change it.
+- **Keep a real account module in the stack.** With `pam_oidc.so` as the only
+  account module, every module ignores and Linux-PAM returns
+  `PAM_PERM_DENIED` — it fails closed rather than admitting everyone, but the
+  account phase then decides nothing useful. The examples above pair it with
+  `pam_unix.so` and `pam_access.so`.
+
+**`password`** likewise: the module cannot change a password (change it at the
+identity provider) and returns `PAM_AUTHTOK_ERR`. List it as `optional` so it
+does not block password changes for local accounts.
+
+**Nothing may follow `requisite pam_deny.so`.** `requisite` returns to the
+application immediately on failure, so a `pam_unix.so` line after it is dead
+configuration, not an emergency fallback. To allow Unix passwords when the broker
+or IdP is unavailable, remove `pam_deny.so` and let `pam_unix.so` decide —
+accepting that a user with a local password then bypasses all OIDC policy. The
+more common arrangement is to leave this stack OIDC-only and keep SSH public-key
+access as the break-glass path, since sshd's pubkey authentication does not
+consult the PAM auth stack at all.
 
 ### 4. System Service Configuration
 

--- a/configs/pam/README.md
+++ b/configs/pam/README.md
@@ -90,6 +90,68 @@ auth    required    pam_oidc.so
 auth    sufficient  pam_oidc.so debug
 ```
 
+## Which PAM phases the module participates in
+
+`pam_oidc.so` implements one decision, in the `auth` phase. Everything the
+module is for — talking to the broker, which enforces identity binding
+(`username_claim`), `require_groups`, risk policy and session limits — happens in
+`pam_sm_authenticate`. The other phases are listed below with the control flag to
+use and why.
+
+| Phase | Use | What the module does |
+|---|---|---|
+| `auth` | `sufficient` or `required` | The real decision. Runs the device flow, waits for it, and returns success only once the broker has authorized the login. |
+| `account` | **`optional`** | Nothing: returns `PAM_IGNORE`. |
+| `session` | `optional` | Logs session open/close. No decision. |
+| `password` | `optional` | Cannot change a password; returns `PAM_AUTHTOK_ERR`. |
+
+### Why `account optional`, never `account sufficient`
+
+The module returns `PAM_IGNORE` from `pam_sm_acct_mgmt` — "I have no opinion" —
+so PAM does not count it toward the account stack's result and the modules after
+it decide.
+
+Earlier versions returned `PAM_SUCCESS` instead, and the example configs used
+`account sufficient pam_oidc.so`. A `sufficient` module that succeeds
+short-circuits the rest of the phase, so that combination silently disabled every
+account check after it: `pam_time`, `pam_nologin`, `pam_access`, account expiry,
+`pam_unix`'s shadow checks. The module was answering a question it never asked,
+and rubber-stamping the account phase for every user. **If your `/etc/pam.d/*`
+files still say `account sufficient pam_oidc.so`, change them to `optional`.**
+
+Keep at least one real account module in the stack. If `pam_oidc.so` is the only
+one, every module ignores and Linux-PAM returns `PAM_PERM_DENIED`: it fails
+closed rather than admitting everyone, but nothing useful is being checked. The
+shipped configs pair it with `pam_unix.so` plus `pam_access.so`/`pam_time.so`.
+
+### Nothing may follow `requisite pam_deny.so`
+
+`requisite` returns to the application immediately on failure, so in
+
+```
+auth    sufficient  pam_oidc.so
+auth    requisite   pam_deny.so
+auth    required    pam_unix.so try_first_pass   # never reached
+```
+
+the third line is dead configuration, not an emergency fallback — the shipped
+`ssh`, `su` and `sudo` examples used to carry exactly that line and describe it as
+one. These stacks are OIDC-only: if OIDC authentication fails, the login is
+refused.
+
+To allow Unix passwords when the broker or IdP is unavailable, drop
+`pam_deny.so`:
+
+```
+auth    sufficient  pam_oidc.so
+auth    required    pam_unix.so try_first_pass nullok_secure
+```
+
+The trade-off is real: a user with a local password then bypasses every OIDC
+policy. The usual alternative is to keep the stack OIDC-only and rely on SSH
+public-key authentication as the break-glass path, since sshd's pubkey path does
+not consult the PAM auth stack at all.
+
 ## PAM Module Parameters
 
 `pam_oidc.so` accepts exactly three arguments:

--- a/configs/pam/login
+++ b/configs/pam/login
@@ -14,7 +14,7 @@ auth    required    pam_unix.so try_first_pass nullok_secure
 auth    optional    pam_group.so
 
 # Account management
-account sufficient  pam_oidc.so
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_nologin.so
@@ -29,7 +29,7 @@ session optional    pam_motd.so
 session optional    pam_mail.so standard
 
 # Password management (disabled for OIDC)
-password sufficient pam_oidc.so
+password optional   pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:

--- a/configs/pam/ssh
+++ b/configs/pam/ssh
@@ -1,19 +1,25 @@
 # PAM Configuration for SSH with OIDC Authentication
 # This file should be placed at /etc/pam.d/ssh (or /etc/pam.d/sshd on some systems)
 # 
-# This configuration enables OIDC authentication for SSH login while maintaining
-# fallback to traditional authentication methods for emergency access.
+# This configuration is OIDC-ONLY: if OIDC authentication fails, the login is
+# refused. It does not fall back to Unix passwords -- see EMERGENCY ACCESS below
+# for how to keep a way in, and AUTHENTICATION FALLBACK for how to enable one.
 #
 # IMPORTANT: Test this configuration thoroughly before deploying to production!
 # Always maintain a backup authentication method for emergency access.
 
-# Authentication stack
+# Authentication stack.
+# 'sufficient' means a successful OIDC authentication ends the auth phase here;
+# 'requisite pam_deny.so' means anything else is refused immediately. Nothing can
+# follow pam_deny.so -- a pam_unix.so line here would never be reached.
 auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass nullok_secure
 
-# Account management
-account sufficient  pam_oidc.so
+# Account management.
+# pam_oidc.so has no account-phase opinion (it returns PAM_IGNORE); authorization
+# is decided in the auth phase by the broker. It is listed as 'optional' only so
+# the account phase is logged -- the modules below are what actually decide.
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 
@@ -23,16 +29,29 @@ session optional    pam_oidc.so
 session optional    pam_systemd.so
 session optional    pam_lastlog.so
 
-# Password management (disabled for OIDC)
-password sufficient pam_oidc.so
+# Password management. pam_oidc.so cannot change a password -- change it at the
+# identity provider. It returns PAM_AUTHTOK_ERR, so keep it 'optional': as
+# 'required' it would block password changes for every user, including local ones.
+password optional   pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:
 # 1. The 'sufficient' control means if pam_oidc.so succeeds, no further auth modules are tried
-# 2. The 'requisite' pam_deny.so provides a security barrier
-# 3. The 'required' pam_unix.so provides fallback authentication
-# 4. Remove 'debug' from pam_oidc.so in production
-# 5. Ensure /etc/oidc-auth/broker.yaml is readable by the PAM module
+# 2. The 'requisite' pam_deny.so refuses everything else, and stops the stack
+# 3. Remove 'debug' from pam_oidc.so in production
+# 4. The module reads no configuration file; the broker reads
+#    /etc/oidc-auth/broker.yaml itself. The module only needs to reach the
+#    broker's socket (/var/run/oidc-auth/broker.sock by default).
+
+# AUTHENTICATION FALLBACK:
+# To allow Unix passwords when OIDC is unavailable, drop pam_deny.so and let
+# pam_unix.so decide -- with pam_deny.so present it is unreachable:
+#
+# auth    sufficient  pam_oidc.so
+# auth    required    pam_unix.so try_first_pass nullok_secure
+#
+# Note the trade-off: this also lets a user with a local password bypass every
+# OIDC policy (group requirements, risk rules, session limits).
 
 # SSH DAEMON CONFIGURATION:
 # Add these lines to /etc/ssh/sshd_config:
@@ -68,15 +87,17 @@ password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 # 4. Test both successful and failed authentication scenarios
 
 # SECURITY CONSIDERATIONS:
-# 1. This configuration allows fallback to Unix authentication
-# 2. For OIDC-only authentication, remove the pam_unix.so lines
+# 1. As shipped this configuration does NOT fall back to Unix authentication
+# 2. To add a fallback, see AUTHENTICATION FALLBACK above
 # 3. Consider using pam_access.so for additional access controls
 # 4. Monitor /var/log/auth.log for authentication events
 # 5. Implement proper group-based access controls in OIDC provider
 
 # EMERGENCY ACCESS:
-# If OIDC authentication fails, users can still authenticate via:
-# 1. Unix password authentication (if enabled)
-# 2. SSH public key authentication
-# 3. Console access (physical or virtual)
-# 4. Recovery user account with traditional authentication
+# This stack refuses the login when OIDC authentication fails, so arrange a way
+# in that does not go through it BEFORE deploying:
+# 1. SSH public key authentication (sshd's pubkey path does not consult this
+#    stack at all) -- the most reliable option
+# 2. Console access (physical or virtual), which uses /etc/pam.d/login
+# 3. A recovery account, reached via a service whose PAM stack keeps pam_unix
+# 4. Unix password authentication, only if you enabled the fallback above

--- a/configs/pam/su
+++ b/configs/pam/su
@@ -11,11 +11,11 @@
 auth    sufficient  pam_rootok.so
 auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass nullok_secure
-auth    optional    pam_group.so
 
-# Account management
-account sufficient  pam_oidc.so
+# Account management. pam_oidc.so returns PAM_IGNORE here -- it has no
+# account-phase opinion, and authorization is decided in the auth phase by the
+# broker. The modules below are what actually decide.
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
@@ -27,8 +27,9 @@ session optional    pam_systemd.so
 session optional    pam_env.so
 session optional    pam_limits.so
 
-# Password management (disabled for OIDC)
-password sufficient pam_oidc.so
+# Password management. pam_oidc.so cannot change a password (change it at the
+# identity provider); it returns PAM_AUTHTOK_ERR, so keep it 'optional'.
+password optional   pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:
@@ -82,7 +83,8 @@ password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 # EMERGENCY ACCESS:
 # If OIDC authentication fails, maintain emergency access via:
 # 1. Root account can always su without authentication (pam_rootok.so)
-# 2. Traditional Unix authentication as fallback
+# 2. A service whose PAM stack still consults pam_unix.so (this one does not:
+#    the requisite pam_deny.so above refuses anything OIDC did not accept)
 # 3. Emergency admin account with Unix password
 # 4. Single-user mode boot for system recovery
 # 5. SSH root access with public key authentication

--- a/configs/pam/sudo
+++ b/configs/pam/sudo
@@ -10,11 +10,11 @@
 # Authentication stack
 auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass
-auth    optional    pam_group.so
 
-# Account management
-account sufficient  pam_oidc.so
+# Account management. pam_oidc.so returns PAM_IGNORE here -- it has no
+# account-phase opinion, and authorization is decided in the auth phase by the
+# broker. The modules below are what actually decide.
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
@@ -26,8 +26,9 @@ session optional    pam_systemd.so
 session optional    pam_env.so
 session optional    pam_limits.so
 
-# Password management (disabled for OIDC)
-password sufficient pam_oidc.so
+# Password management. pam_oidc.so cannot change a password (change it at the
+# identity provider); it returns PAM_AUTHTOK_ERR, so keep it 'optional'.
+password optional   pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 
 # CONFIGURATION NOTES:
@@ -116,7 +117,8 @@ password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 # 2. Root account access via console
 # 3. SSH root access with public key authentication
 # 4. Single-user mode boot for system recovery
-# 5. Traditional Unix authentication as fallback
+# 5. A service whose PAM stack still consults pam_unix.so (this one does not:
+#    the requisite pam_deny.so above refuses anything OIDC did not accept)
 
 # INTEGRATION WITH EXTERNAL SYSTEMS:
 # Consider integrating with external approval systems:

--- a/pkg/pam/cgo_auth.go
+++ b/pkg/pam/cgo_auth.go
@@ -51,3 +51,8 @@ func classifyLoginTypeC(service, tty string) string {
 
 	return C.GoString(C.classify_login_type(cService, cTTY))
 }
+
+// acctMgmtVerdict exposes the C module's account-phase verdict to Go tests.
+func acctMgmtVerdict() PAMResultCode {
+	return PAMResultCode(C.acct_mgmt_verdict())
+}

--- a/pkg/pam/cgo_bridge.c
+++ b/pkg/pam/cgo_bridge.c
@@ -762,6 +762,32 @@ PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const cha
     return PAM_SUCCESS;
 }
 
+// The module's account-phase verdict, which is "no opinion".
+//
+// Authorization is enforced entirely in the auth phase (pam_sm_authenticate ->
+// broker: identity binding, group membership, risk policy). This module has
+// nothing to add in the account phase, so it returns PAM_IGNORE rather than
+// PAM_SUCCESS.
+//
+// The distinction matters. PAM_SUCCESS from a module marked `sufficient`
+// short-circuits the rest of the account stack, so `account sufficient
+// pam_oidc.so` — which these example configs used to ship — silently disabled
+// every account check after it: pam_time, pam_nologin, pam_access, account
+// expiry, pam_unix's shadow checks. Answering a question it was never asked let
+// pam_oidc rubber-stamp the account phase for every user.
+//
+// PAM_IGNORE is not counted toward the stack's result at all, so the modules
+// after it decide. If pam_oidc is the *only* account module, an all-ignored
+// stack yields PAM_PERM_DENIED: it fails closed rather than admitting everyone.
+// The shipped configs use `account optional pam_oidc.so` alongside a real account
+// module; see configs/pam/README.md.
+//
+// This is a separate function so a Go test can pin the value — see
+// TestAcctMgmtHasNoOpinion.
+int acct_mgmt_verdict(void) {
+    return PAM_IGNORE;
+}
+
 // PAM account management function
 PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv) {
     const char *username;
@@ -782,12 +808,7 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const c
     
     log_pam_message(LOG_DEBUG, "Account management check for user: %s", username);
 
-    // L-5: Authorization is enforced entirely in the auth phase (pam_sm_authenticate
-    // -> broker: identity binding, group checks, risk policy). This module does NOT
-    // implement account-phase (acct_mgmt) authorization, so deployments MUST NOT
-    // rely on the PAM `account` stack with pam_oidc as the sole gate. Returning
-    // PAM_SUCCESS here is intentional and documented; see DEPLOYMENT.md.
-    return PAM_SUCCESS;
+    return acct_mgmt_verdict();
 }
 
 // PAM session open function

--- a/pkg/pam/cgo_bridge.h
+++ b/pkg/pam/cgo_bridge.h
@@ -61,6 +61,7 @@ void log_pam_message_string(int priority, const char *message);
 int connect_to_broker(const char *socket_path);
 int get_user_info(pam_handle_t *pamh, const char **username, const char **service, const char **rhost, const char **tty);
 const char *classify_login_type(const char *service, const char *tty);
+int acct_mgmt_verdict(void);
 int send_auth_request(int sock, const char *username, const char *service, const char *rhost, const char *tty);
 int send_check_session_request(int sock, const char *session_id, const char *username);
 int receive_auth_response(int sock, char *response, size_t response_size);

--- a/pkg/pam/device_flow_test.go
+++ b/pkg/pam/device_flow_test.go
@@ -410,3 +410,24 @@ func TestLoginTypeClassificationMatchesGo(t *testing.T) {
 		})
 	}
 }
+
+// TestAcctMgmtHasNoOpinion pins pam_sm_acct_mgmt's return value. The module
+// performs no account-phase authorization — the broker decides during the auth
+// phase — so it must answer PAM_IGNORE ("no opinion"), never PAM_SUCCESS.
+//
+// This is a regression test for a real misconfiguration hazard: PAM_SUCCESS from a
+// module marked `sufficient` short-circuits the rest of the account stack, and the
+// shipped configs used `account sufficient pam_oidc.so`. Together they disabled
+// every account check that followed — pam_time, pam_nologin, pam_access, account
+// expiry, pam_unix's shadow checks — for every user.
+func TestAcctMgmtHasNoOpinion(t *testing.T) {
+	got := acctMgmtVerdict()
+
+	if got == PAMSuccess {
+		t.Fatal("pam_sm_acct_mgmt returns PAM_SUCCESS: with `account sufficient pam_oidc.so` " +
+			"that short-circuits every account module after it")
+	}
+	if got != PAMIgnore {
+		t.Errorf("pam_sm_acct_mgmt returned %d, want PAM_IGNORE (%d)", got, PAMIgnore)
+	}
+}

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -36,6 +36,11 @@ const (
 	PAMAuthError       PAMResultCode = C.PAM_AUTH_ERR
 	PAMAuthInfoUnavail PAMResultCode = C.PAM_AUTHINFO_UNAVAIL
 	PAMMaxTries        PAMResultCode = C.PAM_MAXTRIES
+
+	// PAMIgnore means "this module has no opinion". PAM does not count it
+	// toward the stack's result, so unlike PAMSuccess it cannot short-circuit a
+	// `sufficient` entry.
+	PAMIgnore PAMResultCode = C.PAM_IGNORE
 )
 
 // PAMAuthFailure is returned by AuthenticateUser when the broker reports a

--- a/test-projects/ssh-server/README.md
+++ b/test-projects/ssh-server/README.md
@@ -101,11 +101,13 @@ The SSH server is configured with:
 
 ```bash
 # /etc/pam.d/sshd
+# OIDC-only: nothing may follow `requisite pam_deny.so`, which returns to sshd
+# immediately. pam_oidc.so returns PAM_IGNORE in the account phase, so it is
+# `optional` there and pam_unix/pam_access are what actually decide.
 auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass
 
-account sufficient  pam_oidc.so
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 

--- a/test-projects/ssh-server/docker/ssh-server/pam.d/sshd
+++ b/test-projects/ssh-server/docker/ssh-server/pam.d/sshd
@@ -1,14 +1,16 @@
 # PAM configuration for SSH daemon with OIDC authentication
 # This configuration enables OIDC authentication via the PAM module
 
-# Authentication stack
+# Authentication stack. OIDC-only: a successful OIDC authentication ends the auth
+# phase, and pam_deny.so refuses everything else. Nothing may follow pam_deny.so
+# -- it returns immediately, so any module listed after it never runs.
 auth    sufficient  pam_oidc.so debug
 auth    requisite   pam_deny.so
-auth    required    pam_unix.so try_first_pass nullok_secure
-auth    optional    pam_group.so
 
-# Account management
-account sufficient  pam_oidc.so
+# Account management. pam_oidc.so returns PAM_IGNORE -- it has no account-phase
+# opinion; the broker decides authorization during the auth phase. The modules
+# below are what actually decide.
+account optional    pam_oidc.so
 account required    pam_unix.so
 account required    pam_access.so
 account required    pam_time.so
@@ -28,6 +30,7 @@ session optional    pam_lastlog.so
 session optional    pam_motd.so
 session optional    pam_mail.so standard
 
-# Password management (disabled for OIDC)
-password sufficient pam_oidc.so
+# Password management. pam_oidc.so cannot change a password; it returns
+# PAM_AUTHTOK_ERR, so it is 'optional' rather than 'required'.
+password optional   pam_oidc.so
 password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok


### PR DESCRIPTION
Fixes #122

**Stacked on #132** (base is `fix/go-client-device-flow`). Review that one first; this PR's diff is only its own commit.

## The bug

`pam_sm_acct_mgmt` did no account-phase authorization — that is all done in the auth phase, by the broker — but it returned `PAM_SUCCESS`, and the shipped example configs listed the module as:

```
account sufficient  pam_oidc.so
account required    pam_unix.so
account required    pam_access.so
account required    pam_time.so
```

A `sufficient` module that returns success **ends the phase**. So every account check after that line never ran: `pam_time`, `pam_nologin`, `pam_access`, account expiry, `pam_unix`'s shadow checks. Time-of-day restrictions, `/etc/nologin`, network restrictions in `access.conf`, expired accounts — all silently bypassed for every user, on `ssh`, `login`, `su` and `sudo` alike. The module was answering a question it was never asked.

## The fix

`PAM_IGNORE`. That is the honest answer for a module with no account-phase opinion: PAM does not count an ignored module toward the stack's result, so the modules after it decide, and unlike `PAM_SUCCESS` it cannot short-circuit a `sufficient` entry. If `pam_oidc.so` were the *only* account module, an all-ignored stack yields `PAM_PERM_DENIED` — it fails closed rather than admitting everyone.

The verdict is its own function (`acct_mgmt_verdict`) so `TestAcctMgmtHasNoOpinion` can pin it, with an explicit failure message if it ever regresses to `PAM_SUCCESS`. `PAMIgnore` was also added to the `PAMResultCode` constants, derived from the header like the rest.

## Config changes

- `account sufficient pam_oidc.so` → **`account optional`** in `configs/pam/{ssh,login,su,sudo}`, the DEPLOYMENT.md snippets, `test-projects/ssh-server/{README.md,docker/ssh-server/pam.d/sshd}`. With the `PAM_IGNORE` fix a `sufficient` line no longer short-circuits, but as written it still advertises an authorization the module does not perform.
- `password sufficient` → **`password optional`**: `pam_sm_chauthtok` returns `PAM_AUTHTOK_ERR` (change passwords at the IdP), and as `required` it would block password changes for local accounts too.

## The fake fallback

Four of these configs carried

```
auth    sufficient  pam_oidc.so
auth    requisite   pam_deny.so
auth    required    pam_unix.so try_first_pass    # <- never reached
auth    optional    pam_group.so                  # <- never reached
```

`requisite` returns to the application **immediately** on failure, so nothing after `pam_deny.so` runs. The comments in `configs/pam/ssh`, `su` and `sudo` nonetheless described that line as the emergency Unix fallback ("EMERGENCY ACCESS: ... 1. Unix password authentication"), which is the kind of thing an operator only discovers when they need it. The dead lines are gone and the comments corrected: these stacks are OIDC-only, and if OIDC fails the login is refused.

`configs/pam/README.md` gains a per-phase table plus two sections — why `account optional` and never `sufficient`, and why nothing may follow `pam_deny.so` — including the exact edit to enable a genuine Unix fallback and the trade-off it carries (a user with a local password then bypasses every OIDC policy). DEPLOYMENT.md gains a matching "PAM stack semantics" section. Both point out that sshd's public-key path does not consult the PAM auth stack at all, which is why it is the usual break-glass route.

`configs/pam/login` was left as-is on this point: there the `requisite` module is `pam_nologin.so`, which normally succeeds, so its `pam_unix.so` line is genuinely reachable.

## Verification

`make verify-linux` (vet + `go test -race` + golangci-lint on `./...` in the container):

```
ok  github.com/scttfrdmn/oidc-pam/pkg/pam  34.078s
...
0 issues.
```
