### PR TITLE
fix(auth): select the OIDC provider deterministically, by priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bridge compiles warning-free.
 
 ### Changed
+- **(#125)** `Broker.selectProvider` takes no arguments. It accepted an
+  `*AuthRequest` and a `*PolicyResult` and read neither, which is part of why it
+  went unnoticed that the body was non-deterministic; nothing about the request
+  influences the choice today.
 - **(#124)** `Server.handleRequest` returns `any`, since the admin requests answer
   with their own shapes rather than squeezing a session listing into the fields of
   an authentication response. `internal/adminapi` and `cmd/oidc-admin` are covered
@@ -186,6 +190,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suggested a capability that did not exist.
 
 ### Fixed
+- **(#125)** Provider selection is deterministic. `selectProvider` ranged over a
+  Go map and returned the first login-enabled provider it happened to hit, so on
+  a host with more than one such provider, consecutive logins could be sent to
+  different identity providers at random — and `priority` was read from the
+  config file and then never used. Candidates are now ordered by `priority`
+  ascending (**1 is the most preferred**, matching every shipped config, where the
+  primary provider is `priority: 1` and the failover provider is `priority: 2`),
+  then by name so that equal priorities still order identically on every host and
+  across restarts. A provider that omits `priority` sorts *after* every provider
+  that sets one, so forgetting the field cannot promote a provider over the
+  declared primary; negative values are treated the same way. Documented in
+  `configs/CONFIGURATION-GUIDE.md`.
+- **(#125)** `verification_only` is honoured. It was parsed and never read, so a
+  provider marked "may confirm an identity, must not be logged in against" was a
+  valid login target if `enabled_for_login` was also set. It is now excluded from
+  login selection.
 - **(#124) Every `oidc-admin` command that talks to the broker was silently
   broken.** The CLI sent `status`, `sessions_list` and `keys_list`; the broker
   implemented none of them, so each request fell through to

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -7,9 +7,10 @@ This guide provides comprehensive instructions for configuring the OIDC PAM auth
 1. [Quick Start](#quick-start)
 2. [Configuration Templates](#configuration-templates)
 3. [Provider-Specific Setup](#provider-specific-setup)
-4. [Security Best Practices](#security-best-practices)
-5. [Environment-Specific Configurations](#environment-specific-configurations)
-6. [Troubleshooting](#troubleshooting)
+4. [Multiple Providers and `priority`](#multiple-providers-and-priority)
+5. [Security Best Practices](#security-best-practices)
+6. [Environment-Specific Configurations](#environment-specific-configurations)
+7. [Troubleshooting](#troubleshooting)
 
 ## Quick Start
 
@@ -306,6 +307,49 @@ Any provider that lacks a publicly accessible `/.well-known/openid-configuration
 | `userinfo_endpoint` | optional | OpenID Connect UserInfo endpoint |
 
 When `skip_discovery: true` is set, the broker constructs the OIDC provider from these fields directly using `oidc.ProviderConfig` — no network call is made to the discovery endpoint at startup.
+
+## Multiple Providers and `priority`
+
+A login is served by exactly one provider. When more than one is configured, the
+broker picks it deterministically:
+
+1. Providers with `enabled_for_login: false` (the default) are not candidates.
+2. Providers with `verification_only: true` are not candidates either — that flag
+   means the provider may confirm an identity but must not be the one a login is
+   issued against. Setting both it and `enabled_for_login: true` is
+   contradictory, and the broker resolves it by not offering logins.
+3. The remaining candidates are ordered by `priority` **ascending — 1 is the most
+   preferred**, as in `broker-enterprise.yaml`, where the primary provider is
+   `priority: 1` and the failover provider is `priority: 2`.
+4. A provider that omits `priority` sorts *after* every provider that sets one,
+   so forgetting the field cannot promote a provider over your declared primary.
+   Negative values are treated the same way, as typos rather than as a way to
+   mean "first".
+5. Providers with equal priority are ordered by name, so the choice is the same
+   on every host and across restarts.
+
+```yaml
+oidc:
+  providers:
+    - name: corporate-primary
+      priority: 1              # chosen for every login
+      enabled_for_login: true
+
+    - name: corporate-backup
+      priority: 2              # configured, but not selected while the primary is present
+      enabled_for_login: true
+
+    - name: orcid
+      priority: 3
+      enabled_for_login: true
+      verification_only: true  # never selected for a login
+```
+
+`sudo oidc-admin status` lists the providers the broker loaded. Note that
+priority is a *preference*, not health-based failover: the broker does not
+currently probe providers and fall through to the next one when the preferred
+provider is unreachable, so a login against an unavailable primary fails rather
+than silently using the backup.
 
 ## Security Best Practices
 

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -33,9 +33,14 @@ oidc:
         enable_data_use_agreements: false
         
       # Provider settings
+      # priority orders providers when more than one can serve a login: 1 is the
+      # most preferred, and a provider that omits it sorts last. Ties are broken
+      # by name. See CONFIGURATION-GUIDE.md, "Multiple Providers and priority".
       priority: 1
       user_type: "corporate"
       enabled_for_login: true
+      # verification_only: this provider may confirm an identity but must never
+      # be the one a login is issued against.
       verification_only: false
 
     # Example: Azure AD configuration  
@@ -50,6 +55,8 @@ oidc:
         name_claim: "name"
         groups_claim: "groups"
         
+      # Lower preference than okta-corporate above: configured, but not selected
+      # while a priority-1 provider is present.
       priority: 2
       user_type: "corporate"
       enabled_for_login: true

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -328,7 +330,7 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 	}
 
 	// Select appropriate provider
-	provider := b.selectProvider(req, policyResult)
+	provider := b.selectProvider()
 	if provider == nil {
 		return &AuthResponse{
 			Success:      false,
@@ -732,16 +734,64 @@ func (b *Broker) createSuccessResponse(session *Session) *AuthResponse {
 	}
 }
 
-func (b *Broker) selectProvider(req *AuthRequest, policyResult *PolicyResult) *OIDCProvider {
-	// For now, select the first available provider
-	// In a full implementation, this would consider provider priority,
-	// user preferences, policy requirements, etc.
+// selectProvider returns the provider a new login should be sent to, or nil if
+// the configuration has none that can serve one.
+//
+// It takes no request or policy argument on purpose: nothing about the request
+// influences the choice today. The previous signature accepted both and read
+// neither, which is how it went unnoticed that the body ranged over a map — so
+// with more than one login-enabled provider, consecutive logins on the same host
+// could be sent to different identity providers at random, and `priority` was
+// parsed from the config and never read. Reinstate the parameters along with the
+// logic that actually needs them.
+func (b *Broker) selectProvider() *OIDCProvider {
+	candidates := b.loginProviders()
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates[0]
+}
+
+// loginProviders returns every provider eligible to serve a login, in
+// precedence order: by `priority` ascending, then by name.
+//
+// Priority 1 is the most preferred, matching the shipped configurations, where
+// the primary provider is `priority: 1` and the failover provider is
+// `priority: 2`. A provider that does not set `priority` at all sorts *after*
+// every provider that does, so omitting the field cannot outrank an explicit
+// declaration.
+func (b *Broker) loginProviders() []*OIDCProvider {
+	candidates := make([]*OIDCProvider, 0, len(b.providers))
 	for _, provider := range b.providers {
-		if provider.Config.EnabledForLogin {
-			return provider
+		// verification_only means the provider may confirm an identity but must
+		// not be the one a login is issued against, so it is not a candidate
+		// even if enabled_for_login is also set. The two together are
+		// contradictory config; this resolves it the safe way.
+		if provider.Config.EnabledForLogin && !provider.Config.VerificationOnly {
+			candidates = append(candidates, provider)
 		}
 	}
-	return nil
+
+	sort.Slice(candidates, func(i, j int) bool {
+		left, right := providerPriority(candidates[i]), providerPriority(candidates[j])
+		if left != right {
+			return left < right
+		}
+		// Ties broken by name so that the order is stable across restarts and
+		// independent of Go's map iteration order.
+		return candidates[i].Name < candidates[j].Name
+	})
+
+	return candidates
+}
+
+// providerPriority maps a provider's configured priority onto its sort key,
+// translating "unset" (0, and any nonsensical negative value) to "last".
+func providerPriority(provider *OIDCProvider) int {
+	if provider.Config.Priority <= 0 {
+		return math.MaxInt
+	}
+	return provider.Config.Priority
 }
 
 func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvider, deviceFlow *DeviceFlow) {

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -262,44 +262,22 @@ func TestBrokerProviderSelection(t *testing.T) {
 		},
 	}
 
-	// Test provider selection
-	authRequest := &AuthRequest{
-		UserID:     "test-user@provider1.com",
-		SourceIP:   "192.168.1.100",
-		UserAgent:  "test-agent",
-		TargetHost: "test-host",
-		LoginType:  "ssh",
-		DeviceID:   "test-device",
-		SessionID:  "test-session",
-		Timestamp:  time.Now(),
-	}
-
-	// Create a basic policy result
-	policyResult := &PolicyResult{
-		Allowed:        true,
-		Reason:         "test policy",
-		RequiredMFA:    false,
-		RequiredGroups: nil,
-		MaxDuration:    time.Hour,
-		RiskScore:      0,
-		RiskFactors:    nil,
-		Metadata:       nil,
-	}
-
-	provider := broker.selectProvider(authRequest, policyResult)
+	// provider1 is priority 1 and provider2 is priority 2, so provider1 wins.
+	// This assertion used to accept either one, which is what allowed the map
+	// iteration to go unnoticed.
+	provider := broker.selectProvider()
 	if provider == nil {
-		t.Error("Expected non-nil provider")
-		return
+		t.Fatal("Expected non-nil provider")
 	}
-	if provider.Name != "provider1" && provider.Name != "provider2" {
-		t.Errorf("Expected provider1 or provider2, got %s", provider.Name)
+	if provider.Name != "provider1" {
+		t.Errorf("selectProvider() = %s, want provider1 (priority 1)", provider.Name)
 	}
 
-	// Test provider selection with different user
-	authRequest.UserID = "test-user"
-	provider = broker.selectProvider(authRequest, policyResult)
-	if provider == nil {
-		t.Error("Expected non-nil provider (should default to first)")
+	// And it keeps winning: the choice must not vary between calls.
+	for i := 0; i < 20; i++ {
+		if again := broker.selectProvider(); again.Name != provider.Name {
+			t.Fatalf("call %d selected %s, first call selected %s", i, again.Name, provider.Name)
+		}
 	}
 }
 

--- a/pkg/auth/provider_selection_test.go
+++ b/pkg/auth/provider_selection_test.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// selectionBroker builds a broker whose provider map holds exactly the given
+// provider configs. The map is deliberately the only ordering input, so a
+// selection that depends on Go's map iteration order shows up as a flake here.
+func selectionBroker(providers ...config.OIDCProvider) *Broker {
+	byName := make(map[string]*OIDCProvider, len(providers))
+	for _, providerConfig := range providers {
+		byName[providerConfig.Name] = &OIDCProvider{
+			Name:   providerConfig.Name,
+			Config: providerConfig,
+		}
+	}
+	return &Broker{providers: byName}
+}
+
+func loginProvider(name string, priority int) config.OIDCProvider {
+	return config.OIDCProvider{Name: name, Priority: priority, EnabledForLogin: true}
+}
+
+// Priority 1 is the most preferred, matching every shipped configuration: in
+// configs/production/broker-enterprise.yaml the primary provider is priority 1
+// and the one commented "Backup provider for failover" is priority 2.
+func TestSelectProviderPrefersTheLowestPriorityNumber(t *testing.T) {
+	broker := selectionBroker(
+		loginProvider("contractors", 4),
+		loginProvider("corporate-primary", 1),
+		loginProvider("service-accounts", 3),
+		loginProvider("corporate-backup", 2),
+	)
+
+	provider := broker.selectProvider()
+	if provider == nil {
+		t.Fatal("selectProvider returned nil with four eligible providers")
+	}
+	if provider.Name != "corporate-primary" {
+		t.Errorf("selectProvider() = %s, want corporate-primary (priority 1)", provider.Name)
+	}
+
+	// The full order matters too: it is the failover order.
+	want := []string{"corporate-primary", "corporate-backup", "service-accounts", "contractors"}
+	assertOrder(t, broker, want)
+}
+
+// The bug: ranging over b.providers meant the selection could differ between
+// two consecutive logins on the same host with the same config, sending users
+// to a different identity provider at random.
+func TestSelectProviderIsStableAcrossCalls(t *testing.T) {
+	broker := selectionBroker(
+		loginProvider("alpha", 5),
+		loginProvider("bravo", 5),
+		loginProvider("charlie", 5),
+		loginProvider("delta", 5),
+		loginProvider("echo", 5),
+	)
+
+	first := broker.selectProvider()
+	if first == nil {
+		t.Fatal("selectProvider returned nil")
+	}
+	// Equal priorities are broken by name, so this is deterministic rather than
+	// merely repeatable-by-luck.
+	if first.Name != "alpha" {
+		t.Errorf("selectProvider() = %s, want alpha (first by name among equal priorities)", first.Name)
+	}
+
+	for i := 0; i < 100; i++ {
+		if got := broker.selectProvider(); got.Name != first.Name {
+			t.Fatalf("call %d selected %s, want %s on every call", i, got.Name, first.Name)
+		}
+	}
+}
+
+// A provider that omits `priority` must not outrank one that declares it:
+// unset is 0, which would otherwise sort ahead of priority 1.
+func TestSelectProviderTreatsUnsetPriorityAsLast(t *testing.T) {
+	broker := selectionBroker(
+		loginProvider("undeclared", 0),
+		loginProvider("declared", 2),
+	)
+
+	if provider := broker.selectProvider(); provider.Name != "declared" {
+		t.Errorf("selectProvider() = %s, want declared (priority 2 beats unset)", provider.Name)
+	}
+	assertOrder(t, broker, []string{"declared", "undeclared"})
+}
+
+// Negative priorities are not a documented way to mean "first"; they are a
+// typo. Treat them like unset rather than letting one silently take over every
+// login on the host.
+func TestSelectProviderTreatsNegativePriorityAsUnset(t *testing.T) {
+	broker := selectionBroker(
+		loginProvider("typo", -1),
+		loginProvider("declared", 3),
+	)
+
+	if provider := broker.selectProvider(); provider.Name != "declared" {
+		t.Errorf("selectProvider() = %s, want declared", provider.Name)
+	}
+}
+
+// With no priorities configured at all — the common single- and two-provider
+// case — the order is still fixed, by name.
+func TestSelectProviderWithNoPrioritiesOrdersByName(t *testing.T) {
+	broker := selectionBroker(
+		loginProvider("okta", 0),
+		loginProvider("azure", 0),
+		loginProvider("keycloak", 0),
+	)
+
+	assertOrder(t, broker, []string{"azure", "keycloak", "okta"})
+}
+
+func TestSelectProviderSkipsProvidersNotEnabledForLogin(t *testing.T) {
+	broker := selectionBroker(
+		config.OIDCProvider{Name: "disabled-but-preferred", Priority: 1},
+		loginProvider("enabled", 9),
+	)
+
+	provider := broker.selectProvider()
+	if provider == nil {
+		t.Fatal("selectProvider returned nil with one eligible provider")
+	}
+	if provider.Name != "enabled" {
+		t.Errorf("selectProvider() = %s, want enabled", provider.Name)
+	}
+}
+
+// verification_only means "may confirm an identity, must not be logged in
+// against". Set together with enabled_for_login it is contradictory config, and
+// the safe reading is that it is not a login candidate.
+func TestSelectProviderSkipsVerificationOnlyProviders(t *testing.T) {
+	verificationOnly := loginProvider("orcid", 1)
+	verificationOnly.VerificationOnly = true
+
+	broker := selectionBroker(verificationOnly, loginProvider("globus", 2))
+
+	provider := broker.selectProvider()
+	if provider == nil {
+		t.Fatal("selectProvider returned nil with one eligible provider")
+	}
+	if provider.Name != "globus" {
+		t.Errorf("selectProvider() = %s, want globus (orcid is verification_only)", provider.Name)
+	}
+	assertOrder(t, broker, []string{"globus"})
+}
+
+func TestSelectProviderWithNoEligibleProviders(t *testing.T) {
+	tests := map[string]*Broker{
+		"no providers at all": selectionBroker(),
+		"none enabled for login": selectionBroker(
+			config.OIDCProvider{Name: "verify-only", Priority: 1},
+			config.OIDCProvider{Name: "also-off", Priority: 2},
+		),
+	}
+
+	for name, broker := range tests {
+		t.Run(name, func(t *testing.T) {
+			if provider := broker.selectProvider(); provider != nil {
+				t.Errorf("selectProvider() = %s, want nil", provider.Name)
+			}
+		})
+	}
+}
+
+func assertOrder(t *testing.T, broker *Broker, want []string) {
+	t.Helper()
+
+	candidates := broker.loginProviders()
+	got := make([]string, len(candidates))
+	for i, candidate := range candidates {
+		got[i] = candidate.Name
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("loginProviders() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("loginProviders() = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #125. Stacked on #135 (`feat/admin-ipc-handlers`) — review that first; this PR's diff against `main` shrinks once it merges.

## The bug

`selectProvider` ranged over `b.providers`, a Go map, and returned the first login-enabled provider it happened to hit:

```go
for _, provider := range b.providers {
	if provider.Config.EnabledForLogin {
		return provider
	}
}
```

On a host with more than one login-enabled provider, two consecutive logins with the *same* configuration could be sent to different identity providers at random. And `priority` — parsed into `config.OIDCProvider` since the field was added — was never read by anything.

## Which direction is "higher priority"?

⚠️ **This is where I deviated from the plan.** The plan said sort `priority` *descending*. The repo's own configs say otherwise: `configs/production/broker-enterprise.yaml:37-91` runs `priority: 1, 2, 3, 4` down the list, and the `priority: 2` entry is the one commented **"Backup provider for failover"**. `configs/examples/broker.yaml`, `configs/providers/okta.yaml`'s multi-authorization-server example, and `oidc_provider_configuration.md` all follow the same convention: 1 is the primary.

Sorting descending would have made every shipped multi-provider config select its *least* preferred provider — the enterprise config would have routed all logins to `contractors`. So: **ascending, 1 is most preferred**, consistent with `nice`, MX records, and `ip route metric`.

## The ordering

1. `enabled_for_login: false` (the default) — not a candidate.
2. `verification_only: true` — not a candidate either. See below.
3. `priority` ascending, 1 first.
4. A provider that **omits** `priority` sorts *after* every provider that sets one. Unset is `0`, which would otherwise outrank an explicit `priority: 1`, so forgetting the field cannot promote a provider over your declared primary. Negative values are treated the same way — a typo, not a way to mean "first".
5. Equal priorities are broken by name, so the order is identical on every host and across restarts rather than merely repeatable by luck.

## `verification_only` (in scope, same class of bug)

Another parsed-but-unread field. A provider marked "may confirm an identity but must not be the one a login is issued against" was a perfectly valid login target whenever `enabled_for_login` was also set. Setting both is contradictory config, and this resolves it the safe way: not a login candidate. Flagging it explicitly since it is a small behaviour change beyond the issue's headline — a config with both flags set on a provider will stop issuing logins against it, which is what the field name asks for.

## Signature change

`selectProvider` no longer takes `*AuthRequest` and `*PolicyResult`. It read neither, and a signature that claims to consider the request is part of why the map iteration survived unnoticed. The doc comment says what to reinstate them alongside.

## Tests

`TestBrokerProviderSelection` asserted only that the result was `"provider1 or provider2"` — precisely the non-determinism at issue. It now requires the priority-1 provider, on every one of 20 calls. New `pkg/auth/provider_selection_test.go` covers the four-provider failover ordering, stability across 100 calls with five equal-priority providers, unset and negative priority, name ordering when no priorities are set, both filters, and the no-candidates case. Run with `-count=3 -race`.

## Documentation

The selection rules only existed implicitly in the example configs. `configs/CONFIGURATION-GUIDE.md` gains a "Multiple Providers and `priority`" section stating them, plus the limitation worth knowing before relying on a `priority: 2` entry: **this is a preference, not health-based failover.** The broker does not probe providers and fall through when the preferred one is unreachable, so a login against a down primary fails rather than quietly using the backup. `configs/examples/broker.yaml` gets inline comments to match.

`make verify-linux` is green: `go vet ./...`, `go test -race ./pkg/... ./internal/...`, `golangci-lint run ./...` → 0 issues.
