### PR TITLE
fix(auth): store tokens in the encrypted TokenManager, not on the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **(#123): OAuth2 refresh tokens were held in plaintext on every session; the
+  encrypted `TokenManager` was never called.** `NewTokenManager` was constructed
+  and started, and `StoreToken` encrypts with AES-256-GCM, but no broker code
+  path ever stored a token — so the documented "AES-256 encryption for token
+  storage" applied to an empty store, while the real credentials sat in
+  `Session.RefreshToken` as plaintext strings in a struct that is copied and
+  passed around freely. The broker now stores tokens through the token manager
+  and keeps only `Session.TokenID`; `RefreshSession` decrypts the refresh token
+  for the duration of the call, stores the rotated token and revokes the
+  pre-refresh entry. A structural test fails if any token-bearing field is added
+  back to `Session`.
+- **(#123)** Revoked and expired sessions now destroy their stored tokens
+  (`RevokeSessionTokens`). Previously the session was dropped while its tokens
+  stayed in the store until the tokens themselves expired — which can be well
+  after the session, and a refresh token outlives the access token it renews. A
+  refused cross-user revocation leaves the owner's tokens intact.
 - **High (#122): `pam_sm_acct_mgmt` rubber-stamped the account stack.** It
   returned `PAM_SUCCESS` while performing no account-phase authorization at all,
   and the shipped configs listed it as `account sufficient pam_oidc.so`. A
@@ -138,6 +154,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `-Wall -Wextra` on the cgo `CFLAGS` for `pkg/pam` and `cmd/pam-module`, and
   `(void)` markers on the genuinely unused PAM entry-point parameters so the C
   bridge compiles warning-free.
+
+### Changed
+- **(#123)** `Session.RefreshToken` is replaced by `Session.TokenID`, and
+  `TokenManager.StoreToken` now returns the ID it generated. Both are internal
+  Go APIs (`pkg/auth`), not wire or config surface.
+
+### Removed
+- **(#123)** `TokenManager.RefreshToken`, a stub that validated its arguments and
+  then returned `"token refresh not implemented"`. Refresh is done by
+  `Broker.RefreshSession` via the provider; the stub had no callers and only
+  suggested a capability that did not exist.
 
 ### Fixed
 - **(#118)** `oidc-pam-helper -version` now prints the build date and git commit

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -56,13 +56,18 @@ type Session struct {
 	SourceIP         string
 	UserAgent        string
 	TokenFingerprint string
-	RefreshToken     string // OAuth2 refresh token for session renewal
-	SSHKeyID         string
-	SSHPublicKey     string
-	IsActive         bool
-	RiskScore        int
-	DeviceTrusted    bool
-	Metadata         map[string]interface{}
+	// TokenID identifies this session's entry in the TokenManager, which holds
+	// the access/refresh/ID tokens encrypted with AES-256-GCM. The tokens
+	// themselves are deliberately NOT fields on Session: Session is passed
+	// around, logged and copied, and a refresh token in it is a long-lived
+	// credential sitting in plaintext in the broker's heap.
+	TokenID       string
+	SSHKeyID      string
+	SSHPublicKey  string
+	IsActive      bool
+	RiskScore     int
+	DeviceTrusted bool
+	Metadata      map[string]interface{}
 }
 
 // AuthRequest represents an authentication request
@@ -494,7 +499,29 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 		}, nil
 	}
 
-	if session.RefreshToken == "" {
+	if session.TokenID == "" {
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "NO_REFRESH_TOKEN",
+			ErrorMessage: "No refresh token available for this session",
+		}, nil
+	}
+
+	// The refresh token lives encrypted in the token store; decrypt it only for
+	// the duration of this call rather than keeping a copy on the session.
+	storedToken, err := b.tokenManager.GetToken(session.TokenID)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("session_id", sessionID).
+			Msg("Session has no usable stored token; cannot refresh")
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "NO_REFRESH_TOKEN",
+			ErrorMessage: "No refresh token available for this session",
+		}, nil
+	}
+	if storedToken.RefreshToken == "" {
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "NO_REFRESH_TOKEN",
@@ -505,7 +532,7 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer refreshCancel()
 
-	newToken, err := provider.RefreshToken(refreshCtx, session.RefreshToken)
+	newToken, err := provider.RefreshToken(refreshCtx, storedToken.RefreshToken)
 	if err != nil {
 		b.auditLogger.LogAuthEvent(security.AuditEvent{
 			EventType:    "token_refresh_failed",
@@ -523,13 +550,40 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 		}, nil
 	}
 
+	// Store the refreshed token and point the session at it. The previous entry
+	// is revoked afterwards: a rotated refresh token is no longer usable, and
+	// leaving it in the store would keep dead credential material in memory.
+	newTokenID, err := b.tokenManager.StoreToken(newToken, session.UserID, sessionID)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("session_id", sessionID).
+			Msg("Failed to store refreshed token")
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "REFRESH_FAILED",
+			ErrorMessage: "Failed to store refreshed token",
+		}, nil
+	}
+
+	previousTokenID := session.TokenID
+
 	// Update session with new token data
 	session.TokenFingerprint = newToken.Fingerprint
-	session.RefreshToken = newToken.RefreshToken
+	session.TokenID = newTokenID
 	session.ExpiresAt = time.Now().Add(b.config.Authentication.TokenLifetime)
 	session.LastAccessed = time.Now()
 
 	b.setSession(session)
+
+	if previousTokenID != "" && previousTokenID != newTokenID {
+		if err := b.tokenManager.RevokeToken(previousTokenID); err != nil {
+			log.Debug().
+				Err(err).
+				Str("session_id", sessionID).
+				Msg("Could not revoke the pre-refresh token")
+		}
+	}
 
 	b.auditLogger.LogAuthEvent(security.AuditEvent{
 		EventType: "token_refreshed",
@@ -563,6 +617,16 @@ func (b *Broker) RevokeSession(sessionID, userID string) error {
 				Str("ssh_key_id", session.SSHKeyID).
 				Msg("Failed to revoke SSH key")
 		}
+	}
+
+	// Destroy the session's stored tokens. Dropping the session alone would leave
+	// its access and refresh tokens in the store until the 5-minute sweep, and a
+	// refresh token outlives the session it was issued for.
+	if err := b.tokenManager.RevokeSessionTokens(sessionID); err != nil {
+		log.Error().
+			Err(err).
+			Str("session_id", sessionID).
+			Msg("Failed to revoke stored tokens for session")
 	}
 
 	// Remove session
@@ -785,13 +849,40 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 				return
 			}
 
+			// Hand the tokens to the token manager, which encrypts them with
+			// AES-256-GCM, and keep only its ID on the session. The session must
+			// never carry the refresh token itself: it is a long-lived credential,
+			// and Session is copied, passed around and reachable from a heap dump.
+			tokenID, err := b.tokenManager.StoreToken(token, session.UserID, session.ID)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("session_id", session.ID).
+					Msg("Rejected authentication: could not store tokens securely")
+				if b.metrics != nil {
+					b.metrics.RecordAuth(provider.Name, "failure", "TOKEN_STORE_FAILED")
+				}
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType:    "authentication_denied",
+					UserID:       session.UserID,
+					Email:        userInfo.Email,
+					SessionID:    session.ID,
+					Success:      false,
+					ErrorCode:    "TOKEN_STORE_FAILED",
+					ErrorMessage: err.Error(),
+					Timestamp:    time.Now(),
+				})
+				b.removeSession(session.ID)
+				return
+			}
+
 			// Clone before mutation: getSession returns the raw pointer stored in
 			// the map; writing to it without a lock races with concurrent readers.
 			updated := *session
 			updated.Email = userInfo.Email
 			updated.Groups = userInfo.Groups
 			updated.TokenFingerprint = token.Fingerprint
-			updated.RefreshToken = token.RefreshToken
+			updated.TokenID = tokenID
 			updated.IsActive = true
 			updated.DeviceTrusted = userInfo.DeviceTrusted
 
@@ -850,58 +941,77 @@ func (b *Broker) sessionCleanup(ctx context.Context) {
 		case <-b.stopChan:
 			return
 		case <-ticker.C:
-			now := time.Now()
+			b.expireSessions(time.Now())
+		}
+	}
+}
 
-			// Atomically collect and remove expired sessions under a single write lock
-			// to avoid TOCTOU race between identifying and removing sessions.
-			var expiredSessions []*Session
-			idleTimeout := b.config.Authentication.IdleTimeout
-			b.sessionMutex.Lock()
-			for id, session := range b.sessions {
-				idleExpired := idleTimeout > 0 && time.Since(session.LastAccessed) > idleTimeout
-				if session.ExpiresAt.Before(now) || idleExpired {
-					expiredSessions = append(expiredSessions, session)
-					delete(b.sessions, id)
-				}
-			}
-			b.sessionMutex.Unlock()
+// expireSessions removes every session that has passed its expiry or idle
+// timeout as of now, and tears down what each one owned. Separate from the
+// ticker loop so it can be tested directly.
+func (b *Broker) expireSessions(now time.Time) {
+	// Atomically collect and remove expired sessions under a single write lock
+	// to avoid TOCTOU race between identifying and removing sessions.
+	var expiredSessions []*Session
+	idleTimeout := b.config.Authentication.IdleTimeout
+	b.sessionMutex.Lock()
+	for id, session := range b.sessions {
+		idleExpired := idleTimeout > 0 && now.Sub(session.LastAccessed) > idleTimeout
+		if session.ExpiresAt.Before(now) || idleExpired {
+			expiredSessions = append(expiredSessions, session)
+			delete(b.sessions, id)
+		}
+	}
+	b.sessionMutex.Unlock()
 
-			if b.metrics != nil {
-				for _, session := range expiredSessions {
-					if session.IsActive {
-						b.metrics.ActiveSessions.Dec()
-					}
-				}
-			}
-
-			// Perform SSH key revocation and audit logging outside the lock.
-			// Sessions are already removed from the map, so no TOCTOU risk.
-			for _, session := range expiredSessions {
-				if session.SSHKeyID != "" {
-					if err := b.revokeSSHKey(session); err != nil {
-						log.Error().
-							Err(err).
-							Str("session_id", session.ID).
-							Str("ssh_key_id", session.SSHKeyID).
-							Msg("Failed to revoke SSH key for expired session")
-					}
-				}
-
-				b.auditLogger.LogAuthEvent(security.AuditEvent{
-					EventType: "session_expired",
-					UserID:    session.UserID,
-					SessionID: session.ID,
-					Success:   true,
-					Timestamp: now,
-				})
-			}
-
-			if len(expiredSessions) > 0 {
-				log.Info().
-					Int("count", len(expiredSessions)).
-					Msg("Cleaned up expired sessions")
+	if b.metrics != nil {
+		for _, session := range expiredSessions {
+			if session.IsActive {
+				b.metrics.ActiveSessions.Dec()
 			}
 		}
+	}
+
+	// Perform SSH key revocation and audit logging outside the lock.
+	// Sessions are already removed from the map, so no TOCTOU risk.
+	for _, session := range expiredSessions {
+		if session.SSHKeyID != "" {
+			if err := b.revokeSSHKey(session); err != nil {
+				log.Error().
+					Err(err).
+					Str("session_id", session.ID).
+					Str("ssh_key_id", session.SSHKeyID).
+					Msg("Failed to revoke SSH key for expired session")
+			}
+		}
+
+		// An expired session's tokens are dead credential material; the token
+		// store's own sweep would only catch them once the tokens themselves
+		// expire, which can be later than the session.
+		if b.tokenManager != nil {
+			if err := b.tokenManager.RevokeSessionTokens(session.ID); err != nil {
+				log.Error().
+					Err(err).
+					Str("session_id", session.ID).
+					Msg("Failed to revoke stored tokens for expired session")
+			}
+		}
+
+		if b.auditLogger != nil {
+			b.auditLogger.LogAuthEvent(security.AuditEvent{
+				EventType: "session_expired",
+				UserID:    session.UserID,
+				SessionID: session.ID,
+				Success:   true,
+				Timestamp: now,
+			})
+		}
+	}
+
+	if len(expiredSessions) > 0 {
+		log.Info().
+			Int("count", len(expiredSessions)).
+			Msg("Cleaned up expired sessions")
 	}
 }
 

--- a/pkg/auth/broker_core_test.go
+++ b/pkg/auth/broker_core_test.go
@@ -164,18 +164,22 @@ func TestTokenManagerCore(t *testing.T) {
 		Claims:       make(map[string]interface{}),
 	}
 
-	// Test token operations (these will fail due to encryption setup, but test the code paths)
-	err = tokenManager.StoreToken(testToken, "test-user", "test-session")
+	tokenID, err := tokenManager.StoreToken(testToken, "test-user", "test-session")
 	if err != nil {
-		t.Logf("StoreToken returned error: %v", err)
+		t.Fatalf("StoreToken: %v", err)
+	}
+	if tokenID == "" {
+		t.Fatal("StoreToken returned an empty token ID")
 	}
 
 	// Test ValidateToken
-	isValid, err := tokenManager.ValidateToken("test-fingerprint", "test-user")
+	stored, err := tokenManager.ValidateToken("test-fingerprint", "test-user")
 	if err != nil {
-		t.Logf("ValidateToken returned error: %v", err)
+		t.Fatalf("ValidateToken: %v", err)
 	}
-	t.Logf("Token validation result: %v", isValid)
+	if stored.UserID != "test-user" {
+		t.Errorf("stored token user = %q, want test-user", stored.UserID)
+	}
 
 	// Test GetTokenStats
 	stats := tokenManager.GetTokenStats()

--- a/pkg/auth/broker_session_test.go
+++ b/pkg/auth/broker_session_test.go
@@ -435,6 +435,8 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 		t.Fatalf("Failed to create audit logger: %v", err)
 	}
 
+	tokenManager := newTestTokenManager(t)
+
 	broker := &Broker{
 		config: &config.Config{
 			Authentication: config.AuthenticationConfig{
@@ -446,6 +448,18 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 		sessionMutex: sync.RWMutex{},
 		providers:    map[string]*OIDCProvider{"test-provider": provider},
 		auditLogger:  auditLogger,
+		tokenManager: tokenManager,
+	}
+
+	// The refresh token lives in the token store, not on the session.
+	oldTokenID, err := tokenManager.StoreToken(&Token{
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		ExpiresAt:    time.Now().Add(5 * time.Minute),
+		Fingerprint:  "old-fingerprint",
+	}, "test-user", "refresh-test")
+	if err != nil {
+		t.Fatalf("StoreToken: %v", err)
 	}
 
 	// Session is within the refresh threshold (expires in 5 minutes < 15 minute threshold)
@@ -456,7 +470,7 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 		Provider:         "test-provider",
 		IsActive:         true,
 		TokenFingerprint: "old-fingerprint",
-		RefreshToken:     "old-refresh-token",
+		TokenID:          oldTokenID,
 		ExpiresAt:        time.Now().Add(5 * time.Minute),
 		LastAccessed:     time.Now(),
 	}
@@ -478,8 +492,23 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 	if updated.TokenFingerprint == "old-fingerprint" {
 		t.Error("Expected token fingerprint to be updated after refresh")
 	}
-	if updated.RefreshToken != "refreshed-refresh-token" {
-		t.Errorf("Expected refresh token to be updated, got %q", updated.RefreshToken)
+	if updated.TokenID == "" || updated.TokenID == oldTokenID {
+		t.Errorf("Expected the session to point at a new stored token, got %q", updated.TokenID)
+	}
+
+	// The new refresh token is reachable through the store...
+	refreshed, err := tokenManager.GetToken(updated.TokenID)
+	if err != nil {
+		t.Fatalf("GetToken(%q): %v", updated.TokenID, err)
+	}
+	if refreshed.RefreshToken != "refreshed-refresh-token" {
+		t.Errorf("stored refresh token = %q, want refreshed-refresh-token", refreshed.RefreshToken)
+	}
+
+	// ...and the rotated one is gone, rather than lingering as dead credential
+	// material until the token store's own sweep.
+	if _, err := tokenManager.GetToken(oldTokenID); err == nil {
+		t.Error("the pre-refresh token is still in the store after rotation")
 	}
 }
 
@@ -504,12 +533,12 @@ func TestBrokerRefreshSessionNoRefreshToken(t *testing.T) {
 
 	// Session without a refresh token
 	session := &Session{
-		ID:           "no-refresh-token-session",
-		UserID:       "test-user",
-		Provider:     "test-provider",
-		IsActive:     true,
-		RefreshToken: "", // no refresh token
-		ExpiresAt:    time.Now().Add(5 * time.Minute),
+		ID:        "no-refresh-token-session",
+		UserID:    "test-user",
+		Provider:  "test-provider",
+		IsActive:  true,
+		TokenID:   "", // no stored token, so no refresh token
+		ExpiresAt: time.Now().Add(5 * time.Minute),
 	}
 	broker.setSession(session)
 
@@ -541,11 +570,11 @@ func TestBrokerRefreshSessionNotCloseToExpiry(t *testing.T) {
 	}
 
 	session := &Session{
-		ID:           "fresh-session",
-		UserID:       "test-user",
-		IsActive:     true,
-		RefreshToken: "some-token",
-		ExpiresAt:    time.Now().Add(30 * time.Minute), // well outside threshold
+		ID:        "fresh-session",
+		UserID:    "test-user",
+		IsActive:  true,
+		TokenID:   "some-token-id",
+		ExpiresAt: time.Now().Add(30 * time.Minute), // well outside threshold
 	}
 	broker.setSession(session)
 
@@ -581,4 +610,20 @@ func TestAuthenticateSessionIDUniqueness(t *testing.T) {
 		}
 		seen[resp.SessionID] = true
 	}
+}
+
+// newTestTokenManager returns a TokenManager with a valid AES-256 key, for tests
+// that exercise broker paths which store or read tokens.
+func newTestTokenManager(t *testing.T) *TokenManager {
+	t.Helper()
+
+	tm, err := NewTokenManager(&config.Config{
+		Security: config.SecurityConfig{
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	return tm
 }

--- a/pkg/auth/session_tokens_test.go
+++ b/pkg/auth/session_tokens_test.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+)
+
+// TestSessionHoldsNoTokenMaterial guards the invariant this file is about: a
+// Session identifies its tokens (TokenID, TokenFingerprint) but never carries
+// them. Session values are copied, logged and long-lived, and a refresh token is
+// a standing credential that outlives the access token it renews — the whole
+// point of encrypting the token store is undone if a plaintext copy also sits on
+// the session.
+//
+// Session.RefreshToken existed until this was wired up, which is why the check is
+// structural rather than a comment.
+func TestSessionHoldsNoTokenMaterial(t *testing.T) {
+	// TokenFingerprint is a hash, not a credential; TokenID is a store lookup key
+	// with no value on its own.
+	allowed := map[string]bool{
+		"TokenFingerprint": true,
+		"TokenID":          true,
+	}
+
+	sessionType := reflect.TypeOf(Session{})
+	for i := 0; i < sessionType.NumField(); i++ {
+		name := sessionType.Field(i).Name
+		if allowed[name] {
+			continue
+		}
+		if strings.Contains(name, "Token") {
+			t.Errorf("Session.%s looks like token material; tokens belong in the "+
+				"TokenManager, with only the ID on the session", name)
+		}
+	}
+}
+
+func newTokenTestBroker(t *testing.T) (*Broker, *TokenManager) {
+	t.Helper()
+
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{Enabled: false})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	tokenManager := newTestTokenManager(t)
+	broker := &Broker{
+		config: &config.Config{
+			Authentication: config.AuthenticationConfig{
+				TokenLifetime:    time.Hour,
+				RefreshThreshold: 15 * time.Minute,
+			},
+		},
+		sessions:     make(map[string]*Session),
+		sessionMutex: sync.RWMutex{},
+		providers:    map[string]*OIDCProvider{},
+		auditLogger:  auditLogger,
+		tokenManager: tokenManager,
+	}
+	return broker, tokenManager
+}
+
+// storeSessionWithToken registers a session that owns one stored token.
+func storeSessionWithToken(t *testing.T, broker *Broker, tm *TokenManager, sessionID, userID string, expiresAt time.Time) string {
+	t.Helper()
+
+	tokenID, err := tm.StoreToken(&Token{
+		AccessToken:  "access-" + sessionID,
+		RefreshToken: "refresh-" + sessionID,
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Fingerprint:  "fp-" + sessionID,
+	}, userID, sessionID)
+	if err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	broker.setSession(&Session{
+		ID:           sessionID,
+		UserID:       userID,
+		IsActive:     true,
+		TokenID:      tokenID,
+		ExpiresAt:    expiresAt,
+		LastAccessed: time.Now(),
+	})
+	return tokenID
+}
+
+// A revoked session must take its tokens with it. Dropping only the session
+// leaves a usable refresh token in the store until the token itself expires,
+// which can be long after the session it was issued for.
+func TestRevokeSessionDestroysItsStoredTokens(t *testing.T) {
+	broker, tm := newTokenTestBroker(t)
+	tokenID := storeSessionWithToken(t, broker, tm, "sess-revoke", "test-user", time.Now().Add(time.Hour))
+
+	if _, err := tm.GetToken(tokenID); err != nil {
+		t.Fatalf("token should exist before revocation: %v", err)
+	}
+
+	if err := broker.RevokeSession("sess-revoke", "test-user"); err != nil {
+		t.Fatalf("RevokeSession: %v", err)
+	}
+
+	if _, err := tm.GetToken(tokenID); err == nil {
+		t.Error("session was revoked but its tokens are still in the store")
+	}
+	if total := tm.GetTokenStats()["total_tokens"].(int); total != 0 {
+		t.Errorf("token store holds %d tokens after revoking the only session, want 0", total)
+	}
+}
+
+// A refused cross-user revocation must not destroy the owner's tokens.
+func TestRevokeSessionForWrongUserLeavesTokens(t *testing.T) {
+	broker, tm := newTokenTestBroker(t)
+	tokenID := storeSessionWithToken(t, broker, tm, "sess-owned", "owner", time.Now().Add(time.Hour))
+
+	if err := broker.RevokeSession("sess-owned", "attacker"); err == nil {
+		t.Fatal("expected cross-user revocation to be refused")
+	}
+
+	if _, err := tm.GetToken(tokenID); err != nil {
+		t.Errorf("a refused revocation destroyed the owner's tokens: %v", err)
+	}
+	if broker.getSession("sess-owned") == nil {
+		t.Error("a refused revocation removed the session")
+	}
+}
+
+func TestExpiredSessionsHaveTheirTokensRevoked(t *testing.T) {
+	broker, tm := newTokenTestBroker(t)
+
+	expiredID := storeSessionWithToken(t, broker, tm, "sess-expired", "user-a", time.Now().Add(-time.Minute))
+	liveID := storeSessionWithToken(t, broker, tm, "sess-live", "user-b", time.Now().Add(time.Hour))
+
+	broker.expireSessions(time.Now())
+
+	if broker.getSession("sess-expired") != nil {
+		t.Error("expired session was not removed")
+	}
+	if _, err := tm.GetToken(expiredID); err == nil {
+		t.Error("the expired session's tokens are still in the store")
+	}
+
+	if broker.getSession("sess-live") == nil {
+		t.Fatal("the live session was removed")
+	}
+	if _, err := tm.GetToken(liveID); err != nil {
+		t.Errorf("the live session's tokens were revoked: %v", err)
+	}
+}
+
+// Idle expiry is a separate condition from absolute expiry, and it too must take
+// the session's tokens with it.
+func TestIdleSessionsHaveTheirTokensRevoked(t *testing.T) {
+	broker, tm := newTokenTestBroker(t)
+	broker.config.Authentication.IdleTimeout = 10 * time.Minute
+
+	tokenID := storeSessionWithToken(t, broker, tm, "sess-idle", "user-a", time.Now().Add(time.Hour))
+	session := broker.getSession("sess-idle")
+	session.LastAccessed = time.Now().Add(-30 * time.Minute)
+	broker.setSession(session)
+
+	broker.expireSessions(time.Now())
+
+	if broker.getSession("sess-idle") != nil {
+		t.Error("idle session was not removed")
+	}
+	if _, err := tm.GetToken(tokenID); err == nil {
+		t.Error("the idle session's tokens are still in the store")
+	}
+}

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -16,7 +16,6 @@ import (
 
 // TokenManager handles token lifecycle management
 type TokenManager struct {
-	config     *config.Config
 	tokenStore *TokenStore
 	encryption *security.Encryption
 	stopChan   chan struct{}
@@ -61,7 +60,6 @@ func NewTokenManager(cfg *config.Config) (*TokenManager, error) {
 	}
 
 	return &TokenManager{
-		config:     cfg,
 		tokenStore: tokenStore,
 		encryption: encryption,
 		stopChan:   make(chan struct{}),
@@ -89,12 +87,15 @@ func (tm *TokenManager) Stop() error {
 	return nil
 }
 
-// StoreToken stores a token in the token store
-func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) error {
+// StoreToken encrypts a token and stores it, returning the ID the caller should
+// keep. Callers hold the ID rather than the token: the returned ID is a lookup
+// key with no value on its own, whereas an access or refresh token in a
+// long-lived struct is a usable credential.
+func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) (string, error) {
 	// Generate token ID
 	tokenID, err := tm.generateTokenID()
 	if err != nil {
-		return fmt.Errorf("failed to generate token ID: %w", err)
+		return "", fmt.Errorf("failed to generate token ID: %w", err)
 	}
 
 	// Encrypt token if encryption is enabled
@@ -107,20 +108,20 @@ func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) error
 		var err error
 		accessToken, err = tm.encryption.Encrypt(token.AccessToken)
 		if err != nil {
-			return fmt.Errorf("failed to encrypt access token: %w", err)
+			return "", fmt.Errorf("failed to encrypt access token: %w", err)
 		}
 
 		if token.RefreshToken != "" {
 			refreshToken, err = tm.encryption.Encrypt(token.RefreshToken)
 			if err != nil {
-				return fmt.Errorf("failed to encrypt refresh token: %w", err)
+				return "", fmt.Errorf("failed to encrypt refresh token: %w", err)
 			}
 		}
 
 		if token.IDToken != "" {
 			idToken, err = tm.encryption.Encrypt(token.IDToken)
 			if err != nil {
-				return fmt.Errorf("failed to encrypt ID token: %w", err)
+				return "", fmt.Errorf("failed to encrypt ID token: %w", err)
 			}
 		}
 
@@ -164,7 +165,7 @@ func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) error
 		Bool("encrypted", encrypted).
 		Msg("Token stored")
 
-	return nil
+	return tokenID, nil
 }
 
 // GetToken retrieves a token from the token store
@@ -273,30 +274,6 @@ func (tm *TokenManager) ValidateToken(tokenFingerprint, userID string) (*StoredT
 	// used for any security decision, so it is only updated under write lock
 	// paths (StoreToken, performCleanup).
 	return storedToken, nil
-}
-
-// RefreshToken refreshes a token. userID must match the token owner.
-func (tm *TokenManager) RefreshToken(tokenFingerprint, userID string) (*Token, error) {
-	// Find stored token
-	storedToken, err := tm.ValidateToken(tokenFingerprint, userID)
-	if err != nil {
-		return nil, fmt.Errorf("token validation failed: %w", err)
-	}
-
-	// Check if token is close to expiry
-	if time.Until(storedToken.ExpiresAt) > tm.config.Authentication.RefreshThreshold {
-		// Token doesn't need refresh yet
-		return tm.GetToken(storedToken.ID)
-	}
-
-	// This is a simplified implementation
-	// In a real implementation, we would use the refresh token to get a new access token
-	log.Debug().
-		Str("token_id", storedToken.ID).
-		Str("user_id", storedToken.UserID).
-		Msg("Token refresh requested")
-
-	return nil, fmt.Errorf("token refresh not implemented")
 }
 
 // RevokeToken revokes a token

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -87,31 +87,40 @@ func TestTokenManagerBasicOperations(t *testing.T) {
 		Claims:       make(map[string]interface{}),
 	}
 
-	err = tm.StoreToken(testToken, "test-user", "test-session")
+	tokenID, err := tm.StoreToken(testToken, "test-user", "test-session")
 	if err != nil {
-		t.Logf("StoreToken returned error (expected due to encryption setup): %v", err)
+		t.Fatalf("StoreToken: %v", err)
+	}
+	if tokenID == "" {
+		t.Fatal("StoreToken returned an empty token ID")
 	}
 
-	// Test GetToken
-	retrievedToken, err := tm.GetToken("test-token-id")
+	// A round trip returns the original plaintext, so the ID is all a caller
+	// needs to keep.
+	retrievedToken, err := tm.GetToken(tokenID)
 	if err != nil {
-		t.Logf("GetToken returned error: %v", err)
+		t.Fatalf("GetToken(%q): %v", tokenID, err)
 	}
-	if retrievedToken != nil {
-		t.Log("Retrieved token successfully")
+	if retrievedToken.AccessToken != testToken.AccessToken {
+		t.Errorf("access token = %q, want %q", retrievedToken.AccessToken, testToken.AccessToken)
+	}
+	if retrievedToken.RefreshToken != testToken.RefreshToken {
+		t.Errorf("refresh token = %q, want %q", retrievedToken.RefreshToken, testToken.RefreshToken)
 	}
 
 	// Test ValidateToken
-	isValid, err := tm.ValidateToken("test-token-id", "test-user")
+	stored, err := tm.ValidateToken("test-fingerprint", "test-user")
 	if err != nil {
-		t.Logf("ValidateToken returned error: %v", err)
+		t.Fatalf("ValidateToken: %v", err)
 	}
-	t.Logf("Token validation result: %v", isValid)
+	if stored.ID != tokenID {
+		t.Errorf("ValidateToken returned token %q, want %q", stored.ID, tokenID)
+	}
 
 	// Test GetTokenStats
 	stats := tm.GetTokenStats()
-	if stats != nil {
-		t.Log("Retrieved token stats successfully")
+	if stats == nil {
+		t.Error("expected non-nil token stats")
 	}
 }
 
@@ -146,31 +155,6 @@ func TestTokenManagerRevocation(t *testing.T) {
 	err = tm.RevokeSessionTokens("test-session")
 	if err != nil {
 		t.Logf("RevokeSessionTokens returned error: %v", err)
-	}
-}
-
-func TestTokenManagerRefresh(t *testing.T) {
-	// Test token refresh functionality
-
-	cfg := &config.Config{
-		Security: config.SecurityConfig{
-			SecureTokenStorage: true,
-			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
-		},
-	}
-
-	tm, err := NewTokenManager(cfg)
-	if err != nil {
-		t.Fatalf("Failed to create token manager: %v", err)
-	}
-
-	// Test RefreshToken
-	newToken, err := tm.RefreshToken("test-token-id", "test-user")
-	if err != nil {
-		t.Logf("RefreshToken returned error: %v", err)
-	}
-	if newToken != nil {
-		t.Log("Token refresh attempt completed")
 	}
 }
 
@@ -318,7 +302,7 @@ func TestValidateTokenConcurrent(t *testing.T) {
 		Fingerprint:  "concurrent-fp",
 		Claims:       make(map[string]interface{}),
 	}
-	if err := tm.StoreToken(testToken, "user1", "session1"); err != nil {
+	if _, err := tm.StoreToken(testToken, "user1", "session1"); err != nil {
 		t.Fatalf("Failed to store token: %v", err)
 	}
 
@@ -371,7 +355,7 @@ func storeTestToken(t *testing.T, tm *TokenManager, fp string) *Token {
 		Fingerprint: fp,
 		Claims:      make(map[string]interface{}),
 	}
-	if err := tm.StoreToken(tok, "user1", "sess1"); err != nil {
+	if _, err := tm.StoreToken(tok, "user1", "sess1"); err != nil {
 		t.Fatalf("StoreToken(%q): %v", fp, err)
 	}
 	return tok
@@ -429,7 +413,7 @@ func TestFingerprintIndexRemovedOnCleanup(t *testing.T) {
 		Fingerprint: "fp-cleanup-test",
 		Claims:      make(map[string]interface{}),
 	}
-	if err := tm.StoreToken(tok, "user1", "sess1"); err != nil {
+	if _, err := tm.StoreToken(tok, "user1", "sess1"); err != nil {
 		t.Fatalf("StoreToken: %v", err)
 	}
 
@@ -557,7 +541,7 @@ func BenchmarkValidateToken(b *testing.B) {
 			Fingerprint: fp,
 			Claims:      make(map[string]interface{}),
 		}
-		if err := tm.StoreToken(tok, "user", "sess"); err != nil {
+		if _, err := tm.StoreToken(tok, "user", "sess"); err != nil {
 			b.Fatalf("StoreToken: %v", err)
 		}
 	}
@@ -600,7 +584,7 @@ func BenchmarkValidateTokenSerial(b *testing.B) {
 			Fingerprint: fp,
 			Claims:      make(map[string]interface{}),
 		}
-		if err := tm.StoreToken(tok, "user", "sess"); err != nil {
+		if _, err := tm.StoreToken(tok, "user", "sess"); err != nil {
 			b.Fatalf("StoreToken: %v", err)
 		}
 	}
@@ -640,7 +624,7 @@ func TestTokenManagerAlwaysEncrypts(t *testing.T) {
 		Claims:       make(map[string]interface{}),
 	}
 
-	if err := tm.StoreToken(testToken, "user1", "session1"); err != nil {
+	if _, err := tm.StoreToken(testToken, "user1", "session1"); err != nil {
 		t.Fatalf("StoreToken failed: %v", err)
 	}
 


### PR DESCRIPTION
Fixes #123.

**Stacked on #133** (base is `fix/acct-mgmt-fail-closed`, not `main`) so the diff shows only this change. Review/merge order: #128 → #131 → #132 → #133 → this.

## The problem

`NewTokenManager` is constructed and started at broker startup, and `StoreToken` does encrypt with AES-256-GCM — but **nothing ever called it**. Grep for `StoreToken` before this PR and the only hits are the definition and its tests. So:

- the store was permanently empty, and the "AES-256 encryption for token storage" claim in README/SECURITY described encryption of nothing;
- the actual tokens lived in `Session.AccessToken` / `Session.RefreshToken` / `Session.IDToken` as plaintext strings, on a struct that is copied by value, passed around and logged;
- the refresh token is the one that matters here: it is a standing credential that outlives the access token it renews.

Two related gaps: `RevokeSession` dropped the session but left its tokens in the store until they expired on their own (which can be long after the session), and the same for the expiry sweep. And `TokenManager.RefreshToken` was a stub that validated its arguments and returned `"token refresh not implemented"` — no callers, but it advertised a capability that did not exist.

## The change

`Session` now carries `TokenID` instead of the tokens. `TokenID` is a store lookup key with no value on its own; `TokenFingerprint` stays because it is a hash.

- `pollDeviceAuthorization`, after the identity and `require_groups` checks pass, calls `b.tokenManager.StoreToken(token, session.UserID, session.ID)` and keeps only the ID. **If the store fails, the authentication is denied** — `TOKEN_STORE_FAILED`, recorded in metrics and written as an `authentication_denied` audit event, with the session removed. Completing an authentication whose tokens the broker cannot later produce would just move the failure somewhere less diagnosable.
- `RefreshSession` fetches the refresh token via `GetToken(session.TokenID)`, uses it for the duration of the call, stores the token the provider returns, points the session at the new ID and revokes the pre-refresh entry. Providers rotate refresh tokens; the old one should not linger.
- `RevokeSession` and the expiry sweep call `RevokeSessionTokens(sessionID)`.
- `StoreToken` returns `(tokenID, error)`.

The 5-minute `sessionCleanup` ticker body is extracted into `expireSessions(now time.Time)` so both expiry conditions (absolute and idle) are testable without waiting on a ticker. It takes `now` rather than calling `time.Since` internally, and nil-guards `tokenManager`/`auditLogger` because a number of tests build `&Broker{...}` literals directly.

Deleted: the `TokenManager.RefreshToken` stub, and `TokenManager.config`, which was unused once the stub went.

## Tests

`pkg/auth/session_tokens_test.go`:

- `TestSessionHoldsNoTokenMaterial` — reflects over `Session` and fails on any field whose name contains `Token` other than `TokenID`/`TokenFingerprint`. Structural rather than a comment, because a plaintext token field on `Session` is exactly the bug that was there.
- `TestRevokeSessionDestroysItsStoredTokens`, `TestExpiredSessionsHaveTheirTokensRevoked`, `TestIdleSessionsHaveTheirTokensRevoked` — the token is gone from the store afterwards, and a live session's token is left alone.
- `TestRevokeSessionForWrongUserLeavesTokens` — a refused cross-user revocation destroys nothing.

`TestBrokerRefreshSessionSuccess` now pre-stores an old refresh token and asserts the session ends up pointing at a *new* token ID, that the new entry holds the refreshed refresh token, and that the old entry is gone.

## Verification

`make verify-linux` (Docker: `go vet ./...`, `go test -race ./pkg/... ./internal/...`, `golangci-lint run`) — green, `0 issues`. The cgo packages cannot build on the macOS host, hence the container.

## Note on scope

This makes the encryption-at-rest claim true for tokens the broker holds in memory. It does not add persistence: the store is still in-process, so tokens do not survive a broker restart. That is unchanged behaviour and out of scope here.