### PR TITLE
fix(ssh): key the SSH key store by key ID so logins actually get a key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **High (#152): no login ever got an SSH key, which is the one thing the broker
+  exists to hand out.** `Broker.generateSSHKey` files the on-disk key pair under
+  the *session* ID, deliberately, so that concurrent sessions for one user do not
+  overwrite each other's key — but `KeyManager.SaveKey` validated that argument
+  with `validateUsername`, and a 64-character hex session ID is not a POSIX login
+  name. Every save was refused, the error was only written to the broker's own
+  log, and the login carried on and was audited as `authentication_successful`.
+  So a device flow completed, PAM returned success, and `authorized_keys` was
+  never touched. Introduced by `2e5522a`'s path-traversal hardening: the hardening
+  was right, the validator was simply the wrong one for an argument that is not a
+  username.
+
+  The key store is now explicitly keyed by an opaque **key ID**: `validateKeyID`
+  (anchored, length-bounded, no dots or separators, so traversal is still
+  impossible) replaces `validateUsername` in `SaveKey`/`LoadKey`/`DeleteKey`/
+  `GetKeyPath`/`GetPublicKeyPath`, and those parameters are named `keyID` so the
+  contract is legible from the signature. `validateUsername` stays where the
+  argument really is a username. `KeyInfo` gains a `KeyID`, and its `Username` is
+  now recovered from the key's comment instead of being the storage directory
+  name — so `oidc-admin keys` no longer prints session IDs in a `USERNAME`
+  column, and gains a `SESSION` column to tie a key to the session that owns it.
+  A provisioning failure is now also audited (`ssh_key_provisioning_failed`)
+  rather than only logged, since that silence is why this survived eleven
+  releases.
+
+  Unit tests passed on both sides throughout: each half was self-consistent, and
+  the one test that exercised the store end to end used the session ID
+  `"sess-poll-test"` — which satisfies the POSIX username pattern by accident.
+  The regression gate therefore uses a session ID of the shape the broker really
+  mints, and asserts the key reaches both the store and the user's
+  `authorized_keys`.
 - **Critical (#150): the broker abandoned every device flow on the first poll,
   so no device login could ever complete.** RFC 8628 §3.5 makes
   `authorization_pending` the *normal* answer to every poll before the user

--- a/cmd/oidc-admin/admin.go
+++ b/cmd/oidc-admin/admin.go
@@ -247,9 +247,11 @@ func listSSHKeys() error {
 		fmt.Printf("No SSH keys found.\n")
 	} else {
 		fmt.Printf("Total keys: %d\n\n", response.Total)
-		fmt.Printf("%-20s %-14s %-6s %-8s %-20s %-20s\n", "Username", "Type", "Bits", "Status", "Created", "Expires")
-		fmt.Printf("%-20s %-14s %-6s %-8s %-20s %-20s\n",
+		fmt.Printf("%-20s %-16s %-14s %-6s %-8s %-20s %-20s\n",
+			"Username", "Session", "Type", "Bits", "Status", "Created", "Expires")
+		fmt.Printf("%-20s %-16s %-14s %-6s %-8s %-20s %-20s\n",
 			strings.Repeat("-", 20),
+			strings.Repeat("-", 16),
 			strings.Repeat("-", 14),
 			strings.Repeat("-", 6),
 			strings.Repeat("-", 8),
@@ -257,8 +259,9 @@ func listSSHKeys() error {
 			strings.Repeat("-", 20))
 
 		for _, key := range response.Keys {
-			fmt.Printf("%-20s %-14s %-6d %-8s %-20s %-20s\n",
+			fmt.Printf("%-20s %-16s %-14s %-6d %-8s %-20s %-20s\n",
 				truncateString(key.Username, 20),
+				truncateString(key.SessionID, 16),
 				truncateString(key.KeyType, 14),
 				key.KeySize,
 				truncateString(key.Status, 8),

--- a/internal/adminapi/types.go
+++ b/internal/adminapi/types.go
@@ -89,6 +89,9 @@ type SessionListResponse struct {
 // appears here — never the key material itself.
 type SSHKeyInfo struct {
 	Username string `json:"username"`
+	// SessionID is the session the key was issued for, which is also the ID it is
+	// stored under. Without it an operator cannot tie a listed key to a session.
+	SessionID string `json:"session_id"`
 	// KeyType is the SSH algorithm name, e.g. "ssh-rsa".
 	KeyType string `json:"key_type"`
 	// KeySize is the key's strength in bits.

--- a/internal/ipc/admin.go
+++ b/internal/ipc/admin.go
@@ -81,6 +81,7 @@ func (s *Server) handleKeysList() *adminapi.KeyListResponse {
 		}
 		out = append(out, adminapi.SSHKeyInfo{
 			Username:  key.Username,
+			SessionID: key.KeyID,
 			KeyType:   key.KeyType,
 			KeySize:   key.KeySize,
 			Status:    status,

--- a/pkg/auth/admin.go
+++ b/pkg/auth/admin.go
@@ -139,6 +139,9 @@ func sessionStatus(session *Session, now time.Time) string {
 
 // ListKeys returns metadata for the SSH keys the broker manages, sorted by
 // username, along with the number of key directories it could not read.
+//
+// One user can hold several keys — one per session — so the key ID breaks ties
+// and keeps the order stable across calls.
 func (b *Broker) ListKeys() ([]sshpkg.KeyInfo, int, error) {
 	if b.keyManager == nil {
 		return nil, 0, nil
@@ -149,6 +152,11 @@ func (b *Broker) ListKeys() ([]sshpkg.KeyInfo, int, error) {
 		return nil, 0, err
 	}
 
-	sort.Slice(keys, func(i, j int) bool { return keys[i].Username < keys[j].Username })
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Username != keys[j].Username {
+			return keys[i].Username < keys[j].Username
+		}
+		return keys[i].KeyID < keys[j].KeyID
+	})
 	return keys, unreadable, nil
 }

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -993,6 +993,22 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 						Err(err).
 						Str("session_id", updated.ID).
 						Msg("Failed to generate SSH key")
+					// Audit it too. A login whose key could not be provisioned is
+					// authenticated but cannot actually be used, and #152 stayed
+					// hidden for eleven releases precisely because this failure
+					// only ever reached the broker's own log.
+					b.auditLogger.LogAuthEvent(security.AuditEvent{
+						EventType:    "ssh_key_provisioning_failed",
+						UserID:       updated.UserID,
+						Email:        updated.Email,
+						Groups:       updated.Groups,
+						SessionID:    updated.ID,
+						Provider:     provider.Name,
+						Success:      false,
+						ErrorCode:    "SSH_KEY_PROVISIONING_FAILED",
+						ErrorMessage: err.Error(),
+						Timestamp:    time.Now(),
+					})
 				} else {
 					updated.SSHKeyID = sshKey.ID
 					updated.SSHPublicKey = sshKey.PublicKey

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -3,6 +3,9 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,6 +42,10 @@ type pollTestEnv struct {
 	idp      *testoidc.Server
 	session  *Session
 	flow     *DeviceFlow
+	// homeDir stands in for /home. A test that cares whether a login key was
+	// provisioned has to look at the filesystem, since that is the only place the
+	// answer is recorded.
+	homeDir string
 }
 
 func newPollTestEnv(t *testing.T) *pollTestEnv {
@@ -77,6 +84,8 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 	// critical path of a test that is about polling.
 	keyManager.SetKeySize(2048)
 
+	homeDir := t.TempDir()
+
 	broker := &Broker{
 		config: &config.Config{
 			Authentication: config.AuthenticationConfig{
@@ -91,7 +100,7 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 		auditLogger:           auditLogger,
 		sessions:              make(map[string]*Session),
 		keyManager:            keyManager,
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(t.TempDir()),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir),
 		stopChan:              make(chan struct{}),
 		pollIntervalUnit:      testPollUnit,
 	}
@@ -107,7 +116,12 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 	}
 
 	session := &Session{
-		ID:           "sess-poll-test",
+		// A session ID of the shape the broker actually mints: 32 random bytes,
+		// hex-encoded. It matters that this is not a plausible login name — the key
+		// store is keyed by it, and the bug in #152 was a store that validated it
+		// as a POSIX username. A friendlier "sess-poll-test" passes that check by
+		// accident and hides the defect.
+		ID:           "9d1c6f0e5b4a3827160f9e8d7c6b5a493827160f9e8d7c6b5a4938271605f4e3d",
 		UserID:       "testuser",
 		Provider:     "testidp",
 		LoginType:    "ssh",
@@ -119,7 +133,14 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 	}
 	broker.setSession(session)
 
-	return &pollTestEnv{broker: broker, provider: provider, idp: idp, session: session, flow: flow}
+	return &pollTestEnv{
+		broker:   broker,
+		provider: provider,
+		idp:      idp,
+		session:  session,
+		flow:     flow,
+		homeDir:  homeDir,
+	}
 }
 
 // run drives the poll loop to completion and returns how long it took.
@@ -328,5 +349,54 @@ func TestTokenEndpointError(t *testing.T) {
 	wrapped := fmt.Errorf("failed to poll device authorization: %w", tokenEndpointError("authorization_pending"))
 	if !errors.Is(wrapped, ErrAuthorizationPending) {
 		t.Error("a wrapped pending error is no longer recognisable as pending")
+	}
+}
+
+// The regression gate for #152: a granted device flow must actually provision the
+// login key, which is the whole point of the broker.
+//
+// This failed against the code that keyed the on-disk key store by session ID but
+// validated that ID as a POSIX login name: SaveKey refused every real session ID,
+// the error was only logged, and the login carried on and was audited as a
+// success — so nothing but an end-to-end run noticed that no key was ever written.
+func TestDeviceFlowProvisionsLoginKey(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	session := env.activeSession()
+	if session == nil {
+		t.Fatal("session was removed even though the provider granted the token")
+	}
+	if session.SSHKeyID == "" {
+		t.Fatal("session has no SSHKeyID: no login key was provisioned (#152)")
+	}
+	if session.SSHKeyID != session.ID {
+		t.Errorf("SSHKeyID = %q, want the session ID %q", session.SSHKeyID, session.ID)
+	}
+
+	// The pair has to be retrievable by the ID the session points at, or nothing
+	// can revoke it later.
+	stored, err := env.broker.keyManager.LoadKey(session.SSHKeyID)
+	if err != nil {
+		t.Fatalf("LoadKey(%q): %v", session.SSHKeyID, err)
+	}
+	if len(stored.PrivateKey) == 0 {
+		t.Error("stored key pair has no private key")
+	}
+
+	// And it has to be authorized for the local account, in the user's own file,
+	// exactly once.
+	authorizedKeys := filepath.Join(env.homeDir, session.UserID, ".ssh", "authorized_keys")
+	data, err := os.ReadFile(authorizedKeys)
+	if err != nil {
+		t.Fatalf("reading %s: %v", authorizedKeys, err)
+	}
+	if got := strings.Count(string(data), "@oidc-pam-"); got != 1 {
+		t.Errorf("authorized_keys has %d oidc-pam key(s), want exactly 1:\n%s", got, data)
+	}
+	if !strings.Contains(string(data), session.UserID+"@oidc-pam-") {
+		t.Errorf("the authorized key is not commented for %q:\n%s", session.UserID, data)
 	}
 }

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -61,6 +61,29 @@ func validateUsername(username string) error {
 	return nil
 }
 
+// keyIDPattern is the allowlist for the identifier a stored key pair is filed
+// under. The broker files keys by session ID, so this has to admit a 64-character
+// hex string — but it is still a path element, so it admits nothing else: no
+// dots (hence no "." or ".."), no separators, and a bounded length.
+var keyIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+
+// validateKeyID rejects key identifiers that are not safe to join into a path
+// under the manager's base directory.
+//
+// This is deliberately not validateUsername: the key store is keyed by an opaque
+// key ID, not by a login name. Validating it as a POSIX login name is what broke
+// key provisioning outright (#152) — every session ID the broker passed was
+// refused, so no login ever got a key.
+func validateKeyID(keyID string) error {
+	if keyID == "" {
+		return fmt.Errorf("key ID cannot be empty")
+	}
+	if !keyIDPattern.MatchString(keyID) {
+		return fmt.Errorf("key ID %q is not a valid identifier", keyID)
+	}
+	return nil
+}
+
 // NewKeyManager creates a new SSH key manager
 func NewKeyManager(baseDir string) *KeyManager {
 	return &KeyManager{
@@ -140,14 +163,15 @@ func (km *KeyManager) GenerateKey(username string) (*SSHKey, error) {
 	return sshKey, nil
 }
 
-// SaveKey saves an SSH key pair to disk
-func (km *KeyManager) SaveKey(username string, key *SSHKey) error {
-	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
+// SaveKey saves an SSH key pair to disk under keyID. The broker passes a session
+// ID, so that concurrent sessions for one user do not overwrite each other's key.
+func (km *KeyManager) SaveKey(keyID string, key *SSHKey) error {
+	if err := validateKeyID(keyID); err != nil {
+		return fmt.Errorf("invalid key ID: %w", err)
 	}
-	userDir := filepath.Join(km.baseDir, username)
+	userDir := filepath.Join(km.baseDir, keyID)
 	if err := os.MkdirAll(userDir, 0700); err != nil {
-		return fmt.Errorf("failed to create user directory: %w", err)
+		return fmt.Errorf("failed to create key directory: %w", err)
 	}
 
 	// Save private key
@@ -173,7 +197,7 @@ func (km *KeyManager) SaveKey(username string, key *SSHKey) error {
 	}
 
 	log.Info().
-		Str("username", username).
+		Str("key_id", keyID).
 		Str("private_key_path", privateKeyPath).
 		Str("public_key_path", publicKeyPath).
 		Msg("SSH key pair saved successfully")
@@ -181,12 +205,12 @@ func (km *KeyManager) SaveKey(username string, key *SSHKey) error {
 	return nil
 }
 
-// LoadKey loads an SSH key pair from disk
-func (km *KeyManager) LoadKey(username string) (*SSHKey, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, fmt.Errorf("invalid username: %w", err)
+// LoadKey loads an SSH key pair from disk by the ID it was saved under.
+func (km *KeyManager) LoadKey(keyID string) (*SSHKey, error) {
+	if err := validateKeyID(keyID); err != nil {
+		return nil, fmt.Errorf("invalid key ID: %w", err)
 	}
-	userDir := filepath.Join(km.baseDir, username)
+	userDir := filepath.Join(km.baseDir, keyID)
 
 	// Load private key
 	privateKeyPath := filepath.Join(userDir, "id_rsa")
@@ -233,12 +257,12 @@ func (km *KeyManager) LoadKey(username string) (*SSHKey, error) {
 	return sshKey, nil
 }
 
-// DeleteKey removes an SSH key pair from disk
-func (km *KeyManager) DeleteKey(username string) error {
-	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
+// DeleteKey removes an SSH key pair from disk by the ID it was saved under.
+func (km *KeyManager) DeleteKey(keyID string) error {
+	if err := validateKeyID(keyID); err != nil {
+		return fmt.Errorf("invalid key ID: %w", err)
 	}
-	userDir := filepath.Join(km.baseDir, username)
+	userDir := filepath.Join(km.baseDir, keyID)
 
 	// Remove all key files
 	files := []string{"id_rsa", "id_rsa.pub", "key_metadata"}
@@ -252,14 +276,14 @@ func (km *KeyManager) DeleteKey(username string) error {
 	// Remove directory if empty
 	if err := os.Remove(userDir); err != nil && !os.IsNotExist(err) {
 		log.Debug().
-			Str("username", username).
-			Str("user_dir", userDir).
+			Str("key_id", keyID).
+			Str("key_dir", userDir).
 			Err(err).
-			Msg("Failed to remove user directory (may not be empty)")
+			Msg("Failed to remove key directory (may not be empty)")
 	}
 
 	log.Info().
-		Str("username", username).
+		Str("key_id", keyID).
 		Msg("SSH key pair deleted successfully")
 
 	return nil
@@ -270,23 +294,23 @@ func (km *KeyManager) IsKeyExpired(key *SSHKey) bool {
 	return time.Now().After(key.ExpiresAt)
 }
 
-// GetKeyPath returns the path to the SSH key for a user
-func (km *KeyManager) GetKeyPath(username string) string {
-	if validateUsername(username) != nil {
+// GetKeyPath returns the path to the stored private key for a key ID
+func (km *KeyManager) GetKeyPath(keyID string) string {
+	if validateKeyID(keyID) != nil {
 		return ""
 	}
-	return filepath.Join(km.baseDir, username, "id_rsa")
+	return filepath.Join(km.baseDir, keyID, "id_rsa")
 }
 
-// GetPublicKeyPath returns the path to the SSH public key for a user
-func (km *KeyManager) GetPublicKeyPath(username string) string {
-	if validateUsername(username) != nil {
+// GetPublicKeyPath returns the path to the stored public key for a key ID
+func (km *KeyManager) GetPublicKeyPath(keyID string) string {
+	if validateKeyID(keyID) != nil {
 		return ""
 	}
-	return filepath.Join(km.baseDir, username, "id_rsa.pub")
+	return filepath.Join(km.baseDir, keyID, "id_rsa.pub")
 }
 
-// ListKeys lists all SSH keys managed by this key manager
+// ListKeys lists the IDs of every key pair managed by this key manager
 func (km *KeyManager) ListKeys() ([]string, error) {
 	entries, err := os.ReadDir(km.baseDir)
 	if err != nil {
@@ -296,53 +320,53 @@ func (km *KeyManager) ListKeys() ([]string, error) {
 		return nil, fmt.Errorf("failed to read base directory: %w", err)
 	}
 
-	var users []string
+	var keyIDs []string
 	for _, entry := range entries {
 		if entry.IsDir() {
 			// Check if this directory contains SSH keys
 			privateKeyPath := filepath.Join(km.baseDir, entry.Name(), "id_rsa")
 			if _, err := os.Stat(privateKeyPath); err == nil {
-				users = append(users, entry.Name())
+				keyIDs = append(keyIDs, entry.Name())
 			}
 		}
 	}
 
-	return users, nil
+	return keyIDs, nil
 }
 
 // CleanupExpiredKeys removes expired SSH keys
 func (km *KeyManager) CleanupExpiredKeys() error {
-	users, err := km.ListKeys()
+	keyIDs, err := km.ListKeys()
 	if err != nil {
 		return fmt.Errorf("failed to list keys: %w", err)
 	}
 
 	var cleaned []string
-	for _, username := range users {
-		key, err := km.LoadKey(username)
+	for _, keyID := range keyIDs {
+		key, err := km.LoadKey(keyID)
 		if err != nil {
 			log.Error().
-				Str("username", username).
+				Str("key_id", keyID).
 				Err(err).
 				Msg("Failed to load key for cleanup check")
 			continue
 		}
 
 		if km.IsKeyExpired(key) {
-			if err := km.DeleteKey(username); err != nil {
+			if err := km.DeleteKey(keyID); err != nil {
 				log.Error().
-					Str("username", username).
+					Str("key_id", keyID).
 					Err(err).
 					Msg("Failed to delete expired key")
 			} else {
-				cleaned = append(cleaned, username)
+				cleaned = append(cleaned, keyID)
 			}
 		}
 	}
 
 	if len(cleaned) > 0 {
 		log.Info().
-			Strs("users", cleaned).
+			Strs("key_ids", cleaned).
 			Msg("Cleaned up expired SSH keys")
 	}
 
@@ -353,6 +377,12 @@ func (km *KeyManager) CleanupExpiredKeys() error {
 // listings. It deliberately carries no key material: `oidc-admin keys` wants to
 // know which users have keys, how strong they are and when they expire.
 type KeyInfo struct {
+	// KeyID is the identifier the pair is stored under, which is the ID of the
+	// session it was issued for.
+	KeyID string
+	// Username is the local account the key authorizes, recovered from the key's
+	// comment. It is empty for a key whose comment does not carry one, since the
+	// store itself is keyed by session and does not record the user separately.
 	Username string
 	// KeyType is the SSH algorithm name from the public key itself
 	// (e.g. "ssh-rsa"), not the manager's configured key type — an existing key
@@ -366,6 +396,21 @@ type KeyInfo struct {
 	Expired   bool
 }
 
+// usernameFromComment recovers the local account from a key comment of the form
+// "<username>@oidc-pam-<unix>", as written by GenerateKey. It returns "" for a
+// comment in any other shape rather than guessing, so an operator sees an empty
+// column instead of a plausible-looking wrong name.
+func usernameFromComment(comment string) string {
+	user, rest, found := strings.Cut(comment, "@oidc-pam-")
+	if !found || user == "" {
+		return ""
+	}
+	if _, err := strconv.ParseInt(rest, 10, 64); err != nil {
+		return ""
+	}
+	return user
+}
+
 // ListKeyInfo returns metadata for every managed key pair.
 //
 // A key whose files cannot be read or parsed is skipped and counted in the
@@ -373,18 +418,18 @@ type KeyInfo struct {
 // directory should not make the listing unavailable, but a silently short list
 // would read as "these are all the keys".
 func (km *KeyManager) ListKeyInfo() ([]KeyInfo, int, error) {
-	users, err := km.ListKeys()
+	keyIDs, err := km.ListKeys()
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list keys: %w", err)
 	}
 
-	infos := make([]KeyInfo, 0, len(users))
+	infos := make([]KeyInfo, 0, len(keyIDs))
 	unreadable := 0
-	for _, username := range users {
-		key, err := km.LoadKey(username)
+	for _, keyID := range keyIDs {
+		key, err := km.LoadKey(keyID)
 		if err != nil {
 			log.Warn().
-				Str("username", username).
+				Str("key_id", keyID).
 				Err(err).
 				Msg("Skipping key that could not be read while listing keys")
 			unreadable++
@@ -393,7 +438,8 @@ func (km *KeyManager) ListKeyInfo() ([]KeyInfo, int, error) {
 
 		keyType, keySize := publicKeyStrength(key.PublicKey)
 		infos = append(infos, KeyInfo{
-			Username:  username,
+			KeyID:     keyID,
+			Username:  usernameFromComment(key.Comment),
 			KeyType:   keyType,
 			KeySize:   keySize,
 			CreatedAt: key.CreatedAt,

--- a/pkg/ssh/security_hardening_test.go
+++ b/pkg/ssh/security_hardening_test.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -95,6 +96,104 @@ func TestValidateUsernameAllowlist(t *testing.T) {
 	for _, u := range invalid {
 		if err := validateUsername(u); err == nil {
 			t.Errorf("expected %q to be rejected", u)
+		}
+	}
+}
+
+// The key store is keyed by an opaque key ID — the broker passes a session ID —
+// so validateKeyID has to admit a 64-character hex string while still refusing
+// anything that could escape the base directory. Validating that argument as a
+// POSIX login name is what broke key provisioning outright (#152).
+func TestValidateKeyIDAllowlist(t *testing.T) {
+	valid := []string{
+		"4de51658fa4527eb9e1894ca69732ec8db2800723c21b516b8434d27b6491b5b", // a real session ID
+		"alice", "Session-1", "a", "abc_def-123",
+	}
+	for _, id := range valid {
+		if err := validateKeyID(id); err != nil {
+			t.Errorf("expected %q to be a valid key ID, got: %v", id, err)
+		}
+	}
+
+	invalid := []string{
+		"", "..", ".", "../etc", "a/../b", "/etc/passwd", "keys/id_rsa",
+		".hidden", "with space", "semi;colon", "nul\x00byte",
+		strings.Repeat("a", 129),
+	}
+	for _, id := range invalid {
+		if err := validateKeyID(id); err == nil {
+			t.Errorf("expected key ID %q to be rejected", id)
+		}
+	}
+}
+
+// A key ID that a POSIX login name check would refuse must round-trip through the
+// store, since that is exactly the shape the broker uses.
+func TestSaveAndLoadKeyUnderSessionID(t *testing.T) {
+	km := NewKeyManager(t.TempDir())
+	km.SetKeySize(2048)
+
+	const sessionID = "4de51658fa4527eb9e1894ca69732ec8db2800723c21b516b8434d27b6491b5b"
+
+	key, err := km.GenerateKey("alice")
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := km.SaveKey(sessionID, key); err != nil {
+		t.Fatalf("SaveKey under a session ID: %v", err)
+	}
+
+	loaded, err := km.LoadKey(sessionID)
+	if err != nil {
+		t.Fatalf("LoadKey(%q): %v", sessionID, err)
+	}
+	if string(loaded.PublicKey) != string(key.PublicKey) {
+		t.Error("the loaded public key differs from the saved one")
+	}
+
+	// The listing has to name both the storage ID and the account the key is for.
+	// The store is keyed by session, so the username can only come from the key's
+	// own comment — before #152 this column simply showed the session ID.
+	infos, unreadable, err := km.ListKeyInfo()
+	if err != nil {
+		t.Fatalf("ListKeyInfo: %v", err)
+	}
+	if unreadable != 0 {
+		t.Errorf("unreadable = %d, want 0", unreadable)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("ListKeyInfo returned %d keys, want 1", len(infos))
+	}
+	if infos[0].KeyID != sessionID {
+		t.Errorf("KeyID = %q, want %q", infos[0].KeyID, sessionID)
+	}
+	if infos[0].Username != "alice" {
+		t.Errorf("Username = %q, want %q recovered from the key comment", infos[0].Username, "alice")
+	}
+
+	if err := km.DeleteKey(sessionID); err != nil {
+		t.Fatalf("DeleteKey(%q): %v", sessionID, err)
+	}
+	if _, err := km.LoadKey(sessionID); err == nil {
+		t.Error("LoadKey succeeded after DeleteKey")
+	}
+}
+
+// usernameFromComment returns "" rather than guessing, so an operator sees an
+// empty column instead of a plausible-looking wrong name.
+func TestUsernameFromComment(t *testing.T) {
+	cases := map[string]string{
+		"alice@oidc-pam-1786663703": "alice",
+		"svc-account@oidc-pam-0":    "svc-account",
+		"alice@oidc-pam-":           "",
+		"alice@oidc-pam-notanumber": "",
+		"@oidc-pam-1786663703":      "",
+		"alice@example.org":         "",
+		"":                          "",
+	}
+	for comment, want := range cases {
+		if got := usernameFromComment(comment); got != want {
+			t.Errorf("usernameFromComment(%q) = %q, want %q", comment, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #152. Found by the first run of the end-to-end harness being built for #129.

## The defect

`Broker.generateSSHKey` files the on-disk key pair under the **session** ID —
deliberately, so concurrent sessions for one user do not overwrite each other's
key (`pkg/auth/broker.go:1176-1178`, and `LoadKey`/`DeleteKey` use the same ID).
But `KeyManager.SaveKey` validated that argument with `validateUsername`, and a
64-character hex session ID is not a POSIX login name.

So every save was refused. The error was only written to the broker's own log, and
the login carried on and was audited as `authentication_successful`:

```
{"level":"info","username":"alice","message":"SSH key pair generated successfully"}
{"level":"error","error":"failed to save SSH key: invalid username: username \"4de51658...\" is not a valid POSIX login name","message":"Failed to generate SSH key"}
{"event_type":"authentication_successful","user_id":"alice","success":true}
```

A device flow completed, PAM returned success, and `authorized_keys` was never
touched. Broken since `2e5522a` ("security: six-pass hardening"), which put the
validator there as path-traversal defence — the hardening was right, the validator
was simply the wrong one for an argument that is not a username.

## The fix

The store is keyed by an opaque **key ID**, which is what its only caller passes:

- `validateKeyID` replaces `validateUsername` in `SaveKey`/`LoadKey`/`DeleteKey`/
  `GetKeyPath`/`GetPublicKeyPath`. It is anchored, length-bounded, and admits no
  dots (hence no `.`/`..`) and no separators, so traversal remains impossible
  while a session ID fits. Parameters are renamed `keyID` so the contract is
  legible from the signature.
- `validateUsername` stays where the argument really is a username
  (`pkg/ssh/authorized_keys.go`, and `GenerateKey`'s comment).
- `KeyInfo` gains `KeyID`, and `Username` is recovered from the key comment
  (`<username>@oidc-pam-<unix>`) instead of being the storage directory name. So
  `oidc-admin keys` stops printing session IDs under a `USERNAME` column, and
  gains a `SESSION` column so a key can be tied to the session that owns it
  (`SSHKeyInfo.session_id` on the admin wire type).
- A provisioning failure is now audited as `ssh_key_provisioning_failed` rather
  than only logged. That silence is why this survived eleven releases.

## Why no test caught it

Each half was self-consistent, so both passed. The one test that exercised the
store end to end used the session ID `"sess-poll-test"` — which satisfies
`^[a-z_][a-z0-9_-]{0,31}\$?$` by accident.

`TestDeviceFlowProvisionsLoginKey` therefore uses a session ID of the shape the
broker really mints, and asserts the key reaches both the store and the user's
`authorized_keys` exactly once. Verified to fail against the defect:

```
--- FAIL: TestDeviceFlowProvisionsLoginKey (0.15s)
    device_poll_test.go:373: session has no SSHKeyID: no login key was provisioned (#152)
```

Plus `pkg/ssh` coverage for the new contract: `validateKeyID`'s allowlist
(including traversal attempts), a save/load/delete round trip under a real session
ID, `ListKeyInfo` reporting both IDs, and `usernameFromComment`.

## Verification

`go build ./...`, `gofmt -l`, `go vet`, `golangci-lint run` (0 issues), and
`go test ./...` all pass. The end-to-end `approved_login` case (#129), which
asserts exactly one `@oidc-pam-` line in `authorized_keys`, is what surfaced this
and is what confirms it in a real SSH login.