### PR TITLE
feat(admin): implement the broker's status, sessions_list and keys_list IPC handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,14 @@ jobs:
         run: |
           # PAM/cgo packages are vetted and tested in the separate `pam` job,
           # which installs the PAM and json-c development headers.
-          go vet ./pkg/auth ./pkg/config ./pkg/metrics ./pkg/policy ./pkg/security ./pkg/ssh ./internal/ipc ./cmd/broker ./cmd/oidc-admin
+          go vet ./pkg/auth ./pkg/config ./pkg/metrics ./pkg/policy ./pkg/security ./pkg/ssh \
+            ./internal/adminapi ./internal/brokerclient ./internal/ipc ./cmd/broker ./cmd/oidc-admin
 
       - name: Run tests
         run: |
           go test -race -coverprofile=coverage.out -covermode=atomic \
-            ./pkg/auth ./pkg/config ./pkg/metrics ./pkg/policy ./pkg/security ./pkg/ssh ./internal/ipc
+            ./pkg/auth ./pkg/config ./pkg/metrics ./pkg/policy ./pkg/security ./pkg/ssh \
+            ./internal/adminapi ./internal/brokerclient ./internal/ipc ./cmd/oidc-admin
 
       - name: Check test coverage
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep working.
 
 ### Added
+- **(#124)** `oidc-admin status`, `health`, `sessions` and `keys` work. The broker
+  now implements the `status`, `sessions_list` and `keys_list` IPC requests the
+  CLI has always sent, backed by `Broker.Status()`, `Broker.ListSessions()` and
+  `Broker.ListKeys()`. `status` reports the broker's version, start time, uptime,
+  configured providers and session counts; `sessions` lists user, provider, login
+  type, creation time and status, including **pending** device flows the user has
+  not completed (a login that looks like it is hanging shows up here, which is
+  usually the question being asked); `keys` lists each managed key's algorithm,
+  size in bits, status and expiry. Listings carry no credentials — no tokens, no
+  token IDs, no key material — and are sorted (sessions newest first, keys by
+  username) so repeated runs are diffable. All of them require root, since the
+  broker socket accepts uid 0 only; DEPLOYMENT.md documents the commands and the
+  `sudo` requirement.
+- **(#124)** `Session.LoginType`: the broker applied per-login-type policy without
+  recording which login type a session was opened for.
 - **(#121)** `oidc-pam-helper -timeout` now bounds the device-flow wait rather
   than only arming a watchdog (default 90 s, matching the PAM module's
   `timeout=`); the outer watchdog fires 10 s later so an authentication that runs
@@ -156,6 +171,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bridge compiles warning-free.
 
 ### Changed
+- **(#124)** `Server.handleRequest` returns `any`, since the admin requests answer
+  with their own shapes rather than squeezing a session listing into the fields of
+  an authentication response. `internal/adminapi` and `cmd/oidc-admin` are covered
+  by CI's vet, test and lint runs.
 - **(#123)** `Session.RefreshToken` is replaced by `Session.TokenID`, and
   `TokenManager.StoreToken` now returns the ID it generated. Both are internal
   Go APIs (`pkg/auth`), not wire or config surface.
@@ -167,6 +186,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suggested a capability that did not exist.
 
 ### Fixed
+- **(#124) Every `oidc-admin` command that talks to the broker was silently
+  broken.** The CLI sent `status`, `sessions_list` and `keys_list`; the broker
+  implemented none of them, so each request fell through to
+  `INVALID_REQUEST_TYPE`. The client decoded that error object into its own
+  response struct — which shares no fields with it — and printed the resulting
+  zero value: `status` reported a **running broker with an empty version and no
+  uptime**, and `sessions`/`keys` reported "none". The request and response types
+  now live in one place (`internal/adminapi`) instead of being declared once on
+  each side, every admin response can carry an error the client checks, and a
+  round-trip test fails if the two sides drift again.
+- **(#124)** `oidc-admin` no longer opens a throwaway connection to decide
+  whether the broker is running. It sends the real request: a broker that accepts
+  connections but cannot answer them was previously reported as healthy. Requests
+  are bounded by a 10-second deadline, so a broker that accepts and then goes
+  quiet no longer hangs the CLI indefinitely.
 - **(#118)** `oidc-pam-helper -version` now prints the build date and git commit
   (the `buildDate`/`gitCommit` ldflags targets were set by the Makefile but never
   read, which is what surfaced them as `unused` once linting covered the package).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -826,8 +826,9 @@ journalctl -u oidc-auth-broker --since "1 week ago" | grep -i error
 # Check disk usage
 du -sh /var/log/oidc-auth/
 
-# Test authentication
-./test-broker
+# Check what the broker itself thinks
+sudo oidc-admin status
+sudo oidc-admin sessions
 ```
 
 #### Monthly Tasks
@@ -873,6 +874,50 @@ LimitNOFILE=65536
 LimitNPROC=4096
 LimitMEMLOCK=64M
 ```
+
+## Administrative CLI (`oidc-admin`)
+
+`oidc-admin` asks the running broker about its own state over the same Unix
+socket the PAM module uses. **Every command that talks to the broker must be run
+as root** (`sudo`): the socket accepts connections only from uid 0, so an
+unprivileged invocation is refused by the broker, not by the CLI.
+
+```bash
+# Is the broker running, and since when?
+sudo oidc-admin status
+
+# Detailed local checks: socket, config file, providers
+sudo oidc-admin health
+
+# Who is logged in, and which device flows are still pending?
+sudo oidc-admin sessions
+
+# Which broker-managed SSH keys exist, how strong are they, when do they expire?
+sudo oidc-admin keys
+
+# Generate a token_encryption_key (does not talk to the broker)
+oidc-admin gen-key
+```
+
+If the broker listens somewhere other than the default
+`/var/run/oidc-auth/broker.sock`, point the CLI at it with
+`OIDC_SOCKET_PATH=/path/to/broker.sock`.
+
+`sessions` lists pending device flows as well as authenticated sessions:
+
+| Status | Meaning |
+|---|---|
+| `pending` | The device flow has started; the user has not completed it. Grants nothing. |
+| `active` | Authenticated. Identity binding and `require_groups` have passed. |
+| `expired` | Past its lifetime but not yet removed by the 5-minute cleanup sweep. Not usable. |
+
+A login that appears to hang is usually a `pending` row here — that tells you the
+request reached the broker and is waiting on the user, rather than failing before
+it got that far.
+
+Nothing in this output is a credential: sessions are listed without their tokens
+(which live encrypted in the broker's token store) and keys are listed without
+their key material.
 
 ## Troubleshooting
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -72,6 +72,10 @@ func main() {
 			Msg("Failed to create authentication broker")
 	}
 
+	// Report this binary's version through `oidc-admin status`; pkg/auth cannot
+	// see the ldflags variable itself.
+	broker.SetVersion(version)
+
 	// Initialise Prometheus metrics and optionally start the /metrics endpoint.
 	var metricsServer *oidcmetrics.Server
 	if cfg.Server.MetricsAddr != "" {

--- a/cmd/oidc-admin/admin.go
+++ b/cmd/oidc-admin/admin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -9,43 +10,30 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/scttfrdmn/oidc-pam/internal/adminapi"
 	"github.com/scttfrdmn/oidc-pam/pkg/security"
 	"github.com/spf13/cobra"
 )
 
-// Types for communication with broker
-type StatusResponse struct {
-	Status    string    `json:"status"`
-	Version   string    `json:"version"`
-	Uptime    string    `json:"uptime"`
-	Timestamp time.Time `json:"timestamp"`
-}
+// The request/response types live in internal/adminapi so that this client and
+// the broker's IPC server share one definition. They used to be declared here
+// and again on the server side, and the two had drifted: the types this file
+// sends were not implemented by the broker at all.
 
-type Session struct {
-	ID        string    `json:"id"`
-	UserID    string    `json:"user_id"`
-	Provider  string    `json:"provider"`
-	LoginType string    `json:"login_type"`
-	CreatedAt time.Time `json:"created_at"`
-	Status    string    `json:"status"`
-}
+// defaultSocketPath matches the broker's server.socket_path default; override it
+// with OIDC_SOCKET_PATH.
+const defaultSocketPath = "/var/run/oidc-auth/broker.sock"
 
-type SessionListResponse struct {
-	Sessions []Session `json:"sessions"`
-	Total    int       `json:"total"`
-}
+// requestTimeout bounds a single admin request end to end. Without it a broker
+// that accepts the connection and then stops responding would hang the CLI
+// indefinitely.
+const requestTimeout = 10 * time.Second
 
-type SSHKeyInfo struct {
-	Username  string    `json:"username"`
-	KeyType   string    `json:"key_type"`
-	KeySize   int       `json:"key_size"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
-type KeyListResponse struct {
-	Keys  []SSHKeyInfo `json:"keys"`
-	Total int          `json:"total"`
+func socketPath() string {
+	if path := os.Getenv("OIDC_SOCKET_PATH"); path != "" {
+		return path
+	}
+	return defaultSocketPath
 }
 
 // Simple admin commands without initialization cycles
@@ -124,56 +112,56 @@ func init() {
 
 // System status
 func showSystemStatus() error {
-	socketPath := "/var/run/oidc-auth/broker.sock"
-	if path := os.Getenv("OIDC_SOCKET_PATH"); path != "" {
-		socketPath = path
-	}
-
-	// Check if broker is running
-	if !isServiceRunning(socketPath) {
+	status, err := getBrokerStatus()
+	if errors.Is(err, errBrokerUnreachable) {
 		fmt.Printf("🔴 OIDC PAM Status: STOPPED\n")
 		fmt.Printf("==================\n\n")
-		fmt.Printf("The OIDC authentication broker is not running.\n")
-		fmt.Printf("Socket path: %s\n", socketPath)
+		fmt.Printf("The OIDC authentication broker is not reachable.\n")
+		fmt.Printf("Socket path: %s\n", socketPath())
+		fmt.Printf("Reason:      %v\n", errors.Unwrap(err))
 		return nil
 	}
-
-	// Get status from broker
-	status, err := getBrokerStatusSimple(socketPath)
 	if err != nil {
-		return fmt.Errorf("failed to get broker status: %w", err)
+		return err
 	}
 
 	fmt.Printf("🟢 OIDC PAM Status: RUNNING\n")
 	fmt.Printf("===========================\n\n")
 	fmt.Printf("Version:    %s\n", status.Version)
 	fmt.Printf("Uptime:     %s\n", status.Uptime)
+	fmt.Printf("Started:    %s\n", status.StartedAt.Format(time.RFC3339))
 	fmt.Printf("Status:     %s\n", status.Status)
-	fmt.Printf("Socket:     %s\n", socketPath)
+	fmt.Printf("Sessions:   %d active, %d pending\n", status.ActiveSessions, status.PendingSessions)
+	fmt.Printf("Providers:  %s\n", strings.Join(status.Providers, ", "))
+	fmt.Printf("Socket:     %s\n", socketPath())
 
 	return nil
 }
 
 // System health
 func showSystemHealth() error {
-	socketPath := "/var/run/oidc-auth/broker.sock"
-	if path := os.Getenv("OIDC_SOCKET_PATH"); path != "" {
-		socketPath = path
-	}
+	path := socketPath()
 
 	fmt.Printf("🏥 OIDC PAM Health Check\n")
 	fmt.Printf("========================\n\n")
 
-	// Check broker service
-	if isServiceRunning(socketPath) {
-		fmt.Printf("✅ Broker Service: Running\n")
-	} else {
-		fmt.Printf("❌ Broker Service: Not running\n")
+	// Check broker service. This is a real request rather than a bare connect:
+	// a broker that accepts connections but cannot answer them is not healthy,
+	// and a connect-and-drop looks identical to a working request from outside.
+	status, err := getBrokerStatus()
+	switch {
+	case errors.Is(err, errBrokerUnreachable):
+		fmt.Printf("❌ Broker Service: Not reachable (%v)\n", errors.Unwrap(err))
 		return nil
+	case err != nil:
+		fmt.Printf("❌ Broker Service: Reachable but not answering (%v)\n", err)
+		return nil
+	default:
+		fmt.Printf("✅ Broker Service: Running (version %s, up %s)\n", status.Version, status.Uptime)
 	}
 
 	// Check socket permissions
-	if info, err := os.Stat(socketPath); err == nil {
+	if info, err := os.Stat(path); err == nil {
 		fmt.Printf("✅ Socket Permissions: %s\n", info.Mode())
 	} else {
 		fmt.Printf("❌ Socket Permissions: Cannot access\n")
@@ -200,46 +188,45 @@ func showSystemHealth() error {
 		fmt.Printf("⚠️  Configuration: Not found in standard locations\n")
 	}
 
+	if len(status.Providers) > 0 {
+		fmt.Printf("✅ Providers: %s\n", strings.Join(status.Providers, ", "))
+	} else {
+		fmt.Printf("⚠️  Providers: None configured\n")
+	}
+
 	return nil
 }
 
 // List active sessions
 func listActiveSessions() error {
-	socketPath := "/var/run/oidc-auth/broker.sock"
-	if path := os.Getenv("OIDC_SOCKET_PATH"); path != "" {
-		socketPath = path
+	var response adminapi.SessionListResponse
+	if err := adminRequest("sessions_list", &response); err != nil {
+		return err
 	}
 
-	if !isServiceRunning(socketPath) {
-		return fmt.Errorf("broker service is not running")
-	}
+	fmt.Printf("📊 Sessions\n")
+	fmt.Printf("===========\n\n")
 
-	sessions, err := getSessionsSimple(socketPath)
-	if err != nil {
-		return fmt.Errorf("failed to get sessions: %w", err)
-	}
-
-	fmt.Printf("📊 Active Sessions\n")
-	fmt.Printf("==================\n\n")
-
-	if len(sessions) == 0 {
-		fmt.Printf("No active sessions.\n")
+	if len(response.Sessions) == 0 {
+		fmt.Printf("No sessions.\n")
 		return nil
 	}
 
-	fmt.Printf("Total sessions: %d\n\n", len(sessions))
-	fmt.Printf("%-20s %-15s %-10s %-20s\n", "User", "Provider", "Type", "Created")
-	fmt.Printf("%-20s %-15s %-10s %-20s\n",
+	fmt.Printf("Total sessions: %d\n\n", response.Total)
+	fmt.Printf("%-20s %-15s %-10s %-9s %-20s\n", "User", "Provider", "Type", "Status", "Created")
+	fmt.Printf("%-20s %-15s %-10s %-9s %-20s\n",
 		strings.Repeat("-", 20),
 		strings.Repeat("-", 15),
 		strings.Repeat("-", 10),
+		strings.Repeat("-", 9),
 		strings.Repeat("-", 20))
 
-	for _, session := range sessions {
-		fmt.Printf("%-20s %-15s %-10s %-20s\n",
+	for _, session := range response.Sessions {
+		fmt.Printf("%-20s %-15s %-10s %-9s %-20s\n",
 			truncateString(session.UserID, 20),
 			truncateString(session.Provider, 15),
 			truncateString(session.LoginType, 10),
+			truncateString(session.Status, 9),
 			session.CreatedAt.Format("2006-01-02 15:04:05"))
 	}
 
@@ -248,130 +235,96 @@ func listActiveSessions() error {
 
 // List SSH keys
 func listSSHKeys() error {
-	socketPath := "/var/run/oidc-auth/broker.sock"
-	if path := os.Getenv("OIDC_SOCKET_PATH"); path != "" {
-		socketPath = path
-	}
-
-	if !isServiceRunning(socketPath) {
-		return fmt.Errorf("broker service is not running")
-	}
-
-	keys, err := getKeysSimple(socketPath)
-	if err != nil {
-		return fmt.Errorf("failed to get SSH keys: %w", err)
+	var response adminapi.KeyListResponse
+	if err := adminRequest("keys_list", &response); err != nil {
+		return err
 	}
 
 	fmt.Printf("🔑 SSH Keys\n")
 	fmt.Printf("===========\n\n")
 
-	if len(keys) == 0 {
+	if len(response.Keys) == 0 {
 		fmt.Printf("No SSH keys found.\n")
-		return nil
+	} else {
+		fmt.Printf("Total keys: %d\n\n", response.Total)
+		fmt.Printf("%-20s %-14s %-6s %-8s %-20s %-20s\n", "Username", "Type", "Bits", "Status", "Created", "Expires")
+		fmt.Printf("%-20s %-14s %-6s %-8s %-20s %-20s\n",
+			strings.Repeat("-", 20),
+			strings.Repeat("-", 14),
+			strings.Repeat("-", 6),
+			strings.Repeat("-", 8),
+			strings.Repeat("-", 20),
+			strings.Repeat("-", 20))
+
+		for _, key := range response.Keys {
+			fmt.Printf("%-20s %-14s %-6d %-8s %-20s %-20s\n",
+				truncateString(key.Username, 20),
+				truncateString(key.KeyType, 14),
+				key.KeySize,
+				truncateString(key.Status, 8),
+				key.CreatedAt.Format("2006-01-02 15:04:05"),
+				key.ExpiresAt.Format("2006-01-02 15:04:05"))
+		}
 	}
 
-	fmt.Printf("Total keys: %d\n\n", len(keys))
-	fmt.Printf("%-20s %-10s %-8s %-8s %-20s\n", "Username", "Type", "Size", "Status", "Created")
-	fmt.Printf("%-20s %-10s %-8s %-8s %-20s\n",
-		strings.Repeat("-", 20),
-		strings.Repeat("-", 10),
-		strings.Repeat("-", 8),
-		strings.Repeat("-", 8),
-		strings.Repeat("-", 20))
-
-	for _, key := range keys {
-		fmt.Printf("%-20s %-10s %-8d %-8s %-20s\n",
-			truncateString(key.Username, 20),
-			truncateString(key.KeyType, 10),
-			key.KeySize,
-			truncateString(key.Status, 8),
-			key.CreatedAt.Format("2006-01-02 15:04:05"))
+	if response.Unreadable > 0 {
+		fmt.Printf("\n⚠️  %d key director(y|ies) could not be read and are not listed above;\n", response.Unreadable)
+		fmt.Printf("    see the broker log for details.\n")
 	}
 
 	return nil
 }
 
-// Helper functions
-func isServiceRunning(socketPath string) bool {
-	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
-		return false
-	}
+// errBrokerUnreachable distinguishes "could not reach the broker" from "the
+// broker answered with an error", which the status and health output report
+// differently.
+var errBrokerUnreachable = errors.New("broker unreachable")
 
-	conn, err := net.Dial("unix", socketPath)
-	if err != nil {
-		return false
-	}
-	_ = conn.Close()
-	return true
-}
+// adminRequest sends one parameterless admin request and decodes the reply into
+// out, which must be a pointer to one of the adminapi response types.
+//
+// One connection per request: the broker serves a single request per connection
+// and then closes it.
+func adminRequest(requestType string, out any) error {
+	path := socketPath()
 
-func getBrokerStatusSimple(socketPath string) (*StatusResponse, error) {
-	conn, err := net.Dial("unix", socketPath)
+	conn, err := net.DialTimeout("unix", path, requestTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to broker: %w", err)
+		return fmt.Errorf("%w: %w", errBrokerUnreachable, err)
 	}
 	defer func() { _ = conn.Close() }()
 
-	request := map[string]interface{}{
-		"type": "status",
+	// Bound the whole exchange, so a broker that accepts the connection and then
+	// stops responding cannot hang the CLI indefinitely.
+	if err := conn.SetDeadline(time.Now().Add(requestTimeout)); err != nil {
+		return fmt.Errorf("failed to set request deadline: %w", err)
 	}
 
-	if err := json.NewEncoder(conn).Encode(request); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+	if err := json.NewEncoder(conn).Encode(map[string]any{"type": requestType}); err != nil {
+		return fmt.Errorf("failed to send %s request: %w", requestType, err)
 	}
 
-	var response StatusResponse
-	if err := json.NewDecoder(conn).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := json.NewDecoder(conn).Decode(out); err != nil {
+		return fmt.Errorf("failed to decode %s response: %w", requestType, err)
 	}
 
+	// The broker reports refusals (including "you are not root") in the response
+	// body, so a successful decode is not a successful request.
+	if failable, ok := out.(interface{ Err() error }); ok {
+		if err := failable.Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getBrokerStatus() (*adminapi.StatusResponse, error) {
+	var response adminapi.StatusResponse
+	if err := adminRequest("status", &response); err != nil {
+		return nil, err
+	}
 	return &response, nil
-}
-
-func getSessionsSimple(socketPath string) ([]Session, error) {
-	conn, err := net.Dial("unix", socketPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to broker: %w", err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	request := map[string]interface{}{
-		"type": "sessions_list",
-	}
-
-	if err := json.NewEncoder(conn).Encode(request); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	var response SessionListResponse
-	if err := json.NewDecoder(conn).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return response.Sessions, nil
-}
-
-func getKeysSimple(socketPath string) ([]SSHKeyInfo, error) {
-	conn, err := net.Dial("unix", socketPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to broker: %w", err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	request := map[string]interface{}{
-		"type": "keys_list",
-	}
-
-	if err := json.NewEncoder(conn).Encode(request); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	var response KeyListResponse
-	if err := json.NewDecoder(conn).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return response.Keys, nil
 }
 
 func truncateString(s string, maxLen int) string {

--- a/cmd/oidc-admin/admin_test.go
+++ b/cmd/oidc-admin/admin_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/adminapi"
+)
+
+// fakeBroker is a stand-in for the broker's IPC socket: one request per
+// connection, then close, as the real server behaves.
+type fakeBroker struct {
+	socketPath string
+
+	mu       sync.Mutex
+	requests []string
+}
+
+// requestTypes returns the request types the broker has been sent so far.
+func (f *fakeBroker) requestTypes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.requests...)
+}
+
+// startFakeBroker starts a broker that answers every request with reply(type).
+// A nil reply means "accept the request and say nothing".
+//
+// The socket lives under os.MkdirTemp rather than t.TempDir: sockaddr_un.sun_path
+// is 104 bytes on macOS and the test-name-derived path from t.TempDir routinely
+// exceeds it.
+func startFakeBroker(t *testing.T, reply func(requestType string) any) *fakeBroker {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "adm")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	broker := &fakeBroker{socketPath: filepath.Join(dir, "b.sock")}
+	listener, err := net.Listen("unix", broker.socketPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	// Registered before the listener close below so that the LIFO cleanup order
+	// closes the listener first and *then* waits for the accept loop to notice.
+	t.Cleanup(func() { <-done })
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			var request struct {
+				Type string `json:"type"`
+			}
+			if err := json.NewDecoder(conn).Decode(&request); err == nil {
+				broker.mu.Lock()
+				broker.requests = append(broker.requests, request.Type)
+				broker.mu.Unlock()
+
+				if response := reply(request.Type); response != nil {
+					_ = json.NewEncoder(conn).Encode(response)
+				}
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	return broker
+}
+
+func TestAdminRequestDecodesAResult(t *testing.T) {
+	broker := startFakeBroker(t, func(string) any {
+		return &adminapi.StatusResponse{Status: "running", Version: "v1.0.0", Uptime: "3m 0s"}
+	})
+	t.Setenv("OIDC_SOCKET_PATH", broker.socketPath)
+
+	status, err := getBrokerStatus()
+	if err != nil {
+		t.Fatalf("getBrokerStatus: %v", err)
+	}
+	if status.Version != "v1.0.0" || status.Uptime != "3m 0s" {
+		t.Errorf("got %+v, want version v1.0.0 and uptime 3m 0s", status)
+	}
+	if seen := broker.requestTypes(); len(seen) != 1 || seen[0] != "status" {
+		t.Errorf("broker saw %v, want one status request", seen)
+	}
+}
+
+// The failure this whole change is about: the broker refusing a request must not
+// read as an answer about an idle system.
+func TestAdminRequestSurfacesBrokerErrors(t *testing.T) {
+	broker := startFakeBroker(t, func(string) any {
+		// The shape the peer check and the validator emit.
+		return map[string]any{
+			"success":       false,
+			"error_code":    "INVALID_REQUEST_TYPE",
+			"error_message": "Invalid request type",
+		}
+	})
+	t.Setenv("OIDC_SOCKET_PATH", broker.socketPath)
+
+	var response adminapi.SessionListResponse
+	err := adminRequest("sessions_list", &response)
+	if err == nil {
+		t.Fatal("a refused request was reported as success")
+	}
+	if !strings.Contains(err.Error(), "INVALID_REQUEST_TYPE") {
+		t.Errorf("error %q does not name the broker's error code", err)
+	}
+}
+
+func TestAdminRequestReportsAnUnreachableBroker(t *testing.T) {
+	dir, err := os.MkdirTemp("", "adm")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	// Nothing is listening here.
+	t.Setenv("OIDC_SOCKET_PATH", filepath.Join(dir, "absent.sock"))
+
+	_, err = getBrokerStatus()
+	if !errors.Is(err, errBrokerUnreachable) {
+		t.Fatalf("err = %v, want it to wrap errBrokerUnreachable", err)
+	}
+	// showSystemStatus prints STOPPED for this case rather than failing, so it
+	// must not double as the "broker answered with an error" path.
+	if err := showSystemStatus(); err != nil {
+		t.Errorf("showSystemStatus on an unreachable broker returned %v, want nil", err)
+	}
+}
+
+// A broker that accepts the connection and then says nothing must not hang the
+// CLI. The deadline is requestTimeout; the test only needs to prove there is one.
+func TestAdminRequestHasADeadline(t *testing.T) {
+	if requestTimeout <= 0 {
+		t.Fatalf("requestTimeout = %v, must be positive", requestTimeout)
+	}
+
+	broker := startFakeBroker(t, func(string) any {
+		return nil // accept, read, answer nothing
+	})
+	t.Setenv("OIDC_SOCKET_PATH", broker.socketPath)
+
+	deadline := time.Now().Add(requestTimeout + 5*time.Second)
+	if _, err := getBrokerStatus(); err == nil {
+		t.Fatal("expected an error from a broker that never answers")
+	}
+	if time.Now().After(deadline) {
+		t.Error("the request outlived its own timeout")
+	}
+}
+
+func TestSocketPathDefaultsAndOverride(t *testing.T) {
+	t.Setenv("OIDC_SOCKET_PATH", "")
+	if got := socketPath(); got != defaultSocketPath {
+		t.Errorf("socketPath() = %q, want the default %q", got, defaultSocketPath)
+	}
+
+	t.Setenv("OIDC_SOCKET_PATH", "/run/custom.sock")
+	if got := socketPath(); got != "/run/custom.sock" {
+		t.Errorf("socketPath() = %q, want the override", got)
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		in   string
+		max  int
+		want string
+	}{
+		{"short", 20, "short"},
+		{"exactly-ten", 11, "exactly-ten"},
+		{"a-very-long-username", 10, "a-very-..."},
+		{"abcdef", 3, "abc"},
+	}
+
+	for _, tt := range tests {
+		if got := truncateString(tt.in, tt.max); got != tt.want {
+			t.Errorf("truncateString(%q, %d) = %q, want %q", tt.in, tt.max, got, tt.want)
+		}
+	}
+}

--- a/internal/adminapi/types.go
+++ b/internal/adminapi/types.go
@@ -1,0 +1,109 @@
+// Package adminapi holds the wire types for the broker's administrative IPC
+// requests — `status`, `sessions_list` and `keys_list`, as issued by oidc-admin.
+//
+// They live here, in a package with no dependencies beyond the standard library,
+// so that the broker (internal/ipc) and the client (cmd/oidc-admin) encode and
+// decode the same structs. They were previously declared twice, once on each
+// side, and the two copies had drifted to the point where the client sent
+// request types the broker did not implement at all: every `oidc-admin status`
+// got back an authentication error response, which decoded into an empty
+// StatusResponse and printed as a running broker with no version and no uptime.
+package adminapi
+
+import (
+	"fmt"
+	"time"
+)
+
+// Error is embedded in every admin response so that a failure can be reported
+// in the shape the client is already decoding, rather than as a different
+// object the client would silently read as an empty success.
+type Error struct {
+	ErrorCode    string `json:"error_code,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+// Err reports the failure the response carries, or nil if it carries a result.
+// A client that decodes a response must check it: the zero value of every
+// response type below is indistinguishable from a real answer about an idle
+// broker, so an unchecked error prints as "no sessions" or "no keys".
+func (e Error) Err() error {
+	if e.ErrorCode == "" {
+		return nil
+	}
+	if e.ErrorMessage == "" {
+		return fmt.Errorf("broker returned error %s", e.ErrorCode)
+	}
+	return fmt.Errorf("broker returned error %s: %s", e.ErrorCode, e.ErrorMessage)
+}
+
+// StatusResponse answers a `status` request.
+type StatusResponse struct {
+	Error
+	// Status is a one-word summary: "running" or "degraded".
+	Status string `json:"status"`
+	// Version is the broker binary's version, as set at build time.
+	Version string `json:"version"`
+	// Uptime is how long the broker has been serving, formatted for display.
+	Uptime string `json:"uptime"`
+	// UptimeSeconds is the same value for programmatic consumers.
+	UptimeSeconds float64 `json:"uptime_seconds"`
+	// StartedAt is when the broker's services started.
+	StartedAt time.Time `json:"started_at"`
+	// ActiveSessions counts sessions that have completed authentication;
+	// PendingSessions counts device flows still waiting on the user.
+	ActiveSessions  int `json:"active_sessions"`
+	PendingSessions int `json:"pending_sessions"`
+	// Providers lists the configured OIDC providers, enabled or not.
+	Providers []string `json:"providers"`
+	// Timestamp is when the broker answered.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Session describes one authentication session.
+//
+// Deliberately omitted: the session's tokens (the broker no longer holds them in
+// plaintext), its token ID, and the user's group memberships. A listing exists to
+// answer "who is logged in", and root can read the audit log for the rest.
+type Session struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	Provider  string    `json:"provider"`
+	LoginType string    `json:"login_type"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+	// Status is "active" for an authenticated session, "pending" for a device
+	// flow the user has not completed, and "expired" for one past ExpiresAt that
+	// the cleanup sweep has not reached yet.
+	Status string `json:"status"`
+}
+
+// SessionListResponse answers a `sessions_list` request.
+type SessionListResponse struct {
+	Error
+	Sessions []Session `json:"sessions"`
+	Total    int       `json:"total"`
+}
+
+// SSHKeyInfo describes one broker-managed SSH key pair. Only public metadata
+// appears here — never the key material itself.
+type SSHKeyInfo struct {
+	Username string `json:"username"`
+	// KeyType is the SSH algorithm name, e.g. "ssh-rsa".
+	KeyType string `json:"key_type"`
+	// KeySize is the key's strength in bits.
+	KeySize   int       `json:"key_size"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// KeyListResponse answers a `keys_list` request.
+type KeyListResponse struct {
+	Error
+	Keys  []SSHKeyInfo `json:"keys"`
+	Total int          `json:"total"`
+	// Unreadable counts key directories that could not be read. They are omitted
+	// from Keys, so without this the listing would look complete when it is not.
+	Unreadable int `json:"unreadable,omitempty"`
+}

--- a/internal/ipc/admin.go
+++ b/internal/ipc/admin.go
@@ -1,0 +1,125 @@
+package ipc
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/scttfrdmn/oidc-pam/internal/adminapi"
+)
+
+// Administrative request handlers, backing `oidc-admin status`, `sessions` and
+// `keys`. oidc-admin has sent these three request types since it was written,
+// but the broker implemented none of them: every one fell through
+// handleRequest's default case to INVALID_REQUEST_TYPE, which the client
+// decoded into an empty result and printed as a running broker with no version,
+// no sessions and no keys.
+//
+// They read broker state and take no parameters. Access control is the same as
+// for every other request on this socket: the peer must be uid 0 (see
+// verifyPeerCredentials), so these are root-only and `oidc-admin` must be run
+// with sudo.
+
+// handleStatus answers a `status` request.
+func (s *Server) handleStatus() *adminapi.StatusResponse {
+	status := s.broker.Status()
+
+	return &adminapi.StatusResponse{
+		Status:          "running",
+		Version:         status.Version,
+		Uptime:          formatUptime(status.Uptime),
+		UptimeSeconds:   status.Uptime.Seconds(),
+		StartedAt:       status.StartedAt,
+		ActiveSessions:  status.ActiveSessions,
+		PendingSessions: status.PendingSessions,
+		Providers:       status.Providers,
+		Timestamp:       time.Now(),
+	}
+}
+
+// handleSessionsList answers a `sessions_list` request.
+func (s *Server) handleSessionsList() *adminapi.SessionListResponse {
+	sessions := s.broker.ListSessions()
+
+	out := make([]adminapi.Session, 0, len(sessions))
+	for _, session := range sessions {
+		out = append(out, adminapi.Session{
+			ID:        session.ID,
+			UserID:    session.UserID,
+			Provider:  session.Provider,
+			LoginType: session.LoginType,
+			CreatedAt: session.CreatedAt,
+			ExpiresAt: session.ExpiresAt,
+			Status:    session.Status,
+		})
+	}
+
+	return &adminapi.SessionListResponse{
+		Sessions: out,
+		Total:    len(out),
+	}
+}
+
+// handleKeysList answers a `keys_list` request.
+func (s *Server) handleKeysList() *adminapi.KeyListResponse {
+	keys, unreadable, err := s.broker.ListKeys()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to list managed SSH keys")
+		return &adminapi.KeyListResponse{
+			Error: adminapi.Error{
+				ErrorCode:    "KEY_LIST_FAILED",
+				ErrorMessage: clientErrorMessage("KEY_LIST_FAILED"),
+			},
+		}
+	}
+
+	out := make([]adminapi.SSHKeyInfo, 0, len(keys))
+	for _, key := range keys {
+		status := "active"
+		if key.Expired {
+			status = "expired"
+		}
+		out = append(out, adminapi.SSHKeyInfo{
+			Username:  key.Username,
+			KeyType:   key.KeyType,
+			KeySize:   key.KeySize,
+			Status:    status,
+			CreatedAt: key.CreatedAt,
+			ExpiresAt: key.ExpiresAt,
+		})
+	}
+
+	return &adminapi.KeyListResponse{
+		Keys:       out,
+		Total:      len(out),
+		Unreadable: unreadable,
+	}
+}
+
+// formatUptime renders a duration for an operator: whole units, largest first,
+// dropping the ones that are zero at the front. time.Duration's own String would
+// print "2h0m0.000481723s".
+func formatUptime(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+
+	d = d.Round(time.Second)
+	days := int(d / (24 * time.Hour))
+	d -= time.Duration(days) * 24 * time.Hour
+	hours := int(d / time.Hour)
+	d -= time.Duration(hours) * time.Hour
+	minutes := int(d / time.Minute)
+	seconds := int((d - time.Duration(minutes)*time.Minute) / time.Second)
+
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh %dm", days, hours, minutes)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	case minutes > 0:
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	default:
+		return fmt.Sprintf("%ds", seconds)
+	}
+}

--- a/internal/ipc/admin_test.go
+++ b/internal/ipc/admin_test.go
@@ -1,0 +1,295 @@
+package ipc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/adminapi"
+	"github.com/scttfrdmn/oidc-pam/pkg/auth"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// newAdminTestServer builds a server over a real broker. The provider uses
+// skip_discovery with explicit endpoints so that constructing it makes no
+// network calls.
+func newAdminTestServer(t *testing.T) (*Server, *auth.Broker) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "ipc-admin")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{SocketPath: filepath.Join(tempDir, "broker.sock")},
+		OIDC: config.OIDCConfig{
+			Providers: []config.OIDCProvider{
+				{
+					Name:            "okta",
+					Issuer:          "https://okta.example.com",
+					ClientID:        "test-client",
+					Scopes:          []string{"openid"},
+					SkipDiscovery:   true,
+					TokenEndpoint:   "https://okta.example.com/token",
+					DeviceEndpoint:  "https://okta.example.com/device",
+					JWKSUri:         "https://okta.example.com/jwks",
+					EnabledForLogin: true,
+				},
+			},
+		},
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:         time.Hour,
+			RefreshThreshold:      15 * time.Minute,
+			MaxConcurrentSessions: 10,
+		},
+		Security: config.SecurityConfig{
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+		},
+	}
+
+	broker, err := auth.NewBroker(cfg)
+	if err != nil {
+		t.Fatalf("NewBroker: %v", err)
+	}
+
+	server, err := NewServer(filepath.Join(tempDir, "ipc.sock"), broker, 0660, "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Stop() })
+
+	return server, broker
+}
+
+// The three admin request types must be routed, not rejected. Before this they
+// all fell through to the default case: oidc-admin has sent them since it was
+// written, and the broker answered every one with INVALID_REQUEST_TYPE.
+func TestAdminRequestTypesAreRouted(t *testing.T) {
+	server, _ := newAdminTestServer(t)
+
+	for requestType, want := range map[string]any{
+		"status":        &adminapi.StatusResponse{},
+		"sessions_list": &adminapi.SessionListResponse{},
+		"keys_list":     &adminapi.KeyListResponse{},
+	} {
+		response := server.handleRequest(&Request{Type: requestType})
+
+		if authResp, ok := response.(*Response); ok {
+			t.Errorf("%s answered with an authentication response (error_code=%q), not %T",
+				requestType, authResp.ErrorCode, want)
+			continue
+		}
+		if got, wantType := typeName(response), typeName(want); got != wantType {
+			t.Errorf("%s answered with %s, want %s", requestType, got, wantType)
+		}
+	}
+}
+
+func typeName(v any) string {
+	return fmt.Sprintf("%T", v)
+}
+
+func TestHandleStatusReportsBrokerState(t *testing.T) {
+	server, broker := newAdminTestServer(t)
+	broker.SetVersion("v9.9.9")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := broker.Start(ctx); err != nil {
+		t.Fatalf("broker.Start: %v", err)
+	}
+	defer func() { _ = broker.Stop() }()
+
+	response, ok := server.handleRequest(&Request{Type: "status"}).(*adminapi.StatusResponse)
+	if !ok {
+		t.Fatal("status did not answer with a StatusResponse")
+	}
+	if err := response.Err(); err != nil {
+		t.Fatalf("status reported an error: %v", err)
+	}
+
+	if response.Status != "running" {
+		t.Errorf("status = %q, want running", response.Status)
+	}
+	if response.Version != "v9.9.9" {
+		t.Errorf("version = %q, want v9.9.9", response.Version)
+	}
+	if response.StartedAt.IsZero() {
+		t.Error("started_at is zero for a started broker")
+	}
+	// The client prints Uptime verbatim, so it must be populated even when the
+	// broker has only just started.
+	if response.Uptime == "" {
+		t.Error("uptime is empty")
+	}
+	if len(response.Providers) != 1 || response.Providers[0] != "okta" {
+		t.Errorf("providers = %v, want [okta]", response.Providers)
+	}
+	if response.Timestamp.IsZero() {
+		t.Error("timestamp is zero")
+	}
+}
+
+func TestHandleSessionsListOnIdleBroker(t *testing.T) {
+	server, _ := newAdminTestServer(t)
+
+	response, ok := server.handleRequest(&Request{Type: "sessions_list"}).(*adminapi.SessionListResponse)
+	if !ok {
+		t.Fatal("sessions_list did not answer with a SessionListResponse")
+	}
+	if err := response.Err(); err != nil {
+		t.Fatalf("sessions_list reported an error: %v", err)
+	}
+	if response.Total != 0 || len(response.Sessions) != 0 {
+		t.Errorf("got total=%d sessions=%v, want an empty listing", response.Total, response.Sessions)
+	}
+
+	// Encoded as [] rather than null: the client formats a table from this and
+	// null is a different thing to decode into on any other client.
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !bytes.Contains(encoded, []byte(`"sessions":[]`)) {
+		t.Errorf("empty listing encoded as %s, want \"sessions\":[]", encoded)
+	}
+}
+
+func TestHandleKeysListOnBrokerWithNoKeys(t *testing.T) {
+	server, _ := newAdminTestServer(t)
+
+	response, ok := server.handleRequest(&Request{Type: "keys_list"}).(*adminapi.KeyListResponse)
+	if !ok {
+		t.Fatal("keys_list did not answer with a KeyListResponse")
+	}
+	// The broker's key directory does not exist in a test environment, which is
+	// an empty listing, not an error.
+	if err := response.Err(); err != nil {
+		t.Fatalf("keys_list reported an error: %v", err)
+	}
+	if response.Total != 0 || response.Unreadable != 0 {
+		t.Errorf("got total=%d unreadable=%d, want 0/0", response.Total, response.Unreadable)
+	}
+}
+
+// The drift guard: what the server sends must decode into what the client reads.
+// The two used to declare their own copies of these structs, and the copies
+// disagreed.
+func TestAdminResponsesRoundTripToClientTypes(t *testing.T) {
+	server, broker := newAdminTestServer(t)
+	broker.SetVersion("v1.2.3")
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(server.handleRequest(&Request{Type: "status"})); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Decoded with DisallowUnknownFields: a field the client does not know about
+	// is a sign the two sides have drifted again.
+	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	decoder.DisallowUnknownFields()
+	var status adminapi.StatusResponse
+	if err := decoder.Decode(&status); err != nil {
+		t.Fatalf("client could not decode the broker's status response: %v", err)
+	}
+	if status.Version != "v1.2.3" {
+		t.Errorf("round-tripped version = %q, want v1.2.3", status.Version)
+	}
+}
+
+// A rejected request answers with the authentication-shaped error response
+// (that is what the peer check and the validator emit), so the admin response
+// types must be able to see the error rather than reading it as an empty
+// success.
+func TestAdminClientSeesErrorShapedResponses(t *testing.T) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&Response{
+		Success:      false,
+		ErrorCode:    "PERMISSION_DENIED",
+		ErrorMessage: "Connection rejected",
+	}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	var status adminapi.StatusResponse
+	if err := json.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&status); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	err := status.Err()
+	if err == nil {
+		t.Fatal("a PERMISSION_DENIED response decoded as a successful status")
+	}
+	if !strings.Contains(err.Error(), "PERMISSION_DENIED") {
+		t.Errorf("error %q does not mention the error code", err)
+	}
+}
+
+func TestResponseSucceeded(t *testing.T) {
+	tests := []struct {
+		name     string
+		response any
+		want     bool
+	}{
+		{"successful auth response", &Response{Success: true}, true},
+		{"denied auth response", &Response{Success: false}, false},
+		{"admin result", &adminapi.StatusResponse{Status: "running"}, true},
+		{"admin failure", &adminapi.KeyListResponse{
+			Error: adminapi.Error{ErrorCode: "KEY_LIST_FAILED"},
+		}, false},
+		{"some other shape", struct{}{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := responseSucceeded(tt.response); got != tt.want {
+				t.Errorf("responseSucceeded(%T) = %v, want %v", tt.response, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatUptime(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		want     string
+	}{
+		{0, "0s"},
+		{-time.Second, "0s"},
+		{45 * time.Second, "45s"},
+		{90 * time.Second, "1m 30s"},
+		{2 * time.Hour, "2h 0m"},
+		{25*time.Hour + 30*time.Minute, "1d 1h 30m"},
+		// Rounded to the second, not printed as 2h0m0.000481723s.
+		{2*time.Hour + 481723*time.Nanosecond, "2h 0m"},
+	}
+
+	for _, tt := range tests {
+		if got := formatUptime(tt.duration); got != tt.want {
+			t.Errorf("formatUptime(%v) = %q, want %q", tt.duration, got, tt.want)
+		}
+	}
+}
+
+func TestValidateRequestAcceptsAdminTypes(t *testing.T) {
+	// They take no parameters, and a client that fills in a shared request struct
+	// must not be rejected for it.
+	for _, req := range []*Request{
+		{Type: "status"},
+		{Type: "sessions_list"},
+		{Type: "keys_list"},
+		{Type: "status", UserID: "root", SessionID: "ignored"},
+	} {
+		if err := validateRequest(req); err != nil {
+			t.Errorf("validateRequest(%+v) = %v, want nil", req, err)
+		}
+	}
+}

--- a/internal/ipc/errors.go
+++ b/internal/ipc/errors.go
@@ -37,6 +37,8 @@ func clientErrorMessage(code string) string {
 		return "Too many concurrent authentication requests"
 	case "TOO_MANY_SESSIONS":
 		return "Maximum concurrent sessions reached"
+	case "KEY_LIST_FAILED":
+		return "Failed to list managed SSH keys"
 	default:
 		return "An error occurred"
 	}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -325,12 +325,31 @@ func (s *Server) handleConnection(conn net.Conn) {
 	log.Debug().
 		Str("request_type", request.Type).
 		Str("user_id", request.UserID).
-		Bool("success", response.Success).
+		Bool("success", responseSucceeded(response)).
 		Msg("IPC request handled")
 }
 
-// handleRequest handles different types of requests
-func (s *Server) handleRequest(request *Request) *Response {
+// responseSucceeded reports whether a handler's response carries a result rather
+// than a failure, so the connection handler can log the outcome without knowing
+// which shape it is sending.
+func responseSucceeded(response any) bool {
+	switch r := response.(type) {
+	case *Response:
+		return r.Success
+	case interface{ Err() error }: // the adminapi responses
+		return r.Err() == nil
+	default:
+		return true
+	}
+}
+
+// handleRequest handles different types of requests.
+//
+// It returns `any` rather than *Response because the administrative requests
+// (`status`, `sessions_list`, `keys_list`) answer with their own shapes, defined
+// in internal/adminapi: a session listing does not fit into the fields of an
+// authentication response.
+func (s *Server) handleRequest(request *Request) any {
 	switch request.Type {
 	case "authenticate":
 		if !s.rateLimiter.AcquireAuth() {
@@ -349,6 +368,12 @@ func (s *Server) handleRequest(request *Request) *Response {
 		return s.handleRefreshSession(request)
 	case "revoke_session":
 		return s.handleRevokeSession(request)
+	case "status":
+		return s.handleStatus()
+	case "sessions_list":
+		return s.handleSessionsList()
+	case "keys_list":
+		return s.handleKeysList()
 	default:
 		log.Warn().
 			Str("request_type", request.Type).

--- a/internal/ipc/server_coverage_test.go
+++ b/internal/ipc/server_coverage_test.go
@@ -35,7 +35,7 @@ func TestServerHandleRequestTypes(t *testing.T) {
 		UserID: "test-user",
 	}
 
-	response := server.handleRequest(invalidRequest)
+	response := authResponse(t, server.handleRequest(invalidRequest))
 	if response.Success {
 		t.Error("Expected invalid request type to fail")
 	}

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -20,6 +20,18 @@ func createTestBroker(t *testing.T) *auth.Broker {
 	return nil
 }
 
+// authResponse asserts that a handleRequest result is an authentication-shaped
+// response and returns it. handleRequest returns `any` because the admin request
+// types answer with their own shapes (see internal/adminapi).
+func authResponse(t *testing.T, v any) *Response {
+	t.Helper()
+	response, ok := v.(*Response)
+	if !ok {
+		t.Fatalf("expected *Response, got %T", v)
+	}
+	return response
+}
+
 // skipIfNotRootOnLinux skips the test when running on Linux as a non-root user.
 // The IPC server's verifyPeerCredentials unconditionally requires UID 0 on Linux,
 // so any test that connects to the socket will be rejected when run as non-root.
@@ -333,7 +345,7 @@ func TestServerHandleRequest(t *testing.T) {
 		UserID: "test-user",
 	}
 
-	response := server.handleRequest(invalidRequest)
+	response := authResponse(t, server.handleRequest(invalidRequest))
 	if response.Success {
 		t.Error("Expected failure for invalid request type")
 	}
@@ -362,7 +374,7 @@ func TestServerHandleRequestUnknownTypeDoesNotEcho(t *testing.T) {
 		UserID: "test-user",
 	}
 
-	response := server.handleRequest(request)
+	response := authResponse(t, server.handleRequest(request))
 	if response.Success {
 		t.Error("Expected failure for unknown request type")
 	}
@@ -723,7 +735,7 @@ func TestServerConcurrentAuthLimitOverSocket(t *testing.T) {
 		UserID: "test-user",
 	}
 
-	resp := server.handleRequest(req)
+	resp := authResponse(t, server.handleRequest(req))
 	if resp.ErrorCode != "TOO_MANY_CONCURRENT_AUTHS" {
 		t.Fatalf("expected TOO_MANY_CONCURRENT_AUTHS, got error_code=%q", resp.ErrorCode)
 	}

--- a/internal/ipc/validate.go
+++ b/internal/ipc/validate.go
@@ -89,6 +89,14 @@ func validateRequest(req *Request) error {
 		}
 		return validateUserID(req.UserID)
 
+	case "status", "sessions_list", "keys_list":
+		// Administrative reads. They take no parameters, so there is nothing to
+		// validate: any user_id, session_id or metadata a client sends is
+		// ignored by the handlers rather than rejected, since rejecting it would
+		// break clients that fill in a common request struct. Authorization is
+		// the socket's uid-0 peer check, not a field in the request.
+		return nil
+
 	default:
 		// Unknown types are handled by handleRequest; no validation needed here.
 		return nil

--- a/pkg/auth/admin.go
+++ b/pkg/auth/admin.go
@@ -1,0 +1,154 @@
+package auth
+
+import (
+	"sort"
+	"time"
+
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
+)
+
+// Session status values reported by ListSessions.
+const (
+	// SessionStatusPending is a device flow the user has not completed. The
+	// session exists so the poller can find it, but it grants nothing.
+	SessionStatusPending = "pending"
+	// SessionStatusActive is an authenticated session.
+	SessionStatusActive = "active"
+	// SessionStatusExpired is a session past its ExpiresAt that the cleanup
+	// sweep has not removed yet. It is not usable: every lookup path rechecks
+	// expiry rather than trusting the sweep.
+	SessionStatusExpired = "expired"
+)
+
+// BrokerStatus is a snapshot of the broker's runtime state, as reported by
+// `oidc-admin status`.
+type BrokerStatus struct {
+	Version         string
+	StartedAt       time.Time
+	Uptime          time.Duration
+	ActiveSessions  int
+	PendingSessions int
+	Providers       []string
+}
+
+// SessionInfo describes one session for operator-facing listings. It carries no
+// token material, no token ID and no group memberships: a listing answers "who
+// is logged in", and the audit log is the record for everything else.
+type SessionInfo struct {
+	ID        string
+	UserID    string
+	Provider  string
+	LoginType string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	Status    string
+}
+
+// SetVersion records the broker binary's version so `oidc-admin status` can
+// report it. The version is an ldflags variable in package main, which pkg/auth
+// cannot see; without this the status output would have to say "unknown".
+func (b *Broker) SetVersion(version string) {
+	b.version = version
+}
+
+// Status returns a snapshot of the broker's runtime state.
+//
+// Uptime is measured from Start, not from NewBroker: it answers "how long has
+// this broker been serving requests". A broker that was constructed but never
+// started reports a zero StartedAt and zero uptime rather than a fabricated one.
+func (b *Broker) Status() BrokerStatus {
+	status := BrokerStatus{
+		Version:   b.version,
+		StartedAt: b.startedAt,
+	}
+	if status.Version == "" {
+		status.Version = "unknown"
+	}
+	if !b.startedAt.IsZero() {
+		status.Uptime = time.Since(b.startedAt)
+	}
+
+	if b.config != nil {
+		status.Providers = make([]string, 0, len(b.config.OIDC.Providers))
+		for _, provider := range b.config.OIDC.Providers {
+			status.Providers = append(status.Providers, provider.Name)
+		}
+		sort.Strings(status.Providers)
+	}
+
+	b.sessionMutex.RLock()
+	defer b.sessionMutex.RUnlock()
+	for _, session := range b.sessions {
+		if session.IsActive {
+			status.ActiveSessions++
+		} else {
+			status.PendingSessions++
+		}
+	}
+
+	return status
+}
+
+// ListSessions returns every session the broker is holding, newest first.
+//
+// Pending device flows are included and labelled as such. Hiding them would make
+// the listing useless for the thing an operator most often needs it for —
+// working out whether a login that appears to be hanging has reached the broker
+// at all.
+func (b *Broker) ListSessions() []SessionInfo {
+	now := time.Now()
+
+	b.sessionMutex.RLock()
+	infos := make([]SessionInfo, 0, len(b.sessions))
+	for _, session := range b.sessions {
+		infos = append(infos, SessionInfo{
+			ID:        session.ID,
+			UserID:    session.UserID,
+			Provider:  session.Provider,
+			LoginType: session.LoginType,
+			CreatedAt: session.CreatedAt,
+			ExpiresAt: session.ExpiresAt,
+			Status:    sessionStatus(session, now),
+		})
+	}
+	b.sessionMutex.RUnlock()
+
+	// Newest first, then by ID so the order is stable for equal timestamps —
+	// map iteration order is random, and an unstable listing is hard to read and
+	// impossible to diff between two runs.
+	sort.Slice(infos, func(i, j int) bool {
+		if !infos[i].CreatedAt.Equal(infos[j].CreatedAt) {
+			return infos[i].CreatedAt.After(infos[j].CreatedAt)
+		}
+		return infos[i].ID < infos[j].ID
+	})
+
+	return infos
+}
+
+func sessionStatus(session *Session, now time.Time) string {
+	switch {
+	case !session.ExpiresAt.IsZero() && now.After(session.ExpiresAt):
+		return SessionStatusExpired
+	case session.IsActive:
+		return SessionStatusActive
+	default:
+		return SessionStatusPending
+	}
+}
+
+// ListKeys returns metadata for the SSH keys the broker manages, sorted by
+// username, along with the number of key directories it could not read.
+func (b *Broker) ListKeys() ([]sshpkg.KeyInfo, int, error) {
+	if b.keyManager == nil {
+		return nil, 0, nil
+	}
+
+	keys, unreadable, err := b.keyManager.ListKeyInfo()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Username < keys[j].Username })
+	return keys, unreadable, nil
+}

--- a/pkg/auth/admin_test.go
+++ b/pkg/auth/admin_test.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
+)
+
+func newAdminTestBroker(t *testing.T) *Broker {
+	t.Helper()
+
+	return &Broker{
+		config: &config.Config{
+			OIDC: config.OIDCConfig{
+				Providers: []config.OIDCProvider{
+					{Name: "okta"},
+					{Name: "azure"},
+				},
+			},
+			Authentication: config.AuthenticationConfig{TokenLifetime: time.Hour},
+		},
+		sessions: make(map[string]*Session),
+	}
+}
+
+func TestStatusReportsVersionUptimeAndProviders(t *testing.T) {
+	broker := newAdminTestBroker(t)
+
+	// Before Start: no uptime is claimed. A broker that has been constructed but
+	// is not serving should not report an uptime as if it were.
+	status := broker.Status()
+	if status.Version != "unknown" {
+		t.Errorf("version = %q, want %q when unset", status.Version, "unknown")
+	}
+	if !status.StartedAt.IsZero() || status.Uptime != 0 {
+		t.Errorf("unstarted broker reports started_at=%v uptime=%v, want zero", status.StartedAt, status.Uptime)
+	}
+
+	broker.SetVersion("v0.4.2")
+	broker.startedAt = time.Now().Add(-90 * time.Minute)
+
+	status = broker.Status()
+	if status.Version != "v0.4.2" {
+		t.Errorf("version = %q, want v0.4.2", status.Version)
+	}
+	if status.Uptime < 89*time.Minute || status.Uptime > 91*time.Minute {
+		t.Errorf("uptime = %v, want ~90m", status.Uptime)
+	}
+	// Sorted, so the output does not reshuffle between two runs.
+	if got := strings.Join(status.Providers, ","); got != "azure,okta" {
+		t.Errorf("providers = %q, want \"azure,okta\"", got)
+	}
+}
+
+func TestStatusCountsActiveAndPendingSessionsSeparately(t *testing.T) {
+	broker := newAdminTestBroker(t)
+
+	broker.setSession(&Session{ID: "a", UserID: "alice", IsActive: true})
+	broker.setSession(&Session{ID: "b", UserID: "bob", IsActive: true})
+	// A device flow the user has not completed. Counting it as active would
+	// overstate how many people are logged in.
+	broker.setSession(&Session{ID: "c", UserID: "carol", IsActive: false})
+
+	status := broker.Status()
+	if status.ActiveSessions != 2 {
+		t.Errorf("active = %d, want 2", status.ActiveSessions)
+	}
+	if status.PendingSessions != 1 {
+		t.Errorf("pending = %d, want 1", status.PendingSessions)
+	}
+}
+
+func TestListSessionsLabelsStatusAndOrdersNewestFirst(t *testing.T) {
+	broker := newAdminTestBroker(t)
+	now := time.Now()
+
+	broker.setSession(&Session{
+		ID: "oldest", UserID: "alice", Provider: "okta", LoginType: "ssh",
+		IsActive: true, CreatedAt: now.Add(-3 * time.Hour), ExpiresAt: now.Add(time.Hour),
+	})
+	broker.setSession(&Session{
+		ID: "middle", UserID: "bob", Provider: "azure", LoginType: "console",
+		IsActive: true, CreatedAt: now.Add(-2 * time.Hour), ExpiresAt: now.Add(-time.Minute),
+	})
+	broker.setSession(&Session{
+		ID: "newest", UserID: "carol", Provider: "okta", LoginType: "gui",
+		IsActive: false, CreatedAt: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+	})
+
+	sessions := broker.ListSessions()
+	if len(sessions) != 3 {
+		t.Fatalf("got %d sessions, want 3", len(sessions))
+	}
+
+	wantOrder := []string{"newest", "middle", "oldest"}
+	for i, want := range wantOrder {
+		if sessions[i].ID != want {
+			t.Errorf("sessions[%d].ID = %q, want %q (order should be newest first)", i, sessions[i].ID, want)
+		}
+	}
+
+	wantStatus := map[string]string{
+		"oldest": SessionStatusActive,
+		// Past its ExpiresAt but not yet swept: it is not usable, and reporting
+		// it as active would be a lie.
+		"middle": SessionStatusExpired,
+		// Authenticated flag not set: the user has not finished the device flow.
+		"newest": SessionStatusPending,
+	}
+	for _, session := range sessions {
+		if got := session.Status; got != wantStatus[session.ID] {
+			t.Errorf("session %s status = %q, want %q", session.ID, got, wantStatus[session.ID])
+		}
+	}
+
+	// LoginType is carried through, which is the reason it was added to Session:
+	// the broker applies per-login-type policy but did not record what it applied.
+	if sessions[0].LoginType != "gui" {
+		t.Errorf("login type = %q, want gui", sessions[0].LoginType)
+	}
+}
+
+// ListSessions is the one place session state leaves the broker for human
+// consumption, so it must not carry credentials — not the tokens (which live
+// encrypted in the TokenManager) and not the ID that fetches them.
+func TestSessionInfoCarriesNoTokenMaterial(t *testing.T) {
+	infoType := reflect.TypeOf(SessionInfo{})
+	for i := 0; i < infoType.NumField(); i++ {
+		name := infoType.Field(i).Name
+		if strings.Contains(name, "Token") {
+			t.Errorf("SessionInfo.%s: a session listing must not carry token material", name)
+		}
+	}
+}
+
+func TestListSessionsOnEmptyBroker(t *testing.T) {
+	if sessions := newAdminTestBroker(t).ListSessions(); len(sessions) != 0 {
+		t.Errorf("got %d sessions from an empty broker, want 0", len(sessions))
+	}
+}
+
+func TestListKeysIsSortedByUsername(t *testing.T) {
+	broker := newAdminTestBroker(t)
+	keyManager := sshpkg.NewKeyManager(t.TempDir())
+	keyManager.SetKeySize(2048) // faster than the 4096-bit default; size is not what this asserts
+	broker.keyManager = keyManager
+
+	for _, username := range []string{"zoe", "alice"} {
+		key, err := keyManager.GenerateKey(username)
+		if err != nil {
+			t.Fatalf("GenerateKey(%s): %v", username, err)
+		}
+		if err := keyManager.SaveKey(username, key); err != nil {
+			t.Fatalf("SaveKey(%s): %v", username, err)
+		}
+	}
+
+	keys, unreadable, err := broker.ListKeys()
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if unreadable != 0 {
+		t.Errorf("unreadable = %d, want 0", unreadable)
+	}
+	if len(keys) != 2 || keys[0].Username != "alice" || keys[1].Username != "zoe" {
+		t.Fatalf("got %+v, want alice then zoe", keys)
+	}
+}
+
+func TestListKeysWithoutKeyManager(t *testing.T) {
+	broker := newAdminTestBroker(t)
+
+	keys, unreadable, err := broker.ListKeys()
+	if err != nil {
+		t.Fatalf("ListKeys with no key manager should not error: %v", err)
+	}
+	if len(keys) != 0 || unreadable != 0 {
+		t.Errorf("got %d keys / %d unreadable, want 0/0", len(keys), unreadable)
+	}
+}

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -33,6 +33,8 @@ type Broker struct {
 	wg                    sync.WaitGroup
 	metrics               *oidcmetrics.Metrics // nil when metrics are disabled
 	pendingFlows          int64                // atomic counter of in-progress device authorization goroutines
+	version               string               // build version, set via SetVersion; reported by Status
+	startedAt             time.Time            // when Start ran; zero until then. Reported by Status
 }
 
 // SetMetrics attaches a Metrics instance to the broker and its policy engine.
@@ -44,11 +46,15 @@ func (b *Broker) SetMetrics(m *oidcmetrics.Metrics) {
 
 // Session represents an active authentication session
 type Session struct {
-	ID               string
-	UserID           string
-	Email            string
-	Groups           []string
-	Provider         string
+	ID       string
+	UserID   string
+	Email    string
+	Groups   []string
+	Provider string
+	// LoginType is the kind of login this session was opened for ("ssh",
+	// "console", "gui"), as classified by the PAM client. The broker applies
+	// per-login-type policy on it, and `oidc-admin sessions` reports it.
+	LoginType        string
 	DeviceID         string
 	CreatedAt        time.Time
 	ExpiresAt        time.Time
@@ -199,6 +205,8 @@ func NewBroker(cfg *config.Config) (*Broker, error) {
 // Start starts the broker services
 func (b *Broker) Start(ctx context.Context) error {
 	log.Info().Msg("Starting authentication broker services")
+
+	b.startedAt = time.Now()
 
 	// Start token manager
 	if err := b.tokenManager.Start(ctx); err != nil {
@@ -366,6 +374,7 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		ID:               sessionID,
 		UserID:           req.UserID,
 		Provider:         provider.Name,
+		LoginType:        req.LoginType,
 		DeviceID:         req.DeviceID,
 		CreatedAt:        time.Now(),
 		ExpiresAt:        time.Now().Add(b.config.Authentication.TokenLifetime),

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -345,6 +347,92 @@ func (km *KeyManager) CleanupExpiredKeys() error {
 	}
 
 	return nil
+}
+
+// KeyInfo is the public metadata of one managed key pair, for operator-facing
+// listings. It deliberately carries no key material: `oidc-admin keys` wants to
+// know which users have keys, how strong they are and when they expire.
+type KeyInfo struct {
+	Username string
+	// KeyType is the SSH algorithm name from the public key itself
+	// (e.g. "ssh-rsa"), not the manager's configured key type — an existing key
+	// may predate a configuration change.
+	KeyType string
+	// KeySize is the key's strength in bits, or 0 if it cannot be determined
+	// from the public key.
+	KeySize   int
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	Expired   bool
+}
+
+// ListKeyInfo returns metadata for every managed key pair.
+//
+// A key whose files cannot be read or parsed is skipped and counted in the
+// second return value rather than failing the whole listing: one half-written
+// directory should not make the listing unavailable, but a silently short list
+// would read as "these are all the keys".
+func (km *KeyManager) ListKeyInfo() ([]KeyInfo, int, error) {
+	users, err := km.ListKeys()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list keys: %w", err)
+	}
+
+	infos := make([]KeyInfo, 0, len(users))
+	unreadable := 0
+	for _, username := range users {
+		key, err := km.LoadKey(username)
+		if err != nil {
+			log.Warn().
+				Str("username", username).
+				Err(err).
+				Msg("Skipping key that could not be read while listing keys")
+			unreadable++
+			continue
+		}
+
+		keyType, keySize := publicKeyStrength(key.PublicKey)
+		infos = append(infos, KeyInfo{
+			Username:  username,
+			KeyType:   keyType,
+			KeySize:   keySize,
+			CreatedAt: key.CreatedAt,
+			ExpiresAt: key.ExpiresAt,
+			Expired:   km.IsKeyExpired(key),
+		})
+	}
+
+	return infos, unreadable, nil
+}
+
+// publicKeyStrength reports an authorized_keys line's algorithm name and size in
+// bits. An unparseable line yields ("unknown", 0); a parseable one whose size we
+// cannot derive keeps its algorithm name and a size of 0, since the algorithm is
+// still worth showing.
+func publicKeyStrength(publicKey []byte) (string, int) {
+	parsed, _, _, _, err := ssh.ParseAuthorizedKey(publicKey)
+	if err != nil {
+		return "unknown", 0
+	}
+
+	keyType := parsed.Type()
+
+	cryptoKey, ok := parsed.(ssh.CryptoPublicKey)
+	if !ok {
+		return keyType, 0
+	}
+
+	switch pub := cryptoKey.CryptoPublicKey().(type) {
+	case *rsa.PublicKey:
+		return keyType, pub.N.BitLen()
+	case *ecdsa.PublicKey:
+		return keyType, pub.Curve.Params().BitSize
+	case ed25519.PublicKey:
+		// Ed25519 keys have one size; there is no parameter to read.
+		return keyType, ed25519.PublicKeySize * 8
+	default:
+		return keyType, 0
+	}
 }
 
 // parseMetadata parses key metadata from a string

--- a/pkg/ssh/keys_test.go
+++ b/pkg/ssh/keys_test.go
@@ -410,3 +410,123 @@ func BenchmarkLoadKey(b *testing.B) {
 		_, _ = km.LoadKey(username)
 	}
 }
+
+func TestListKeyInfoReportsAlgorithmSizeAndExpiry(t *testing.T) {
+	tempDir := t.TempDir()
+
+	km := NewKeyManager(tempDir)
+	// 2048 bits rather than the 4096-bit default: this test is about reading the
+	// size back off the public key, and RSA generation dominates its runtime.
+	km.SetKeySize(2048)
+
+	km.SetExpiration(-time.Hour) // already expired
+	expired, err := km.GenerateKey("expired_user")
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := km.SaveKey("expired_user", expired); err != nil {
+		t.Fatalf("SaveKey: %v", err)
+	}
+
+	km.SetExpiration(time.Hour)
+	active, err := km.GenerateKey("active_user")
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := km.SaveKey("active_user", active); err != nil {
+		t.Fatalf("SaveKey: %v", err)
+	}
+
+	infos, unreadable, err := km.ListKeyInfo()
+	if err != nil {
+		t.Fatalf("ListKeyInfo: %v", err)
+	}
+	if unreadable != 0 {
+		t.Errorf("unreadable = %d, want 0", unreadable)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("got %d keys, want 2", len(infos))
+	}
+
+	byUser := make(map[string]KeyInfo, len(infos))
+	for _, info := range infos {
+		byUser[info.Username] = info
+	}
+
+	for username, wantExpired := range map[string]bool{"expired_user": true, "active_user": false} {
+		info, ok := byUser[username]
+		if !ok {
+			t.Fatalf("%s missing from listing", username)
+		}
+		if info.KeyType != "ssh-rsa" {
+			t.Errorf("%s key type = %q, want ssh-rsa", username, info.KeyType)
+		}
+		if info.KeySize != 2048 {
+			t.Errorf("%s key size = %d, want 2048", username, info.KeySize)
+		}
+		if info.Expired != wantExpired {
+			t.Errorf("%s expired = %v, want %v", username, info.Expired, wantExpired)
+		}
+		if info.CreatedAt.IsZero() || info.ExpiresAt.IsZero() {
+			t.Errorf("%s has zero timestamps: created=%v expires=%v", username, info.CreatedAt, info.ExpiresAt)
+		}
+	}
+}
+
+// A key directory that cannot be read must not take the whole listing down with
+// it, but it must be counted: a silently short list reads as "these are all the
+// keys".
+func TestListKeyInfoSkipsAndCountsUnreadableKeys(t *testing.T) {
+	tempDir := t.TempDir()
+
+	km := NewKeyManager(tempDir)
+	km.SetKeySize(2048)
+
+	key, err := km.GenerateKey("good_user")
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := km.SaveKey("good_user", key); err != nil {
+		t.Fatalf("SaveKey: %v", err)
+	}
+
+	// A directory with a private key but no metadata: what a half-finished
+	// SaveKey leaves behind. ListKeys finds it, LoadKey cannot read it.
+	brokenDir := filepath.Join(tempDir, "broken_user")
+	if err := os.MkdirAll(brokenDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brokenDir, "id_rsa"), []byte("not a key"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	infos, unreadable, err := km.ListKeyInfo()
+	if err != nil {
+		t.Fatalf("ListKeyInfo: %v", err)
+	}
+	if unreadable != 1 {
+		t.Errorf("unreadable = %d, want 1", unreadable)
+	}
+	if len(infos) != 1 || infos[0].Username != "good_user" {
+		t.Fatalf("got %+v, want just good_user", infos)
+	}
+}
+
+func TestListKeyInfoOnMissingBaseDir(t *testing.T) {
+	km := NewKeyManager(filepath.Join(t.TempDir(), "does-not-exist"))
+
+	infos, unreadable, err := km.ListKeyInfo()
+	if err != nil {
+		t.Fatalf("ListKeyInfo on a missing base dir should not error: %v", err)
+	}
+	if len(infos) != 0 || unreadable != 0 {
+		t.Errorf("got %d keys / %d unreadable, want 0/0", len(infos), unreadable)
+	}
+}
+
+func TestPublicKeyStrengthOnUnparseableKey(t *testing.T) {
+	keyType, keySize := publicKeyStrength([]byte("this is not an authorized_keys line"))
+	if keyType != "unknown" || keySize != 0 {
+		t.Errorf("got (%q, %d), want (\"unknown\", 0)", keyType, keySize)
+	}
+}


### PR DESCRIPTION
Fixes #124. Stacked on #134 (`feat/wire-token-manager`) — review that one first; this PR's diff against `main` will shrink once it merges.

## The bug

Every `oidc-admin` command that talks to the broker was silently broken. The CLI sent `status`, `sessions_list` and `keys_list`; the broker implemented none of them, so each request fell through to `INVALID_REQUEST_TYPE`. The client then decoded that error object into its own response struct — which shares no fields with it — and printed the resulting zero value:

```
$ sudo oidc-admin status
Broker Status: RUNNING          # ...answering INVALID_REQUEST_TYPE
Version:
Uptime:
$ sudo oidc-admin sessions
No active sessions
```

The root cause is drift: the request and response types were declared twice, once on each side, and the two copies disagreed. So the fix is structural, not just "add three handlers".

## What changed

**One definition of the wire types.** New `internal/adminapi`, imported by both the broker and the CLI. Every admin response embeds `adminapi.Error`, so a broker refusal can no longer decode as an empty success, and `TestAdminResponsesRoundTripToClientTypes` decodes the server's own output with `DisallowUnknownFields` — it fails if the two sides drift again.

**The broker can answer.** `pkg/auth/admin.go` adds `Broker.Status()`, `ListSessions()` and `ListKeys()`; `internal/ipc/admin.go` maps them to wire types, keeping the layering the repo already uses (`cmd/oidc-admin` never imports `pkg/auth`). `Server.handleRequest` returns `any`, since these answers have their own shapes rather than being squeezed into an authentication response's fields.

- `status`: version (via `SetVersion`, called from `cmd/broker` with the ldflags value — `pkg/auth` cannot see it), start time, uptime, sorted providers, active vs pending session counts. An unstarted broker reports zero uptime rather than a fabricated one.
- `sessions`: user, provider, login type, creation time, expiry, status. **`pending`** rows are device flows the user never completed — that is what a "login is hanging" report actually looks like, and until now there was no way to see them.
- `keys`: algorithm, size in bits, status, expiry, from the new `KeyManager.ListKeyInfo`.

**Nothing in a listing is a credential** — no tokens, no token IDs, no key material. `TestSessionInfoCarriesNoTokenMaterial` is a reflection guard against `SessionInfo` regaining a token field.

**Truthful listings.** `ListKeyInfo` skips key directories it cannot read but *counts* them, surfaced as `unreadable` on the wire and a warning in the CLI, so a short listing is never mistaken for a complete one. Sessions sort newest-first and keys by username, so repeated runs are diffable.

**A client that can tell failure from silence.** `oidc-admin` no longer decides whether the broker is running by opening a throwaway connection — a broker that accepts connections but cannot answer them was reported as healthy. It sends the real request, distinguishes `errBrokerUnreachable` (prints `STOPPED`) from a broker that answers with an error, and bounds every request with a 10-second deadline so a broker that goes quiet mid-response cannot hang the CLI.

Also: `Session.LoginType`, because the broker applied per-login-type policy without recording which login type the session was opened for.

## Access control

Unchanged: the broker socket accepts uid 0 only, via the existing peer-credential check, so all five commands need `sudo`. `DEPLOYMENT.md` gains an "Administrative CLI" section documenting the commands, the `sudo` requirement, `OIDC_SOCKET_PATH`, and the pending/active/expired status values; the weekly-maintenance block now uses `oidc-admin` instead of the deleted `./test-broker` binary.

## Tests

`internal/adminapi` and `cmd/oidc-admin` are added to CI's vet, test and lint lists (neither was covered before). New tests: routing and payload shape for all three types, `Status` on a started broker, empty listings encoding as `[]` rather than `null`, the drift guard, error-shaped responses, `formatUptime`, `validateRequest` acceptance, `ListKeyInfo` algorithm/size/expiry plus the unreadable-directory path, and a fake-broker suite for the client covering decode, broker error, unreachable broker and the request deadline.

`make verify-linux` is green: `go vet ./...`, `go test -race ./pkg/... ./internal/...`, `golangci-lint run ./...` → 0 issues.
