### PR TITLE
chore(security): bump the Go toolchain pin to 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Verify dependencies
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Install PAM development libraries
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Install PAM development libraries
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Install PAM development libraries
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Install build dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Initialize CodeQL
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Run Gosec Security Scanner
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
 
       - name: Install PAM development libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- Bumped the Go toolchain pin from 1.25.12 to 1.25.13. govulncheck reported four
+  called standard-library vulnerabilities against 1.25.12, all fixed in 1.25.13:
+  GO-2026-6218 (quadratic `resolvePath` in `net/url`), GO-2026-6090
+  (post-handshake message limit in `crypto/tls`), GO-2026-6089
+  (`ReadHeaderTimeout` on the unencrypted HTTP/2 check in `net/http`) and
+  GO-2026-5972 (asn1 recursion depth). They are reachable from the metrics HTTP
+  server, the HTTP audit sink, and the provider TLS setup. Clean afterwards.
 - **Critical (#140): every `pam_oidc.so` this project has ever released contains
   no PAM entry points at all.** `nm -D --defined-only bin/pam_oidc.so` finds zero
   `pam_sm_*` symbols, and `readelf -d` shows the module does not even link

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scttfrdmn/oidc-pam
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/coreos/go-oidc/v3 v3.19.0

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -1,10 +1,10 @@
 # Integration-test image, built by docker-compose.test.yml.
 #
 # Pin the toolchain to the version in go.mod and in .github/workflows/ci.yml.
-# This was golang:1.21-alpine, four minor versions behind the `go 1.25.12`
+# This was golang:1.21-alpine, four minor versions behind the `go 1.25.13`
 # directive in go.mod, so the build either refused outright or silently spent
 # time downloading a second toolchain at image-build time.
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
govulncheck started failing on 1.25.12 with four **called** standard-library
vulnerabilities, all fixed in 1.25.13:

| Advisory | Issue | Reachable from |
|---|---|---|
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | quadratic `resolvePath` in `net/url` | `pkg/security/audit.go:538` (HTTP audit sink) |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | post-handshake message limit in `crypto/tls` | `pkg/metrics/server.go:44`, `pkg/security/audit.go:538` |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `ReadHeaderTimeout` on the unencrypted HTTP/2 check in `net/http` | `pkg/metrics/server.go:44` (metrics server) |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | recursion depth in `encoding/asn1` | `pkg/auth/device_flow.go:218` (provider TLS setup) |

The advisories were published between the last `security.yml` run on `main`
(21:14 UTC, green) and the run on #143 (22:20 UTC, red), so this is a
vulnerability-database update, not a regression from any code change.

Bumps `go.mod` and the `setup-go` pins in `ci.yml`, `security.yml` and
`release.yml`, plus `test/Dockerfile.integration`.
`test/docker/Dockerfile.verify` tracks `golang:1.25` and picks the patch up on
rebuild. The README and CONTRIBUTING requirements are stated as a minor version
(`Go 1.25 or higher`) and remain correct.

Verified locally: `go build ./...` and `go test ./pkg/... ./internal/...` clean.