### PR TITLE
fix(auth): keep polling on authorization_pending so device logins complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Critical (#150): the broker abandoned every device flow on the first poll,
+  so no device login could ever complete.** RFC 8628 §3.5 makes
+  `authorization_pending` the *normal* answer to every poll before the user
+  finishes in the browser, but `PollDeviceAuthorization` returned it wrapped as
+  `"token error: authorization_pending"` while `pollDeviceAuthorization`
+  compared `err.Error()` against the bare `"authorization_pending"`. The
+  comparison never matched, so the pending answer fell through to the deny path:
+  audit `device_authorization_failed`, session deleted, goroutine gone —
+  typically about five seconds after the verification URL was displayed, leaving
+  the user with a code and a session that no longer existed. `slow_down` was
+  treated the same way, and the polling interval never grew as the RFC requires.
+  The two codes are now sentinel errors (`ErrAuthorizationPending`, `ErrSlowDown`)
+  wrapped with `%w` and matched with `errors.Is`, so the pending path continues
+  polling, `slow_down` adds 5 s to the interval and resets the ticker, and only
+  the device code's own expiry or a genuinely terminal code (`access_denied`,
+  `expired_token`, an invalid ID token) ends the flow. The audit message keeps
+  its `token error: <code>` shape.
+
+  The bug was invisible to unit tests on either side — the provider returned the
+  right code and the loop compared against a plausible string; what went untested
+  was the two halves agreeing. So the regression gate is an end-to-end one: see
+  **Added** below.
+
+### Added
+- `internal/testoidc`, an in-process OpenID Connect issuer for tests: discovery,
+  JWKS, RS256-signed ID tokens (real signatures, real `aud`/`iss`/`exp`/`nonce`,
+  so go-oidc's verifier is exercised rather than bypassed), the device
+  authorization endpoint and userinfo. Its point is `Script(...)`, which sets the
+  *sequence* of token-endpoint answers — a fake that grants on the first poll
+  cannot tell a working client from one that treats `authorization_pending` as
+  fatal, which is precisely #150.
+- `pkg/auth` tests driving `pollDeviceAuthorization` against that issuer:
+  pending-pending-grant reaches an active session with its tokens in the
+  encrypted store (this fails on the pre-fix code with the session already
+  deleted after one poll), `slow_down` slows the poll rate without ending the
+  flow, `access_denied` and `expired_token` stay terminal, the device code's
+  expiry bounds the loop, and stopping the broker abandons it. `Broker` gained an
+  unexported `pollIntervalUnit` so those tests do not have to wait out RFC 8628's
+  5-second interval floor.
+
 ### Security
 - Bumped the Go toolchain pin from 1.25.12 to 1.25.13. govulncheck reported four
   called standard-library vulnerabilities against 1.25.12, all fixed in 1.25.13:

--- a/internal/testoidc/testoidc.go
+++ b/internal/testoidc/testoidc.go
@@ -1,0 +1,319 @@
+// Package testoidc provides an in-process OpenID Connect issuer for tests.
+//
+// It speaks enough of OIDC discovery and RFC 8628 (device authorization) for the
+// broker to run a whole device flow against it: discovery, JWKS, the device
+// authorization endpoint, the token endpoint and userinfo. ID tokens are real
+// RS256 JWTs signed with a per-server key and published through the JWKS
+// endpoint, so go-oidc's verifier — signature, issuer, audience, expiry and
+// nonce — is exercised rather than bypassed.
+//
+// The point of it is the token endpoint's *sequence* of answers. A real device
+// flow answers authorization_pending to every poll until the user finishes in
+// the browser, and may answer slow_down; a fake that grants on the first poll
+// cannot tell a working client from one that treats pending as fatal, which is
+// exactly the bug #150 was. Script() sets that sequence explicitly.
+//
+// It listens on 127.0.0.1 over plain HTTP, which the broker's endpoint
+// validation accepts for localhost only. The containerised end-to-end harness
+// needs TLS and a control API on top of this; see test/e2e/fakeoidc.
+package testoidc
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Outcome is one answer from the token endpoint.
+type Outcome string
+
+const (
+	// Pending is authorization_pending: the user has not finished in the
+	// browser yet. Non-terminal — the client must keep polling (RFC 8628 §3.5).
+	Pending Outcome = "authorization_pending"
+	// SlowDown asks the client to poll less often. Also non-terminal, and the
+	// client must add 5 seconds to its interval.
+	SlowDown Outcome = "slow_down"
+	// Grant issues the tokens: the user approved.
+	Grant Outcome = "grant"
+	// AccessDenied is terminal: the user (or the IdP) refused.
+	AccessDenied Outcome = "access_denied"
+	// ExpiredToken is terminal: the device code is no longer valid.
+	ExpiredToken Outcome = "expired_token"
+)
+
+// Server is a running fake issuer. Create one with New.
+type Server struct {
+	ts       *httptest.Server
+	key      *rsa.PrivateKey
+	kid      string
+	clientID string
+
+	mu      sync.Mutex
+	script  []Outcome
+	polls   int
+	claims  map[string]any
+	devices map[string]string // device_code -> nonce received at the device endpoint
+}
+
+// New starts a fake issuer for clientID and registers its shutdown with tb.
+// Until Script is called the token endpoint grants on the first poll.
+func New(tb testing.TB, clientID string) *Server {
+	tb.Helper()
+
+	// 2048 bits: large enough that nothing rejects it, small enough not to
+	// dominate the runtime of every test that needs an issuer.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		tb.Fatalf("testoidc: generate signing key: %v", err)
+	}
+
+	pub, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		tb.Fatalf("testoidc: marshal public key: %v", err)
+	}
+	sum := sha256.Sum256(pub)
+
+	s := &Server{
+		key:      key,
+		kid:      b64(sum[:8]),
+		clientID: clientID,
+		script:   []Outcome{Grant},
+		devices:  make(map[string]string),
+		claims: map[string]any{
+			"sub":                "test-subject",
+			"preferred_username": "testuser",
+			"email":              "testuser@example.org",
+			"groups":             []string{"researchers"},
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", s.handleDiscovery)
+	mux.HandleFunc("/jwks", s.handleJWKS)
+	mux.HandleFunc("/device", s.handleDevice)
+	mux.HandleFunc("/token", s.handleToken)
+	mux.HandleFunc("/userinfo", s.handleUserInfo)
+
+	s.ts = httptest.NewServer(mux)
+	tb.Cleanup(s.ts.Close)
+	return s
+}
+
+// Issuer is the server's issuer URL, for a provider's `issuer` setting.
+func (s *Server) Issuer() string { return s.ts.URL }
+
+// Close shuts the server down. New already registers this with tb.Cleanup;
+// call it only to stop the issuer early, e.g. to test a provider going away.
+func (s *Server) Close() { s.ts.Close() }
+
+// Script sets the outcomes the token endpoint returns, in order. The last one
+// repeats once the script is exhausted, so Script(Pending) answers pending
+// forever and Script(Pending, Pending, Grant) grants on the third poll.
+func (s *Server) Script(outcomes ...Outcome) {
+	if len(outcomes) == 0 {
+		panic("testoidc: Script needs at least one outcome")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.script = outcomes
+	s.polls = 0
+}
+
+// SetClaims replaces the claim set put in ID tokens and returned by userinfo.
+// "iss", "aud", "exp", "iat" and "nonce" are always set by the server and
+// cannot be overridden here.
+func (s *Server) SetClaims(claims map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.claims = claims
+}
+
+// Polls is the number of token-endpoint requests received so far.
+func (s *Server) Polls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.polls
+}
+
+func (s *Server) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issuer":                                s.ts.URL,
+		"authorization_endpoint":                s.ts.URL + "/authorize",
+		"token_endpoint":                        s.ts.URL + "/token",
+		"device_authorization_endpoint":         s.ts.URL + "/device",
+		"userinfo_endpoint":                     s.ts.URL + "/userinfo",
+		"jwks_uri":                              s.ts.URL + "/jwks",
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"grant_types_supported": []string{
+			"authorization_code",
+			"urn:ietf:params:oauth:grant-type:device_code",
+		},
+	})
+}
+
+func (s *Server) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"keys": []map[string]any{{
+			"kty": "RSA",
+			"alg": "RS256",
+			"use": "sig",
+			"kid": s.kid,
+			// RFC 7518 §6.3.1 wants the minimal big-endian encoding of each
+			// value, which is what big.Int.Bytes gives.
+			"n": b64(s.key.N.Bytes()),
+			"e": b64(big.NewInt(int64(s.key.E)).Bytes()),
+		}},
+	})
+}
+
+func (s *Server) handleDevice(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+
+	deviceCode := randomString()
+	s.mu.Lock()
+	// The client sends its nonce here, not at the token endpoint, and expects
+	// it echoed in the ID token; remember it per device code.
+	s.devices[deviceCode] = r.Form.Get("nonce")
+	s.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_code":      deviceCode,
+		"user_code":        "WDJB-MJHT",
+		"verification_uri": s.ts.URL + "/activate",
+		"expires_in":       600,
+		"interval":         5,
+	})
+}
+
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+	if got := r.Form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:device_code" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":             "unsupported_grant_type",
+			"error_description": fmt.Sprintf("grant_type %q", got),
+		})
+		return
+	}
+
+	s.mu.Lock()
+	nonce, known := s.devices[r.Form.Get("device_code")]
+	outcome := s.script[min(s.polls, len(s.script)-1)]
+	s.polls++
+	claims := s.claims
+	s.mu.Unlock()
+
+	if !known {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "unknown device_code",
+		})
+		return
+	}
+
+	if outcome != Grant {
+		// RFC 8628 §3.5: all of these are 400s with an error code; only the
+		// code tells a client whether to keep polling.
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": string(outcome)})
+		return
+	}
+
+	idToken, err := s.signIDToken(claims, nonce)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "server_error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  "access-" + randomString(),
+		"refresh_token": "refresh-" + randomString(),
+		"id_token":      idToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+	})
+}
+
+func (s *Server) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_token"})
+		return
+	}
+	s.mu.Lock()
+	claims := s.claims
+	s.mu.Unlock()
+	writeJSON(w, http.StatusOK, claims)
+}
+
+// signIDToken builds an RS256 JWT over claims, with the registered claims the
+// verifier checks filled in. Hand-rolled rather than pulled from a JWT library:
+// it is three base64 segments and one signature, and it keeps a test-only
+// helper from adding a direct dependency.
+func (s *Server) signIDToken(claims map[string]any, nonce string) (string, error) {
+	payload := make(map[string]any, len(claims)+5)
+	for k, v := range claims {
+		payload[k] = v
+	}
+	now := time.Now()
+	payload["iss"] = s.ts.URL
+	payload["aud"] = s.clientID
+	payload["iat"] = now.Unix()
+	payload["exp"] = now.Add(time.Hour).Unix()
+	if nonce != "" {
+		payload["nonce"] = nonce
+	}
+
+	header, err := json.Marshal(map[string]any{"alg": "RS256", "typ": "JWT", "kid": s.kid})
+	if err != nil {
+		return "", fmt.Errorf("marshal JWT header: %w", err)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal JWT claims: %w", err)
+	}
+
+	signingInput := b64(header) + "." + b64(body)
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, s.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign ID token: %w", err)
+	}
+	return signingInput + "." + b64(sig), nil
+}
+
+func b64(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// randomString returns an unguessable opaque identifier for device codes and
+// tokens, so a test cannot accidentally pass by reusing a hardcoded one.
+func randomString() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("testoidc: crypto/rand failed: " + err.Error())
+	}
+	return b64(b)
+}

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -37,6 +38,22 @@ type Broker struct {
 	pendingFlows          int64                // atomic counter of in-progress device authorization goroutines
 	version               string               // build version, set via SetVersion; reported by Status
 	startedAt             time.Time            // when Start ran; zero until then. Reported by Status
+
+	// pollIntervalUnit is how much real time one second of a provider's
+	// polling interval is worth. Zero means time.Second, which is what
+	// production always uses; tests shrink it so a flow that must survive
+	// several authorization_pending polls finishes in milliseconds instead of
+	// the ~15 s that RFC 8628's 5 s floor would otherwise cost.
+	pollIntervalUnit time.Duration
+}
+
+// pollUnit is the real-time duration of one second of a device flow's polling
+// interval. See the pollIntervalUnit field.
+func (b *Broker) pollUnit() time.Duration {
+	if b.pollIntervalUnit <= 0 {
+		return time.Second
+	}
+	return b.pollIntervalUnit
 }
 
 // SetMetrics attaches a Metrics instance to the broker and its policy engine.
@@ -798,7 +815,10 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 	defer b.wg.Done()
 	defer atomic.AddInt64(&b.pendingFlows, -1)
 
-	ticker := time.NewTicker(time.Duration(deviceFlow.PollingInterval) * time.Second)
+	// interval is not fixed: RFC 8628 §3.5 lets the provider ask for a slower
+	// poll rate mid-flow with slow_down, and requires the client to comply.
+	interval := deviceFlow.PollingInterval
+	ticker := time.NewTicker(time.Duration(interval) * b.pollUnit())
 	defer ticker.Stop()
 
 	timeout := time.NewTimer(time.Until(deviceFlow.ExpiresAt))
@@ -818,10 +838,30 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 			token, err := provider.PollDeviceAuthorization(pollCtx, deviceFlow.DeviceCode, deviceFlow.Nonce)
 			pollCancel()
 			if err != nil {
-				// Handle specific error types
-				if err.Error() == "authorization_pending" {
-					continue // Keep polling
+				// The user has not finished at the IdP yet. This is the normal
+				// answer to every poll before the last one, so it must not end the
+				// flow — only the deadline above does. (#150: this used to be a
+				// string comparison against an error that never matched, so the
+				// first pending poll deleted the session, roughly five seconds
+				// after the verification URL was displayed.)
+				if errors.Is(err, ErrAuthorizationPending) {
+					continue
 				}
+
+				// The provider is asking to be polled less often, and RFC 8628 §3.5
+				// requires compliance rather than a retry at the old rate.
+				if errors.Is(err, ErrSlowDown) {
+					if interval < maxPollingInterval {
+						interval = min(interval+slowDownIncrement, maxPollingInterval)
+						ticker.Reset(time.Duration(interval) * b.pollUnit())
+					}
+					log.Debug().
+						Str("session_id", session.ID).
+						Int("polling_interval", interval).
+						Msg("Provider asked to slow down device authorization polling")
+					continue
+				}
+
 				// Other errors mean failure. Use a bounded error-code enum for the
 				// metric label (never the raw error string) to avoid Prometheus
 				// cardinality explosion and leaking transient infra detail.

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -492,7 +492,12 @@ func TestBrokerAuthenticateScenarios(t *testing.T) {
 	}
 }
 
-// Test pollDeviceAuthorization method
+// Test pollDeviceAuthorization method.
+//
+// This is a smoke test only — it needs network dependencies it does not have,
+// so it returns early. The poll loop's actual behaviour (pending polls,
+// slow_down, terminal errors, expiry) is covered in device_poll_test.go against
+// an in-process issuer.
 func TestBrokerPollDeviceAuthorization(t *testing.T) {
 	cfg := &config.Config{
 		OIDC: config.OIDCConfig{

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,29 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
 	"golang.org/x/oauth2"
+)
+
+// The two non-terminal responses the token endpoint gives while a device
+// authorization is still in progress (RFC 8628 §3.5). They are the *normal*
+// answer to any poll made before the user has finished with the browser, not
+// failures: the first poll happens a full polling interval after the code is
+// displayed, so the honest expectation is several pending answers and then a
+// grant. Callers match them with errors.Is; treating them as failures means no
+// device flow can ever complete, which is what #150 was.
+var (
+	ErrAuthorizationPending = errors.New("authorization_pending")
+	ErrSlowDown             = errors.New("slow_down")
+)
+
+// Polling interval bounds, in seconds. RFC 8628 §3.5 requires clients to wait at
+// least the interval the provider asks for, and to add slowDownIncrement to it on
+// each slow_down. The minimum also keeps time.NewTicker from panicking on a
+// provider-supplied 0, and the maximum bounds what a provider can make the broker
+// wait.
+const (
+	minPollingInterval = 5
+	maxPollingInterval = 3600
+	slowDownIncrement  = 5
 )
 
 // DeviceFlow represents an OAuth2 device authorization flow
@@ -300,13 +324,7 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 		return nil, fmt.Errorf("provider returned invalid expires_in value: %d (must be 1–%d seconds)", deviceResp.ExpiresIn, maxDeviceCodeExpiry)
 	}
 
-	// RFC 8628 §3.5: clients MUST wait at least the interval seconds between polls.
-	// Clamp to [5, 3600]: prevents time.NewTicker panic on ≤0 and resource
-	// exhaustion from provider-supplied sub-second intervals.
-	const (
-		minPollingInterval = 5
-		maxPollingInterval = 3600
-	)
+	// Clamp the provider's interval to [minPollingInterval, maxPollingInterval].
 	if deviceResp.Interval < minPollingInterval {
 		deviceResp.Interval = minPollingInterval
 	} else if deviceResp.Interval > maxPollingInterval {
@@ -367,7 +385,7 @@ func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode, 
 
 	// Handle error responses
 	if tokenResp.Error != "" {
-		return nil, fmt.Errorf("token error: %s", tokenResp.Error)
+		return nil, tokenEndpointError(tokenResp.Error)
 	}
 
 	// Check if we have a valid response
@@ -424,6 +442,21 @@ func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode, 
 		Msg("Device authorization completed")
 
 	return token, nil
+}
+
+// tokenEndpointError maps an OAuth error code from the token endpoint onto an
+// error value, wrapping the two non-terminal codes so a caller can recognise them
+// with errors.Is instead of comparing strings. The message keeps the
+// "token error: <code>" shape that the audit log and classifyPollError read.
+func tokenEndpointError(code string) error {
+	switch code {
+	case "authorization_pending":
+		return fmt.Errorf("token error: %w", ErrAuthorizationPending)
+	case "slow_down":
+		return fmt.Errorf("token error: %w", ErrSlowDown)
+	default:
+		return fmt.Errorf("token error: %s", code)
+	}
 }
 
 // GetUserInfo retrieves user information using the access token

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -1,0 +1,332 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/testoidc"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
+)
+
+// These tests drive Broker.pollDeviceAuthorization against a real in-process
+// issuer, because the bug they exist for (#150) lived precisely in the gap
+// between the two: the provider reported a pending authorization as
+// "token error: authorization_pending", the poll loop compared the error string
+// against "authorization_pending", the comparison never matched, and so the
+// first pending poll — which is the *normal* answer to every poll before the
+// user finishes in the browser — took the deny path and deleted the session.
+// The device flow could not complete at all, roughly five seconds after the
+// verification URL was shown.
+//
+// Nothing short of an end-to-end loop catches that. A unit test on the provider
+// would have passed (it returned the right code), and a unit test on the loop
+// with a hand-built error would have passed too (whichever spelling the test
+// chose would have been the one the loop compared against). What was untested
+// was the two halves agreeing.
+
+const testPollUnit = 10 * time.Millisecond
+
+// pollTestEnv is a broker wired to an in-process issuer, plus a started device
+// flow and the pending session that goes with it.
+type pollTestEnv struct {
+	broker   *Broker
+	provider *OIDCProvider
+	idp      *testoidc.Server
+	session  *Session
+	flow     *DeviceFlow
+}
+
+func newPollTestEnv(t *testing.T) *pollTestEnv {
+	t.Helper()
+
+	const clientID = "oidc-pam-test-client"
+	idp := testoidc.New(t, clientID)
+
+	secCfg := config.SecurityConfig{
+		VerifyAudience:     true,
+		TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+	}
+	provider, err := NewOIDCProvider(config.OIDCProvider{
+		Name:            "testidp",
+		Issuer:          idp.Issuer(),
+		ClientID:        clientID,
+		Scopes:          []string{"openid", "profile", "email"},
+		EnabledForLogin: true,
+		UserMapping: config.UserMapping{
+			UsernameClaim: "preferred_username",
+			EmailClaim:    "email",
+			GroupsClaim:   "groups",
+		},
+	}, secCfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider against the in-process issuer: %v", err)
+	}
+
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{Enabled: false})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	keyManager := sshpkg.NewKeyManager(t.TempDir())
+	// The happy path generates a login key; 2048 bits keeps that off the
+	// critical path of a test that is about polling.
+	keyManager.SetKeySize(2048)
+
+	broker := &Broker{
+		config: &config.Config{
+			Authentication: config.AuthenticationConfig{
+				TokenLifetime:    time.Hour,
+				RefreshThreshold: 15 * time.Minute,
+			},
+			Security: secCfg,
+		},
+		providers:             map[string]*OIDCProvider{"testidp": provider},
+		tokenManager:          newTestTokenManager(t),
+		policyEngine:          &PolicyEngine{},
+		auditLogger:           auditLogger,
+		sessions:              make(map[string]*Session),
+		keyManager:            keyManager,
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(t.TempDir()),
+		stopChan:              make(chan struct{}),
+		pollIntervalUnit:      testPollUnit,
+	}
+
+	// A real StartDeviceFlow, so the device code and nonce the token endpoint
+	// is asked about are the ones the provider actually negotiated.
+	flow, err := provider.StartDeviceFlow(&AuthRequest{UserID: "testuser", LoginType: "ssh"})
+	if err != nil {
+		t.Fatalf("StartDeviceFlow: %v", err)
+	}
+	if flow.PollingInterval != minPollingInterval {
+		t.Fatalf("polling interval = %d, want the RFC 8628 floor of %d", flow.PollingInterval, minPollingInterval)
+	}
+
+	session := &Session{
+		ID:           "sess-poll-test",
+		UserID:       "testuser",
+		Provider:     "testidp",
+		LoginType:    "ssh",
+		CreatedAt:    time.Now(),
+		ExpiresAt:    flow.ExpiresAt,
+		LastAccessed: time.Now(),
+		SourceIP:     "192.0.2.10",
+		IsActive:     false,
+	}
+	broker.setSession(session)
+
+	return &pollTestEnv{broker: broker, provider: provider, idp: idp, session: session, flow: flow}
+}
+
+// run drives the poll loop to completion and returns how long it took.
+// pollDeviceAuthorization is only ever started as a tracked goroutine, so the
+// bookkeeping it unwinds has to be set up here too.
+func (e *pollTestEnv) run(t *testing.T) time.Duration {
+	t.Helper()
+
+	e.broker.wg.Add(1)
+	atomic.AddInt64(&e.broker.pendingFlows, 1)
+
+	started := time.Now()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		e.broker.pollDeviceAuthorization(e.session, e.provider, e.flow)
+	}()
+
+	select {
+	case <-done:
+		return time.Since(started)
+	case <-time.After(30 * time.Second):
+		close(e.broker.stopChan) // let the goroutine exit rather than leak
+		t.Fatal("pollDeviceAuthorization never returned")
+		return 0
+	}
+}
+
+// activeSession is the session as the broker holds it, or nil if the loop
+// removed it. The loop replaces the map entry with a clone rather than mutating
+// in place, so re-reading through the broker is the only way to see the result.
+func (e *pollTestEnv) activeSession() *Session {
+	return e.broker.getSession(e.session.ID)
+}
+
+// The regression gate for #150: a flow that answers authorization_pending twice
+// before granting must reach an active session. On the broken code the loop
+// exited during the first poll, so this fails there with the session gone.
+func TestDeviceFlowCompletesAfterAuthorizationPending(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.Script(testoidc.Pending, testoidc.Pending, testoidc.Grant)
+
+	env.run(t)
+
+	if polls := env.idp.Polls(); polls != 3 {
+		t.Errorf("token endpoint saw %d polls, want 3 (two pending, then the grant)", polls)
+	}
+
+	session := env.activeSession()
+	if session == nil {
+		t.Fatal("session was removed: a pending authorization was treated as a failure (#150)")
+	}
+	if !session.IsActive {
+		t.Error("session is still inactive after the provider granted the token")
+	}
+	if session.Email != "testuser@example.org" {
+		t.Errorf("session email = %q, want the value from the ID token claims", session.Email)
+	}
+	if len(session.Groups) != 1 || session.Groups[0] != "researchers" {
+		t.Errorf("session groups = %v, want [researchers] from the claims", session.Groups)
+	}
+
+	// The tokens must have reached the encrypted store, since that is what the
+	// session's TokenID points at.
+	if session.TokenID == "" {
+		t.Fatal("session has no TokenID, so its tokens were never stored")
+	}
+	stored, err := env.broker.tokenManager.GetToken(session.TokenID)
+	if err != nil {
+		t.Fatalf("GetToken(%q): %v", session.TokenID, err)
+	}
+	if stored.RefreshToken == "" {
+		t.Error("stored token has no refresh token")
+	}
+}
+
+// slow_down is the other non-terminal code. The flow must survive it *and* poll
+// more slowly afterwards — RFC 8628 §3.5 requires the client to add 5 s to its
+// interval each time, and a provider that sends it is usually rate-limiting.
+func TestDeviceFlowHonoursSlowDown(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.Script(testoidc.SlowDown, testoidc.SlowDown, testoidc.SlowDown, testoidc.Grant)
+
+	elapsed := env.run(t)
+
+	if polls := env.idp.Polls(); polls != 4 {
+		t.Errorf("token endpoint saw %d polls, want 4 (three slow_down, then the grant)", polls)
+	}
+	if session := env.activeSession(); session == nil || !session.IsActive {
+		t.Fatal("slow_down ended the flow instead of slowing it down")
+	}
+
+	// Intervals in units: 5, then 10, 15, 20 as each slow_down adds
+	// slowDownIncrement — 50 units to the grant, against 20 if the increase
+	// were ignored. The bound is deliberately loose and one-sided: a slow
+	// machine only ever pushes the measurement up.
+	want := 40 * testPollUnit
+	if elapsed < want {
+		t.Errorf("four polls took %v, want at least %v — the interval did not grow by %d s per slow_down",
+			elapsed, want, slowDownIncrement)
+	}
+}
+
+// The terminal codes must stay terminal. Continuing to poll after access_denied
+// would leave a pending session behind and hammer the provider.
+func TestDeviceFlowStopsOnTerminalErrors(t *testing.T) {
+	for _, outcome := range []testoidc.Outcome{testoidc.AccessDenied, testoidc.ExpiredToken} {
+		t.Run(string(outcome), func(t *testing.T) {
+			env := newPollTestEnv(t)
+			env.idp.Script(testoidc.Pending, outcome)
+
+			env.run(t)
+
+			if polls := env.idp.Polls(); polls != 2 {
+				t.Errorf("token endpoint saw %d polls, want 2 (one pending, then %s)", polls, outcome)
+			}
+			if session := env.activeSession(); session != nil {
+				t.Errorf("session survived %s (IsActive=%v); a refused authorization must remove it",
+					outcome, session.IsActive)
+			}
+		})
+	}
+}
+
+// With the pending path fixed, the device code's own expiry is what bounds the
+// flow. It has to actually fire, or a never-completed login leaks a goroutine
+// and a pending session for as long as the broker runs.
+func TestDeviceFlowEndsAtDeviceCodeExpiry(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.Script(testoidc.Pending) // pending forever
+
+	// Long enough for several polls, short enough not to slow the suite down.
+	env.flow.ExpiresAt = time.Now().Add(20 * testPollUnit)
+	env.session.ExpiresAt = env.flow.ExpiresAt
+	env.broker.setSession(env.session)
+
+	env.run(t)
+
+	if polls := env.idp.Polls(); polls < 2 {
+		t.Errorf("token endpoint saw %d polls before the deadline, want at least 2 "+
+			"(a pending answer must not end the flow)", polls)
+	}
+	if session := env.activeSession(); session != nil {
+		t.Error("session survived the device code's expiry")
+	}
+}
+
+// Stopping the broker must abandon in-flight flows rather than keep polling a
+// provider until the device code expires.
+func TestDeviceFlowStopsWithTheBroker(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.Script(testoidc.Pending)
+
+	env.broker.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		env.broker.pollDeviceAuthorization(env.session, env.provider, env.flow)
+	}()
+
+	// Let it poll at least once so it is genuinely mid-flow.
+	time.Sleep(10 * testPollUnit)
+	close(env.broker.stopChan)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pollDeviceAuthorization ignored stopChan")
+	}
+}
+
+// tokenEndpointError is the seam #150 turned on: the two non-terminal codes have
+// to be recognisable by identity, not by the shape of a formatted string, while
+// the message the audit log records stays what it was.
+func TestTokenEndpointError(t *testing.T) {
+	cases := []struct {
+		code     string
+		sentinel error
+		message  string
+	}{
+		{"authorization_pending", ErrAuthorizationPending, "token error: authorization_pending"},
+		{"slow_down", ErrSlowDown, "token error: slow_down"},
+		{"access_denied", nil, "token error: access_denied"},
+		{"expired_token", nil, "token error: expired_token"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			err := tokenEndpointError(tc.code)
+			if err.Error() != tc.message {
+				t.Errorf("message = %q, want %q", err.Error(), tc.message)
+			}
+
+			// Every terminal code must match neither sentinel, or the loop
+			// would poll forever on a denial.
+			for _, sentinel := range []error{ErrAuthorizationPending, ErrSlowDown} {
+				want := errors.Is(sentinel, tc.sentinel)
+				if got := errors.Is(err, sentinel); got != want {
+					t.Errorf("errors.Is(%v, %v) = %v, want %v", err, sentinel, got, want)
+				}
+			}
+		})
+	}
+
+	// And wrapping must survive the layer the broker actually sees it through.
+	wrapped := fmt.Errorf("failed to poll device authorization: %w", tokenEndpointError("authorization_pending"))
+	if !errors.Is(wrapped, ErrAuthorizationPending) {
+		t.Error("a wrapped pending error is no longer recognisable as pending")
+	}
+}


### PR DESCRIPTION
Fixes #150.

## The bug

RFC 8628 §3.5 makes `authorization_pending` the *normal* answer to every poll before the user finishes in the browser. The two halves of the flow disagreed on how to spell it:

- `pkg/auth/device_flow.go` returned `fmt.Errorf("token error: %s", tokenResp.Error)` → `"token error: authorization_pending"`.
- `pkg/auth/broker.go` tested `if err.Error() == "authorization_pending"`.

The comparison never matched, so the first pending poll fell through to the deny path: audit `device_authorization_failed`, `removeSession`, goroutine returns. That happens one polling interval after `Authenticate` returns — about **five seconds** after the verification URL and user code are shown. **No device login could complete**, and the user was left holding a code for a session that no longer existed.

`slow_down` had the same fate, and the polling interval never grew, which the RFC requires.

## The fix

`ErrAuthorizationPending` and `ErrSlowDown` are sentinel errors wrapped with `%w` by a new `tokenEndpointError` helper, and the poll loop matches them with `errors.Is`:

- pending → keep polling;
- `slow_down` → `interval += slowDownIncrement` (capped at `maxPollingInterval`), `ticker.Reset`, keep polling;
- anything else — `access_denied`, `expired_token`, a bad ID token, transport failure — stays terminal, as does the device code's own expiry.

The message keeps its `token error: <code>` shape, so the audit log and `classifyPollError`'s bounded metric labels are unchanged. The polling-interval constants moved to package scope (they were function-local inside `StartDeviceFlow`) since the loop now needs them too.

## Why the tests look like this

A unit test on either half would have passed. The provider returned the right code; the loop compared against a plausible string. What went untested was **the two halves agreeing** — so the gate has to run the real loop against a real token endpoint.

`internal/testoidc` is an in-process OIDC issuer: discovery, JWKS, RS256-signed ID tokens with real `aud`/`iss`/`exp`/`nonce` (go-oidc's verifier is exercised, not bypassed), the device authorization endpoint and userinfo. Its reason for existing is `Script(...)`, which sets the *sequence* of token-endpoint answers — a fake that grants on the first poll cannot tell a working client from one that treats pending as fatal. It listens on 127.0.0.1 over plain HTTP, which `validateEndpoint` accepts for localhost only; the containerised harness for #129 will wrap it with TLS and a `/control/*` API.

`pkg/auth/device_poll_test.go` then covers:

| test | asserts |
|---|---|
| `TestDeviceFlowCompletesAfterAuthorizationPending` | pending, pending, grant → active session, claims mapped, tokens in the encrypted store |
| `TestDeviceFlowHonoursSlowDown` | three `slow_down`s then grant → flow survives **and** the interval grows |
| `TestDeviceFlowStopsOnTerminalErrors` | `access_denied` / `expired_token` → session removed, polling stops |
| `TestDeviceFlowEndsAtDeviceCodeExpiry` | pending forever → bounded by the device code's expiry, not by the first poll |
| `TestDeviceFlowStopsWithTheBroker` | `stopChan` abandons an in-flight flow |
| `TestTokenEndpointError` | `errors.Is` identity for both sentinels, terminal codes match neither, message shape preserved, wrapping survives |

Confirmed against the pre-fix code — reverting just the poll loop gives:

```
--- FAIL: TestDeviceFlowCompletesAfterAuthorizationPending
    token endpoint saw 1 polls, want 3 (two pending, then the grant)
    session was removed: a pending authorization was treated as a failure (#150)
--- FAIL: TestDeviceFlowHonoursSlowDown
--- FAIL: TestDeviceFlowStopsOnTerminalErrors/access_denied
--- FAIL: TestDeviceFlowStopsOnTerminalErrors/expired_token
--- FAIL: TestDeviceFlowEndsAtDeviceCodeExpiry
```

`Broker.pollIntervalUnit` (unexported, zero means `time.Second`) is how those tests avoid waiting out RFC 8628's 5 s interval floor; the whole file runs in ~2 s.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -s -l .` clean
- `go test -race ./pkg/... ./internal/...` — all green
- `golangci-lint run` (v2.12.2, the repo pin) — 0 issues
- `./scripts/check-cgo-quarantine.sh` — OK
- No new dependencies: the JWT is three base64 segments and one `rsa.SignPKCS1v15`, so `go.mod` is untouched

## Note

This unblocks #129's harness, whose happy path could not have passed before it.