### PR TITLE
fix(auth): enforce require_groups from the config operators are told to write (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **High (#158): `require_groups` written the way every document tells operators
+  to write it enforced nothing.** Group membership was checked against the global
+  `authentication.require_groups`, but the configuration in QUICK-START.md,
+  DEPLOYMENT.md and the provider examples puts `require_groups` under
+  `authentication.policies.<name>`. The policy engine collected those into
+  `PolicyResult.RequiredGroups` and nothing ever read it, so on the documented
+  configuration any identity the provider would authenticate received a login,
+  a session, and an SSH key. `pollDeviceAuthorization` now enforces the list the
+  policy engine resolved — the union of the global setting and every matching
+  policy — which it takes as an argument, because the check runs in a background
+  goroutine long after policy evaluation and re-evaluating there would evaluate
+  against a different clock.
+
+  Two things prevented that resolved list from ever containing anything:
+
+  - Policies were matched against `AuthRequest.TargetHost`, which despite its
+    name is populated from PAM's `PAM_RHOST` by both clients — the address the
+    user is connecting *from*. A policy named `production` therefore only matched
+    a *client* literally named `production`. Matching is now against the
+    hostname of the machine being logged into, which is what a policy naming a
+    resource means.
+  - No policy name in any shipped configuration is a hostname; they are all
+    `default`, `production`, `staging`. `default` is now a documented catch-all
+    that applies to every host, so `policies.default.require_groups` — the
+    QUICK-START configuration — is enforced.
+
+  Policies whose names cannot match this host are logged by name at startup
+  instead of silently doing nothing, and `applyResourcePolicies` now applies
+  *every* matching policy rather than ranging over a map and breaking on the
+  first, which made the effective policy vary between runs of the same binary on
+  the same host. Unioning `require_groups` and taking the minimum
+  `max_session_duration` means an additional match can only restrict access
+  further.
+
+  `configs/CONFIGURATION-GUIDE.md` documents how a policy is selected;
+  DEPLOYMENT.md's example no longer uses three keys that are not fields of a
+  policy (`session_duration`, `max_concurrent_sessions`, `require_mfa`) or two
+  names that can never match (`admin_operations`, `sudo_operations`). Policies
+  still cannot be scoped to an operation such as `sudo`.
 - **Medium (#153): every `authentication_successful` record was written without
   the identity it authenticated.** The device-flow poll loop clones the session
   before mutating it (the map holds the raw pointer, so writing through it would

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -276,27 +276,33 @@ oidc:
   retry_delay: "5s"
 
 # Authentication policies
+#
+# A policy is selected by its name: "default" applies to every host, and any
+# other name must match the hostname of the machine being logged into (exactly,
+# or as a domain component — "production" matches "api.production.example.com").
+# A policy whose name matches no host never applies; the broker logs a warning
+# naming it at startup. Policies cannot be scoped to an operation such as sudo.
+#
+# Every matching policy applies: require_groups is the union of the global
+# authentication.require_groups and every match's, and max_session_duration is
+# the smallest of them.
 authentication:
+  # Applies everywhere, whatever the host is called.
+  require_groups: ["employees"]
+  max_concurrent_sessions: 3
+
   policies:
     default:
       require_groups: ["employees", "contractors"]
-      session_duration: "8h"
-      max_concurrent_sessions: 3
-      require_mfa: false
+      max_session_duration: "8h"
       audit_level: "standard"
-      
-    admin_operations:
+
+    # Applies only on hosts named "admin", e.g. admin.example.com.
+    admin:
       require_groups: ["administrators", "sysadmins"]
-      session_duration: "4h"
-      max_concurrent_sessions: 1
-      require_mfa: true
-      audit_level: "detailed"
-      
-    sudo_operations:
-      require_groups: ["sudo-users", "administrators"]
-      session_duration: "1h"
-      max_concurrent_sessions: 2
-      require_mfa: true
+      max_session_duration: "4h"
+      require_additional_mfa: true
+      require_device_trust: true
       audit_level: "detailed"
 
 # Security settings

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -411,14 +411,37 @@ audit:
     - "policy_violations"
 ```
 
+## Authentication Policies
+
+An `authentication.policies` entry is selected by its **name**:
+
+- `default` applies to **every host**. Use this unless you need per-host rules.
+- Any other name is matched against the **hostname of the machine being logged
+  into** — exactly, or as a domain component. A policy named `production`
+  applies on `production` and on `api.production.example.com`, but not on
+  `prod-login-01`.
+
+The name is the only selector a policy has. There is no way to scope a policy to
+an operation (`sudo`, `su`) or to an environment that is not part of the
+hostname; a policy whose name matches no host is inert, and the broker logs a
+warning naming it at startup.
+
+Every matching policy applies. `require_groups` is the union of the global
+`authentication.require_groups` and every matching policy's, and
+`max_session_duration` is the smallest — so an additional matching policy can
+only further restrict access.
+
 ## Environment-Specific Configurations
+
+Deploy one configuration per environment and name its policy `default`, so that
+it applies to the hosts in that environment regardless of what they are called.
 
 ### Development Environment
 
 ```yaml
 authentication:
   policies:
-    development:
+    default:
       require_groups: ["developers"]
       max_session_duration: "8h"
       allow_untrusted_devices: true
@@ -434,7 +457,7 @@ security:
 ```yaml
 authentication:
   policies:
-    staging:
+    default:
       require_groups: ["developers", "qa-team"]
       max_session_duration: "4h"
       require_device_trust: true
@@ -446,7 +469,7 @@ authentication:
 ```yaml
 authentication:
   policies:
-    production:
+    default:
       require_groups: ["production-access"]
       max_session_duration: "2h"
       require_device_trust: true

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -75,6 +75,13 @@ authentication:
     require_private_network: false
     
   # Resource-specific policies
+  # A policy is selected by its NAME: "default" applies to every host, any other
+  # name must match this host's name (exactly, or as a domain component, so
+  # "production" matches "api.production.example.com" but not "prod-login-01").
+  # A policy that matches no host never applies — the broker logs a warning
+  # naming it at startup. Rename the tier that applies to these hosts to
+  # "default", or name your hosts to match. Every matching policy applies:
+  # require_groups is the union of all matches and the global setting.
   policies:
     production:
       require_groups: ["production-access", "senior-engineers"]

--- a/configs/production/broker-cloud.yaml
+++ b/configs/production/broker-cloud.yaml
@@ -50,6 +50,13 @@ authentication:
   require_groups: ["${REQUIRED_GROUPS:-users}"]
   
   # Cloud-optimized policies
+  # A policy is selected by its NAME: "default" applies to every host, any other
+  # name must match this host's name (exactly, or as a domain component, so
+  # "production" matches "api.production.example.com" but not "prod-login-01").
+  # A policy that matches no host never applies — the broker logs a warning
+  # naming it at startup. Rename the tier that applies to these hosts to
+  # "default", or name your hosts to match. Every matching policy applies:
+  # require_groups is the union of all matches and the global setting.
   policies:
     production:
       require_groups: ["${PROD_GROUPS:-production-access}"]

--- a/configs/production/broker-enterprise.yaml
+++ b/configs/production/broker-enterprise.yaml
@@ -103,6 +103,13 @@ authentication:
   require_groups: ["company-employees"]
   
   # Environment-specific policies
+  # A policy is selected by its NAME: "default" applies to every host, any other
+  # name must match this host's name (exactly, or as a domain component, so
+  # "production" matches "api.production.example.com" but not "prod-login-01").
+  # A policy that matches no host never applies — the broker logs a warning
+  # naming it at startup. Rename the tier that applies to these hosts to
+  # "default", or name your hosts to match. Every matching policy applies:
+  # require_groups is the union of all matches and the global setting.
   policies:
     # Production environment - maximum security
     production:

--- a/configs/providers/azure-ad.yaml
+++ b/configs/providers/azure-ad.yaml
@@ -61,6 +61,13 @@ authentication:
   require_groups: ["linux-users"]
   
   # Azure AD specific policies
+  # A policy is selected by its NAME: "default" applies to every host, any other
+  # name must match this host's name (exactly, or as a domain component, so
+  # "production" matches "api.production.example.com" but not "prod-login-01").
+  # A policy that matches no host never applies — the broker logs a warning
+  # naming it at startup. Rename the tier that applies to these hosts to
+  # "default", or name your hosts to match. Every matching policy applies:
+  # require_groups is the union of all matches and the global setting.
   policies:
     production:
       require_groups: ["production-access", "azuread-admin"]

--- a/configs/providers/keycloak.yaml
+++ b/configs/providers/keycloak.yaml
@@ -66,6 +66,13 @@ authentication:
   require_groups: ["linux-users"]
   
   # Keycloak-specific policies
+  # A policy is selected by its NAME: "default" applies to every host, any other
+  # name must match this host's name (exactly, or as a domain component, so
+  # "production" matches "api.production.example.com" but not "prod-login-01").
+  # A policy that matches no host never applies — the broker logs a warning
+  # naming it at startup. Rename the tier that applies to these hosts to
+  # "default", or name your hosts to match. Every matching policy applies:
+  # require_groups is the union of all matches and the global setting.
   policies:
     production:
       require_groups: ["production-access", "keycloak-admin"]

--- a/configs/providers/okta.yaml
+++ b/configs/providers/okta.yaml
@@ -61,6 +61,13 @@ authentication:
   require_groups: ["linux-users"]
   
   # Okta-specific policies
+  # A policy is selected by its NAME: "default" applies to every host, any other
+  # name must match this host's name (exactly, or as a domain component, so
+  # "production" matches "api.production.example.com" but not "prod-login-01").
+  # A policy that matches no host never applies — the broker logs a warning
+  # naming it at startup. Rename the tier that applies to these hosts to
+  # "default", or name your hosts to match. Every matching policy applies:
+  # require_groups is the union of all matches and the global setting.
   policies:
     production:
       require_groups: ["production-access", "okta-admin"]

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -422,7 +422,12 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 
 	// Start polling for device authorization in background
 	b.wg.Add(1)
-	go b.pollDeviceAuthorization(session, provider, deviceFlow)
+	// policyResult.RequiredGroups is the union of the global
+	// authentication.require_groups and every matching per-resource policy's
+	// require_groups. It has to be carried into the goroutine: the group check
+	// happens when the flow completes, long after this function has returned, and
+	// re-evaluating policy there would evaluate it against a different clock.
+	go b.pollDeviceAuthorization(session, provider, deviceFlow, policyResult.RequiredGroups)
 
 	return &AuthResponse{
 		Success:        true,
@@ -811,7 +816,7 @@ func providerPriority(provider *OIDCProvider) int {
 	return provider.Config.Priority
 }
 
-func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvider, deviceFlow *DeviceFlow) {
+func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvider, deviceFlow *DeviceFlow, requiredGroups []string) {
 	defer b.wg.Done()
 	defer atomic.AddInt64(&b.pendingFlows, -1)
 
@@ -929,7 +934,14 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 
 			// SECURITY (H-1): enforce required group membership. RequiredGroups
 			// was previously collected by the policy engine but never checked.
-			if err := b.verifyRequiredGroups(userInfo.Groups); err != nil {
+			//
+			// (#158) Enforce the list the policy engine resolved, not
+			// config.Authentication.RequireGroups. Reading the global key directly
+			// meant require_groups written under authentication.policies.<name> —
+			// the form QUICK-START.md and DEPLOYMENT.md both tell operators to use —
+			// was collected into PolicyResult.RequiredGroups and then never read by
+			// anything, so the documented config enforced no groups at all.
+			if err := b.verifyRequiredGroups(requiredGroups, userInfo.Groups); err != nil {
 				log.Warn().
 					Err(err).
 					Str("session_id", session.ID).
@@ -1412,12 +1424,16 @@ func classifyPollError(err error) string {
 	}
 }
 
-// verifyRequiredGroups enforces that the authenticated user is a member of all
-// globally required groups (Authentication.RequireGroups). Returns nil when no
-// groups are required. Comparison is exact and case-sensitive (group names are
-// provider-defined identifiers).
-func (b *Broker) verifyRequiredGroups(userGroups []string) error {
-	required := b.config.Authentication.RequireGroups
+// verifyRequiredGroups enforces that the authenticated user is a member of every
+// group in required. Returns nil when no groups are required. Comparison is exact
+// and case-sensitive (group names are provider-defined identifiers).
+//
+// required is supplied by the caller rather than read from config here, because the
+// effective list is the union of the global authentication.require_groups and the
+// require_groups of every matching per-resource policy — a union only the policy
+// engine can compute. See PolicyEngine.applyGlobalPolicies and
+// applyResourcePolicies.
+func (b *Broker) verifyRequiredGroups(required, userGroups []string) error {
 	if len(required) == 0 {
 		return nil
 	}

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -561,7 +561,7 @@ func TestBrokerPollDeviceAuthorization(t *testing.T) {
 	// This method runs in a goroutine and doesn't return values
 	// We'll just call it to test it doesn't panic
 	broker.wg.Add(1)
-	go broker.pollDeviceAuthorization(mockSession, provider, deviceFlow)
+	go broker.pollDeviceAuthorization(mockSession, provider, deviceFlow, nil)
 
 	// Wait briefly for the polling to start
 	time.Sleep(10 * time.Millisecond)

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -49,6 +49,11 @@ type pollTestEnv struct {
 	homeDir string
 	// auditPath is the JSON-lines file the broker's audit logger writes to.
 	auditPath string
+	// requiredGroups is what the policy engine would have resolved for this login:
+	// the union of the global require_groups and every matching per-resource
+	// policy's. pollDeviceAuthorization takes it as an argument rather than reading
+	// config, so a test drives group enforcement by setting this (#158).
+	requiredGroups []string
 }
 
 func newPollTestEnv(t *testing.T) *pollTestEnv {
@@ -219,7 +224,7 @@ func (e *pollTestEnv) run(t *testing.T) time.Duration {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		e.broker.pollDeviceAuthorization(e.session, e.provider, e.flow)
+		e.broker.pollDeviceAuthorization(e.session, e.provider, e.flow, e.requiredGroups)
 	}()
 
 	select {
@@ -361,7 +366,7 @@ func TestDeviceFlowStopsWithTheBroker(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		env.broker.pollDeviceAuthorization(env.session, env.provider, env.flow)
+		env.broker.pollDeviceAuthorization(env.session, env.provider, env.flow, env.requiredGroups)
 	}()
 
 	// Let it poll at least once so it is genuinely mid-flow.
@@ -531,5 +536,201 @@ func TestDeviceFlowProvisionsLoginKey(t *testing.T) {
 	}
 	if !strings.Contains(string(data), session.UserID+"@oidc-pam-") {
 		t.Errorf("the authorized key is not commented for %q:\n%s", session.UserID, data)
+	}
+}
+
+// TestPerPolicyRequireGroupsIsEnforced covers #158.
+//
+// The gate is the *config path*, not the comparison. verifyRequiredGroups was
+// always correct; it was reading the wrong list. require_groups written under
+// authentication.policies.<name> — the form QUICK-START.md:136-138 and
+// DEPLOYMENT.md:280-297 both instruct operators to use — was collected into
+// PolicyResult.RequiredGroups by applyResourcePolicies and then read by nothing,
+// while the enforcement looked at the global authentication.require_groups, which
+// in this configuration is empty. So the documented configuration enforced no
+// groups at all and any identity the IdP would authenticate got a login.
+//
+// Note what this test deliberately does not do: it does not set
+// Authentication.RequireGroups. That is the field the old code read, and setting it
+// is what let TestVerifyRequiredGroups pass while the real path was open.
+func TestPerPolicyRequireGroupsIsEnforced(t *testing.T) {
+	env := newPollTestEnv(t)
+
+	// A policy named for the resource being logged into — this host. The engine
+	// matches on its own hostname rather than on req.TargetHost, which is PAM_RHOST
+	// and names the *client*.
+	const host = "policy-test-host"
+	policyCfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			Policies: map[string]config.AuthenticationPolicy{
+				host: {RequireGroups: []string{"hpc-admins"}},
+			},
+		},
+	}
+	engine := &PolicyEngine{config: policyCfg, resourceHost: host}
+
+	result, err := engine.EvaluateRequest(&AuthRequest{
+		UserID:     "testuser",
+		LoginType:  "ssh",
+		SourceIP:   "192.0.2.10",
+		TargetHost: "some-client.example.net", // what a client actually sends
+	})
+	if err != nil {
+		t.Fatalf("EvaluateRequest: %v", err)
+	}
+	if len(result.RequiredGroups) != 1 || result.RequiredGroups[0] != "hpc-admins" {
+		t.Fatalf("policy resolved RequiredGroups = %v, want [hpc-admins] from the per-policy config", result.RequiredGroups)
+	}
+
+	// Now the login. The issuer's identity is in "researchers" and no other group,
+	// so the requirement cannot be satisfied.
+	env.requiredGroups = result.RequiredGroups
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("the session survived a login that satisfies no required group: %+v", session)
+	}
+
+	event := env.auditEvent(t, "authentication_denied")
+	if event.ErrorCode != "GROUP_DENIED" {
+		t.Errorf("denial recorded with error_code %q, want GROUP_DENIED", event.ErrorCode)
+	}
+	if event.Success {
+		t.Error("the denial event is recorded with success=true")
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("a login that satisfies no required group was recorded as successful (#158)")
+		}
+	}
+
+	// And no credential was left behind for it.
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a refused login installed a login key:\n%s", data)
+	}
+}
+
+// TestResourcePolicyMatchesTheResourceNotTheClient covers the other half of #158:
+// policies were matched against req.TargetHost, which both clients populate from
+// PAM_RHOST — the address the user is connecting *from*. A policy named
+// "production" therefore only ever matched a client literally named "production",
+// so the whole policies: block never fired for anyone.
+func TestResourcePolicyMatchesTheResourceNotTheClient(t *testing.T) {
+	policyCfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			Policies: map[string]config.AuthenticationPolicy{
+				"production": {RequireGroups: []string{"prod-admins"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		resourceHost string
+		targetHost   string
+		wantGroups   bool
+	}{
+		{"resource host matches the policy name", "production", "laptop.example.net", true},
+		{"resource host in the policy's domain", "api.production.example.com", "laptop.example.net", true},
+		{"client host matching the policy name does not", "some-host", "production", false},
+		{"neither matches", "some-host", "laptop.example.net", false},
+		{"no hostname resolved, so nothing matches", "", "production", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &PolicyEngine{config: policyCfg, resourceHost: tc.resourceHost}
+			result, err := engine.EvaluateRequest(&AuthRequest{
+				UserID: "testuser", LoginType: "ssh", TargetHost: tc.targetHost,
+			})
+			if err != nil {
+				t.Fatalf("EvaluateRequest: %v", err)
+			}
+			got := len(result.RequiredGroups) > 0
+			if got != tc.wantGroups {
+				t.Errorf("RequiredGroups = %v, want a requirement: %v", result.RequiredGroups, tc.wantGroups)
+			}
+		})
+	}
+}
+
+// TestQuickStartConfigEnforcesItsRequiredGroups is the acceptance test for #158:
+// the exact configuration QUICK-START.md hands a first-time operator, loaded
+// through the real config loader, must deny a user who is in none of the groups it
+// names.
+//
+// This is the test that mattered. The two tests above construct a config.Config in
+// Go, so they prove the engine and the enforcement agree; they cannot prove that
+// the YAML in the docs reaches the engine at all. It did not: `policies.default`
+// names no host, so before the DefaultPolicyName catch-all this config matched
+// nothing, resolved no required groups, and admitted every identity the IdP would
+// authenticate.
+func TestQuickStartConfigEnforcesItsRequiredGroups(t *testing.T) {
+	// Verbatim from QUICK-START.md:131-138 — the authentication block a new
+	// operator is told to write. If this literal changes in the docs, change it
+	// here too, and expect this test to tell you if it stopped enforcing anything.
+	const quickStartAuth = `
+authentication:
+  policies:
+    default:
+      require_groups: ["users"]
+      session_duration: "8h"
+      audit_level: "standard"
+`
+	configPath := filepath.Join(t.TempDir(), "broker.yaml")
+	if err := os.WriteFile(configPath, []byte(quickStartAuth), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig on the QUICK-START configuration: %v", err)
+	}
+	if got := cfg.Authentication.Policies["default"].RequireGroups; len(got) != 1 || got[0] != "users" {
+		t.Fatalf("loader read policies.default.require_groups as %v, want [users]", got)
+	}
+	// The global key stays empty: that is the whole point. It is what the old
+	// enforcement read.
+	if len(cfg.Authentication.RequireGroups) != 0 {
+		t.Fatalf("authentication.require_groups = %v, want empty; this config sets only the per-policy form",
+			cfg.Authentication.RequireGroups)
+	}
+
+	// A real engine, so the host resolution and the catch-all both run for real.
+	engine, err := NewPolicyEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	defer engine.Close()
+
+	result, err := engine.EvaluateRequest(&AuthRequest{
+		UserID:     "testuser",
+		LoginType:  "ssh",
+		SourceIP:   "192.0.2.10",
+		TargetHost: "some-client.example.net",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateRequest: %v", err)
+	}
+	if len(result.RequiredGroups) != 1 || result.RequiredGroups[0] != "users" {
+		t.Fatalf("the QUICK-START config resolved RequiredGroups = %v, want [users]; "+
+			"a policies.default block that resolves nothing enforces nothing (#158)", result.RequiredGroups)
+	}
+
+	// And the login it governs is refused: the issuer's identity is in
+	// "researchers", not "users".
+	env := newPollTestEnv(t)
+	env.requiredGroups = result.RequiredGroups
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("the QUICK-START configuration admitted a user in none of its require_groups: %+v", session)
+	}
+	if event := env.auditEvent(t, "authentication_denied"); event.ErrorCode != "GROUP_DENIED" {
+		t.Errorf("denial recorded with error_code %q, want GROUP_DENIED", event.ErrorCode)
 	}
 }

--- a/pkg/auth/identity_binding_test.go
+++ b/pkg/auth/identity_binding_test.go
@@ -110,7 +110,7 @@ func TestVerifyRequiredGroups(t *testing.T) {
 			b := &Broker{config: &config.Config{
 				Authentication: config.AuthenticationConfig{RequireGroups: tc.required},
 			}}
-			err := b.verifyRequiredGroups(tc.have)
+			err := b.verifyRequiredGroups(tc.required, tc.have)
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected error, got nil")
 			}

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"fmt"
 	"net"
+	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -18,6 +20,11 @@ type PolicyEngine struct {
 	geoipDB         *geoip2.Reader
 	locationHistory *LocationHistory
 	metrics         *oidcmetrics.Metrics // nil when metrics are disabled
+
+	// resourceHost is the host a per-resource policy is matched against: this
+	// machine, the resource being logged into. It is deliberately not taken from
+	// the request — see applyResourcePolicies (#158).
+	resourceHost string
 }
 
 // SetMetrics attaches a Metrics instance to the policy engine.
@@ -56,7 +63,61 @@ func NewPolicyEngine(cfg *config.Config) (*PolicyEngine, error) {
 		pe.locationHistory = NewLocationHistory(config.LocationHistoryConfig{})
 	}
 
+	// Resolve this host once. A per-resource policy names the resource it governs,
+	// and the resource is this machine.
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		// Not fatal, but say so loudly: with no hostname, no per-resource policy can
+		// match, and a policy that does not match enforces nothing — including its
+		// require_groups.
+		log.Warn().
+			Err(err).
+			Msg("Could not determine this host's name; per-resource policies cannot match and will not be enforced")
+	}
+	pe.resourceHost = hostname
+	pe.warnAboutInertPolicies()
+
 	return pe, nil
+}
+
+// DefaultPolicyName is the policy that governs every host. A policy under this
+// name is always in effect; any other name is matched against this host's name.
+//
+// This exists because the name is the only selector a policy has, and the
+// configuration every doc hands operators (QUICK-START.md, DEPLOYMENT.md) is
+// `policies.default.require_groups` — a name intended as "all hosts", not as a
+// hostname. Without a catch-all the documented configuration would match no host
+// and enforce nothing.
+const DefaultPolicyName = "default"
+
+// warnAboutInertPolicies logs any configured policy that cannot match this host.
+//
+// A policy's name is its only selector, so a policy named for an environment
+// ("production", "staging") matches only a host actually named that. Such a
+// policy is silently inert — including its require_groups — which is how #158
+// went unnoticed. Saying so at startup makes it visible instead.
+func (pe *PolicyEngine) warnAboutInertPolicies() {
+	if pe.config == nil {
+		return
+	}
+
+	var inert []string
+	for name := range pe.config.Authentication.Policies {
+		if !pe.matchesResourcePolicy(pe.resourceHost, name) {
+			inert = append(inert, name)
+		}
+	}
+	if len(inert) == 0 {
+		return
+	}
+	sort.Strings(inert)
+
+	log.Warn().
+		Strs("inert_policies", inert).
+		Str("this_host", pe.resourceHost).
+		Msgf("These authentication.policies entries do not apply to this host and will not be enforced. "+
+			"A policy name must be %q (all hosts) or match this host's name; rename them or move their "+
+			"require_groups to authentication.require_groups", DefaultPolicyName)
 }
 
 // RecordLocation records a successful login from sourceIP for userID so that
@@ -250,11 +311,35 @@ func (pe *PolicyEngine) applyRiskPolicies(req *AuthRequest, result *PolicyResult
 	return nil
 }
 
-// applyResourcePolicies applies resource-specific policies
+// applyResourcePolicies applies resource-specific policies.
+//
+// (#158) Policies are matched against pe.resourceHost — this machine — and not
+// against req.TargetHost. Despite its name, TargetHost is populated from PAM's
+// PAM_RHOST by both clients (cmd/pam-module/cgo_bridge_linux.c get_user_info,
+// pkg/pam/pam.go), which is the address of the host the user is connecting *from*.
+// Matching policy names against that meant a policy named "production" only ever
+// matched a client literally named "production", so the whole policies: block —
+// its require_groups, its ip_whitelist, its max_session_duration — never fired.
+//
+// (#158) Every matching policy is applied, not just the first one found. The old
+// loop ranged over a map and broke on the first match, so when more than one
+// policy matched — which is now normal, since DefaultPolicyName matches every
+// host — which policy took effect varied between runs of the same binary on the
+// same host. Applying all of them is both deterministic and the safer reading:
+// require_groups unions and max_session_duration takes the minimum, so more
+// matching policies can only ever restrict access further.
 func (pe *PolicyEngine) applyResourcePolicies(req *AuthRequest, result *PolicyResult) error {
-	// Find matching policy for target resource
-	for policyName, policy := range pe.config.Authentication.Policies {
-		if pe.matchesResourcePolicy(req.TargetHost, policyName) {
+	// Sorted so that the denial reported for an ip_whitelist miss names the same
+	// policy every time.
+	names := make([]string, 0, len(pe.config.Authentication.Policies))
+	for name := range pe.config.Authentication.Policies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, policyName := range names {
+		policy := pe.config.Authentication.Policies[policyName]
+		if pe.matchesResourcePolicy(pe.resourceHost, policyName) {
 			// Apply policy requirements
 			if len(policy.RequireGroups) > 0 {
 				result.RequiredGroups = append(result.RequiredGroups, policy.RequireGroups...)
@@ -289,8 +374,6 @@ func (pe *PolicyEngine) applyResourcePolicies(req *AuthRequest, result *PolicyRe
 					return nil
 				}
 			}
-
-			break
 		}
 	}
 
@@ -476,6 +559,12 @@ func (pe *PolicyEngine) evaluateRiskCondition(condition string, req *AuthRequest
 }
 
 func (pe *PolicyEngine) matchesResourcePolicy(targetHost, policyName string) bool {
+	// DefaultPolicyName governs every host, including one whose name could not be
+	// determined. See the constant's doc comment.
+	if policyName == DefaultPolicyName {
+		return true
+	}
+
 	// Match exact hostname or hosts in a subdomain of policyName.
 	// e.g. policy "production" matches "production" and "api.production.example.com"
 	// but NOT "not-production" or "production-test".


### PR DESCRIPTION
Fixes #158.

## The bug

`require_groups` was enforced against `authentication.require_groups`, but the configuration QUICK-START.md, DEPLOYMENT.md and every provider example hands operators puts it under `authentication.policies.<name>`. The policy engine collected those into `PolicyResult.RequiredGroups` and **nothing read the field**. On the documented configuration, any identity the provider would authenticate received a login, a session, and an SSH key.

Three defects had to be fixed together, because fixing only the first would still have enforced nothing:

1. **Enforcement read the wrong list.** `pollDeviceAuthorization` now checks the list the policy engine resolved — the union of the global setting and every matching policy. It takes the list as an argument rather than reading config, because the check runs in a background goroutine long after policy evaluation; re-resolving there would evaluate against a different clock.

2. **Policies were matched against the wrong host.** Matching used `AuthRequest.TargetHost`, which despite its name is populated from `PAM_RHOST` by both clients (`cgo_bridge_linux.c` `get_user_info`, `pkg/pam/pam.go`) — the address the user connects *from*. A policy named `production` only ever matched a *client* literally named `production`. Matching is now against this host, the resource being logged into.

3. **No shipped policy name is a hostname.** Every one is `default`, `production`, `staging`, `development`. So even after (2), nothing matched. `default` is now a documented catch-all that applies to every host, which makes `policies.default.require_groups` — the QUICK-START configuration — enforced.

Also fixed along the way: `applyResourcePolicies` ranged over a map and `break`ed on the first match, so with more than one matching policy *which one took effect varied between runs of the same binary on the same host*. It now applies all matches; `require_groups` unions and `max_session_duration` takes the minimum, so an extra match can only restrict access further.

## Fail loudly instead of silently

A policy name is a policy's only selector, so a policy named for an environment is inert unless the host is named that — which is how this went unnoticed. The broker now logs the inert policies by name at startup:

```
WARN These authentication.policies entries do not apply to this host and will not be
     enforced. A policy name must be "default" (all hosts) or match this host's name
     inert_policies=["production","staging"] this_host="prod-login-01"
```

## Tests

The acceptance test loads the **literal QUICK-START authentication block** through the real `config.LoadConfig` and asserts a user in none of its groups is denied — `GROUP_DENIED` in the audit log, no surviving session, no `@oidc-pam-` key installed. Two narrower tests cover the resolved-list enforcement and the resource-vs-client matching (a 5-case table).

Verified as a regression gate in both directions. Restoring the global-key read:

```
--- FAIL: TestPerPolicyRequireGroupsIsEnforced
    the session survived a login that satisfies no required group
    audit log has 0 "authentication_denied" event(s), want exactly 1; it recorded [authentication_successful]
```

Removing the catch-all:

```
--- FAIL: TestQuickStartConfigEnforcesItsRequiredGroups
    the QUICK-START config resolved RequiredGroups = [], want [users]
```

## Docs

`configs/CONFIGURATION-GUIDE.md` gains a section on how a policy is selected, and its environment examples use `default` (one config per environment) instead of names that match no host. DEPLOYMENT.md's example drops three keys that are not fields of `AuthenticationPolicy` (`session_duration`, `max_concurrent_sessions`, `require_mfa`) and two names that can never match (`admin_operations`, `sudo_operations`). The six shipped configs carry the selection rule inline.

## Known gap, not addressed here

There is still **no way to scope a policy to an environment that is not part of the hostname**, which is what all six shipped configs want (`production`/`staging`/`development` tiers on hosts named `prod-login-01`), nor **to an operation** such as `sudo`, which DEPLOYMENT.md previously implied. Both need a new selector — a config-schema change I kept out of a security fix. Filing as a follow-up; until then the startup warning means no operator is silently unprotected.

Local: `make fmt`, `go build ./...`, `go vet ./pkg/... ./internal/...`, `go test -race ./pkg/... ./internal/...`, `golangci-lint run ./pkg/auth/...` — all clean.