### PR TITLE
fix(auth): stop the IdP choosing which local account a login becomes (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **High (#159): an identity provider could choose which local account a login
+  became, including root.** Identity binding accepted the **local part** of an
+  email-shaped claim as a match for the requested account, so `root@evil.tld`
+  logging in as `root` was bound and approved. With `auth sufficient pam_oidc.so`
+  (the shipped stack) that short-circuits the rest of the auth stack. Reaching it
+  needed only the ability to choose the local part of one's own address — a mail
+  alias, a second verified domain, a B2B guest identity from another tenant —
+  and the branch was live in every shipped configuration: `username_claim: email`
+  in four of them, and `preferred_username`, which *is* the UPN on Entra ID, in
+  two more. The weaker variant needed no provider control at all: guest
+  `alice@partner.example` and employee `alice@example.com` both bound to local
+  `alice`.
+
+  Two independent fixes, either of which stops the escalation:
+
+  - The whole claim value must now equal the requested account. Local-part
+    matching is opt-in per provider (`username_claim_strip_domain: true`) and
+    requires `allowed_email_domains` to pin the domains it may come from —
+    enabling one without the other is a startup error, and domains are matched
+    exactly, since a wildcard re-opens the subdomain an attacker can get a
+    verified address under.
+  - No OIDC identity may bind to uid 0 or to any account with uid below 1000,
+    whatever the token says and however the mapping is configured. This is the
+    check that holds when `username_claim` or `allowed_email_domains` is wrong.
+    Deliberate exceptions go in `authentication.allow_privileged_accounts`, named
+    one at a time, and each use is logged.
+
+  Refusals of the second kind are audited as `PRIVILEGED_ACCOUNT_DENIED`: the
+  identity matched, so recording it as `IDENTITY_MISMATCH` would send an operator
+  looking for a claim problem that is not there.
+
+  **This is a breaking change for anyone using an email-shaped
+  `username_claim`.** Logins that relied on the local part being stripped will be
+  refused until `username_claim_strip_domain` and `allowed_email_domains` are
+  set; the refusal names both keys and the domain it saw. The six affected
+  shipped configs are updated with the opt-in and a placeholder domain. The
+  environment-variable-derived config deliberately does *not* enable it, because
+  it cannot know the operator's domain and guessing a domain pin is the wrong
+  direction to fail.
+
+  Coverage: the previous test suite asserted the vulnerable behaviour was correct
+  (`identity_binding_test.go` had `email: alice@example.com` + requested `alice`
+  ⇒ no error), which is why it survived. That case now asserts the refusal and
+  moves under the opt-in. `root@evil.tld` is tested against all four plausible
+  provider configurations, the uid guard is tested on an exact claim match, and
+  both run through the full device flow — not just the binding function — so the
+  poll loop is proven to act on the result. Two e2e cases: an exactly-matching
+  identity refused for a uid-400 account (`root` is unusable there, since
+  `PermitRootLogin no` means sshd refuses before PAM runs and the case would pass
+  without testing anything), and `alice@example.org` refused for local `alice`.
+
 ### Fixed
 - **High (#158): `require_groups` written the way every document tells operators
   to write it enforced nothing.** Group membership was checked against the global

--- a/README.md
+++ b/README.md
@@ -114,10 +114,18 @@ oidc:
       # match, preventing an IdP user from logging in as another local account.
       user_mapping:
         username_claim: "preferred_username"
+        # If that claim is an email or a UPN, the whole value must equal the local
+        # username by default. To let the local part match instead — alice@example.com
+        # logging in as "alice" — opt in and pin the domains it may come from:
+        # username_claim_strip_domain: true
+        # allowed_email_domains: ["example.com"]
 
 authentication:
   token_lifetime: "8h"
   require_groups: ["linux-users"]    # enforced against the user's OIDC groups
+  # No OIDC identity may log in as uid 0 or any account with uid < 1000. List an
+  # account here to make a deliberate exception:
+  # allow_privileged_accounts: ["deploy"]
 
 security:
   audit_enabled: true

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -411,6 +411,51 @@ audit:
     - "policy_violations"
 ```
 
+## Binding an OIDC Identity to a Local Account
+
+`user_mapping.username_claim` names the claim whose value must equal the local
+account being logged into. By default the comparison is against the **whole**
+value, case-insensitively.
+
+When that claim is an email address or a UPN — `email` anywhere, and
+`preferred_username` on Entra ID — the whole value never equals a Unix account
+name, so nothing matches until you say what should happen:
+
+```yaml
+user_mapping:
+  username_claim: "email"
+  username_claim_strip_domain: true
+  allowed_email_domains: ["example.com", "eng.example.com"]
+```
+
+That permits `alice@example.com` to log in as `alice`, and refuses
+`alice@partner.example` and `root@anything`. Both keys are required together;
+enabling the first without the second is a startup error.
+
+Domains are matched exactly — no wildcards. A wildcard would re-open what the
+pin exists to close: a subdomain under which an attacker can get a verified
+address. Every domain you list is a domain whose local parts choose local
+accounts on this host, so list only domains whose addresses you control.
+
+### Privileged accounts
+
+No OIDC identity may log in as uid 0, or as any account with uid below 1000,
+regardless of what the token says or how the mapping is configured. This holds
+even for an exact claim match, because whether `root` is a legitimate destination
+for a federated login does not depend on the mapping being right.
+
+To make a deliberate exception:
+
+```yaml
+authentication:
+  allow_privileged_accounts: ["deploy"]
+```
+
+Each exception is named individually — allowing `deploy` does not allow `root` —
+and the broker logs a warning every time one is used. Refusals are audited as
+`PRIVILEGED_ACCOUNT_DENIED`, distinct from the `IDENTITY_MISMATCH` recorded when
+the claim itself does not match.
+
 ## Authentication Policies
 
 An `authentication.policies` entry is selected by its **name**:

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -21,6 +21,13 @@ oidc:
       # User attribute mapping
       user_mapping:
         username_claim: "email"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "groups"

--- a/configs/production/broker-cloud.yaml
+++ b/configs/production/broker-cloud.yaml
@@ -32,6 +32,13 @@ oidc:
       
       user_mapping:
         username_claim: "${OIDC_USERNAME_CLAIM:-email}"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "${OIDC_EMAIL_CLAIM:-email}"
         name_claim: "${OIDC_NAME_CLAIM:-name}"
         groups_claim: "${OIDC_GROUPS_CLAIM:-groups}"

--- a/configs/production/broker-enterprise.yaml
+++ b/configs/production/broker-enterprise.yaml
@@ -27,6 +27,13 @@ oidc:
       
       user_mapping:
         username_claim: "email"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "groups"
@@ -48,6 +55,13 @@ oidc:
       
       user_mapping:
         username_claim: "email"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "groups"
@@ -84,6 +98,13 @@ oidc:
       
       user_mapping:
         username_claim: "email"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "contractor-groups"

--- a/configs/production/broker-minimal.yaml
+++ b/configs/production/broker-minimal.yaml
@@ -32,6 +32,13 @@ oidc:
       # REQUIRED: Map OIDC claims to user attributes
       user_mapping:
         username_claim: "email"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "groups"

--- a/configs/providers/azure-ad.yaml
+++ b/configs/providers/azure-ad.yaml
@@ -28,6 +28,13 @@ oidc:
       # Azure AD user mapping
       user_mapping:
         username_claim: "preferred_username"  # Usually email in Azure AD
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@yourtenant.onmicrosoft.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace yourtenant.onmicrosoft.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["yourtenant.onmicrosoft.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "groups"

--- a/configs/providers/okta.yaml
+++ b/configs/providers/okta.yaml
@@ -28,6 +28,13 @@ oidc:
       # Okta user mapping
       user_mapping:
         username_claim: "preferred_username"  # or "email"
+        # (#159) An email-shaped claim binds on its local part only when you ask for it
+        # and pin the domains it may come from: with these settings alice@example.com can
+        # log in as "alice", while alice@partner.example and root@anything cannot.
+        # Replace example.com with your domain(s). Privileged accounts (uid < 1000)
+        # are refused regardless; see authentication.allow_privileged_accounts.
+        username_claim_strip_domain: true
+        allowed_email_domains: ["example.com"]
         email_claim: "email"
         name_claim: "name"
         groups_claim: "groups"

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os/user"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -45,6 +47,12 @@ type Broker struct {
 	// several authorization_pending polls finishes in milliseconds instead of
 	// the ~15 s that RFC 8628's 5 s floor would otherwise cost.
 	pollIntervalUnit time.Duration
+
+	// lookupLocalUID resolves a local account name to its uid, reporting whether the
+	// account exists. Nil means the real getpwnam-backed lookup; tests substitute a
+	// fixed passwd table so that the privileged-account guard can be exercised
+	// without depending on the uids of whatever host runs the suite (#159).
+	lookupLocalUID func(name string) (int, bool, error)
 }
 
 // pollUnit is the real-time duration of one second of a device flow's polling
@@ -909,14 +917,25 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 			// could authenticate as any local account (including root). Fail
 			// closed on any mismatch or misconfiguration.
 			if err := b.verifyIdentityBinding(provider, userInfo, session.UserID); err != nil {
+				// (#159) A privileged-account refusal is not a mismatch: the identity
+				// matched, and the local account is simply not one an OIDC login may
+				// become. Audited separately so an operator is not sent looking for a
+				// claim problem that is not there.
+				errCode := "IDENTITY_MISMATCH"
+				message := "Rejected authentication: OIDC identity does not match requested local user"
+				if errors.Is(err, ErrPrivilegedAccount) {
+					errCode = "PRIVILEGED_ACCOUNT_DENIED"
+					message = "Rejected authentication: refusing to bind an OIDC identity to a privileged local account"
+				}
 				log.Warn().
 					Err(err).
 					Str("session_id", session.ID).
 					Str("requested_user", session.UserID).
 					Str("oidc_subject", userInfo.Subject).
-					Msg("Rejected authentication: OIDC identity does not match requested local user")
+					Str("error_code", errCode).
+					Msg(message)
 				if b.metrics != nil {
-					b.metrics.RecordAuth(provider.Name, "failure", "IDENTITY_MISMATCH")
+					b.metrics.RecordAuth(provider.Name, "failure", errCode)
 				}
 				b.auditLogger.LogAuthEvent(security.AuditEvent{
 					EventType:    "authentication_denied",
@@ -924,7 +943,7 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 					Email:        userInfo.Email,
 					SessionID:    session.ID,
 					Success:      false,
-					ErrorCode:    "IDENTITY_MISMATCH",
+					ErrorCode:    errCode,
 					ErrorMessage: err.Error(),
 					Timestamp:    time.Now(),
 				})
@@ -1360,15 +1379,148 @@ func (b *Broker) verifyIdentityBinding(provider *OIDCProvider, userInfo *UserInf
 		return fmt.Errorf("username_claim %q produced an empty username", claimName)
 	}
 
-	// If the claim is an email (e.g. preferred_username/email), allow matching
-	// either the full value or its local-part against the requested user.
+	// No OIDC identity binds to a privileged account, however well it matches.
+	// Checked before the claim comparison so that it holds even when the claim is an
+	// exact match and the domain is pinned.
+	if err := b.verifyLocalAccountIsBindable(requested); err != nil {
+		return err
+	}
+
+	// The whole claim value must equal the requested account.
 	if mapped == requested {
 		return nil
 	}
-	if local, _, found := strings.Cut(mapped, "@"); found && local == requested {
+
+	// (#159) The local part of an email-shaped claim binds only when the operator
+	// has asked for it *and* pinned the domains it may come from. This used to be
+	// unconditional, which meant anyone able to choose the local part of their
+	// address — a B2B guest from another tenant, a second verified domain,
+	// self-service alias editing — chose which local account they logged in as, by
+	// setting it to e.g. "root@their.tld".
+	local, domain, isEmail := strings.Cut(mapped, "@")
+	mapping := provider.Config.UserMapping
+	if isEmail && local == requested {
+		switch {
+		case !mapping.StripEmailDomain:
+			return fmt.Errorf("authenticated identity %q (claim %q) does not match requested local user %q; "+
+				"its local part does, but binding on the local part is off by default because it lets the "+
+				"identity provider choose the local account. To allow it, set "+
+				"username_claim_strip_domain: true and allowed_email_domains: [%q] on provider %q",
+				mapped, claimName, requested, domain, provider.Config.Name)
+		case len(mapping.AllowedEmailDomains) == 0:
+			return fmt.Errorf("provider %q sets username_claim_strip_domain but no allowed_email_domains; "+
+				"refusing to bind %q to local user %q, since an unpinned domain lets any federated or guest "+
+				"identity claim any local account", provider.Config.Name, mapped, requested)
+		case !domainIsAllowed(domain, mapping.AllowedEmailDomains):
+			return fmt.Errorf("authenticated identity %q is from domain %q, which is not in "+
+				"allowed_email_domains for provider %q; refusing to bind it to local user %q",
+				mapped, domain, provider.Config.Name, requested)
+		default:
+			return nil
+		}
+	}
+
+	return fmt.Errorf("authenticated identity %q (claim %q) does not match requested local user %q", mapped, claimName, requested)
+}
+
+// domainIsAllowed reports whether domain is pinned in allowed. Comparison is exact
+// and case-insensitive: no wildcards, because a wildcard on an email domain
+// re-opens exactly what allowed_email_domains exists to close (a subdomain an
+// attacker can get a verified address under).
+func domainIsAllowed(domain string, allowed []string) bool {
+	domain = strings.TrimSpace(strings.ToLower(domain))
+	if domain == "" {
+		return false
+	}
+	for _, a := range allowed {
+		if domain == strings.TrimSpace(strings.ToLower(a)) {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrPrivilegedAccount is returned when an OIDC identity is refused because the
+// local account it would bind to is privileged, rather than because the identity
+// did not match. The two are audited under different error codes: the identity in
+// the privileged case matched perfectly, and reporting it as a mismatch would send
+// an operator looking for a claim problem that is not there.
+var ErrPrivilegedAccount = errors.New("local account is privileged")
+
+// PrivilegedUIDThreshold is the uid below which a local account is treated as
+// privileged and is not bindable by an OIDC identity unless explicitly allowed.
+// 1000 is the first non-system uid on every distribution this project targets
+// (Debian/Ubuntu, RHEL/Fedora, SUSE, Arch).
+const PrivilegedUIDThreshold = 1000
+
+// verifyLocalAccountIsBindable refuses to bind an OIDC identity to a privileged
+// local account: uid 0, or any uid below PrivilegedUIDThreshold, unless the account
+// is named in authentication.allow_privileged_accounts.
+//
+// (#159) This is the check that holds when the others are misconfigured. Identity
+// binding depends on username_claim being set correctly, on the provider not letting
+// the user edit that claim, and on allowed_email_domains being pinned — three things
+// the operator can get wrong. Whether "root" is a legitimate destination for a
+// federated login does not depend on any of them.
+//
+// An account that does not exist locally is not refused here: there is no privilege
+// to escalate to, and the login cannot succeed anyway. "root" is refused by name
+// even if the lookup fails, since that is the case worth being sure about.
+func (b *Broker) verifyLocalAccountIsBindable(requested string) error {
+	if b.config != nil {
+		for _, allowed := range b.config.Authentication.AllowPrivilegedAccounts {
+			if strings.EqualFold(strings.TrimSpace(allowed), requested) {
+				log.Warn().
+					Str("local_user", requested).
+					Msg("Binding an OIDC identity to a privileged local account, permitted by authentication.allow_privileged_accounts")
+				return nil
+			}
+		}
+	}
+
+	if requested == "root" {
+		return fmt.Errorf("refusing to bind an OIDC identity to local user %q: it is uid 0. "+
+			"Log in as an unprivileged account and escalate, or add it to "+
+			"authentication.allow_privileged_accounts to override: %w", requested, ErrPrivilegedAccount)
+	}
+
+	lookup := b.lookupLocalUID
+	if lookup == nil {
+		lookup = lookupLocalUID
+	}
+	uid, exists, err := lookup(requested)
+	if err != nil {
+		// Neither "it exists and is privileged" nor "it does not exist": we could not
+		// tell. Do not silently allow a check we did not perform.
+		return fmt.Errorf("could not determine whether local user %q is privileged: %w", requested, err)
+	}
+	if !exists {
 		return nil
 	}
-	return fmt.Errorf("authenticated identity %q (claim %q) does not match requested local user %q", mapped, claimName, requested)
+	if uid < PrivilegedUIDThreshold {
+		return fmt.Errorf("refusing to bind an OIDC identity to local user %q: it is a system account "+
+			"(uid %d < %d). Add it to authentication.allow_privileged_accounts to override: %w",
+			requested, uid, PrivilegedUIDThreshold, ErrPrivilegedAccount)
+	}
+	return nil
+}
+
+// lookupLocalUID resolves a local account name to its numeric uid. The second
+// return value is false when there is no such account, which is not an error.
+func lookupLocalUID(name string) (int, bool, error) {
+	u, err := user.Lookup(name)
+	if err != nil {
+		var unknown user.UnknownUserError
+		if errors.As(err, &unknown) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, false, fmt.Errorf("local user %q has a non-numeric uid %q: %w", name, u.Uid, err)
+	}
+	return uid, true, nil
 }
 
 // claimToUsername extracts a string username from the resolved claims using the

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -1495,6 +1495,14 @@ func (b *Broker) verifyLocalAccountIsBindable(requested string) error {
 		return fmt.Errorf("could not determine whether local user %q is privileged: %w", requested, err)
 	}
 	if !exists {
+		// Logged because "no such account here" and "account exists and is
+		// unprivileged" reach the same conclusion by different routes, and the first
+		// one means the guard did not really run. If the broker's passwd view differs
+		// from the authenticating host's — a container, a chroot, an sssd domain the
+		// broker cannot see — every account looks unprivileged.
+		log.Debug().
+			Str("local_user", requested).
+			Msg("Requested account does not exist in the broker's passwd view; privileged-account guard has nothing to check")
 		return nil
 	}
 	if uid < PrivilegedUIDThreshold {

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -122,6 +122,11 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir),
 		stopChan:              make(chan struct{}),
 		pollIntervalUnit:      testPollUnit,
+		// A fixed passwd table, so the privileged-account guard (#159) behaves the
+		// same wherever the suite runs. Reading the host's real passwd would make
+		// these tests depend on whether it happens to have a "testuser" and what uid
+		// it gave them.
+		lookupLocalUID: testLookupUID,
 	}
 
 	// A real StartDeviceFlow, so the device code and nonce the token endpoint
@@ -732,5 +737,71 @@ authentication:
 	}
 	if event := env.auditEvent(t, "authentication_denied"); event.ErrorCode != "GROUP_DENIED" {
 		t.Errorf("denial recorded with error_code %q, want GROUP_DENIED", event.ErrorCode)
+	}
+}
+
+// TestPrivilegedAccountRefusedOnTheRealPath drives #159 through the whole device
+// flow, not just the binding function: a completed, approved authorization whose
+// identity exactly matches a privileged local account must still be refused, leave
+// no session, install no key, and be audited as PRIVILEGED_ACCOUNT_DENIED rather
+// than as an identity mismatch.
+//
+// The unit tests call verifyIdentityBinding directly. This one proves the poll loop
+// reaches it and acts on what it returns, which is where #120 showed the wiring can
+// be wrong even when the check is right.
+func TestPrivilegedAccountRefusedOnTheRealPath(t *testing.T) {
+	// uid 400 in testPasswd. Nothing about this identity is wrong except the
+	// account it wants to be: the claim matches exactly.
+	const account = "deploy"
+
+	env := newPollTestEnv(t)
+	env.session.UserID = account
+	env.idp.SetClaims(map[string]any{
+		"sub":                "sub-deploy",
+		"preferred_username": account,
+		"email":              account + "@example.org",
+		"groups":             []string{"researchers"},
+	})
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("an OIDC login was activated for privileged account %q: %+v", account, session)
+	}
+
+	event := env.auditEvent(t, "authentication_denied")
+	if event.ErrorCode != "PRIVILEGED_ACCOUNT_DENIED" {
+		t.Errorf("denial recorded with error_code %q, want PRIVILEGED_ACCOUNT_DENIED "+
+			"(the identity matched; the account is what was refused)", event.ErrorCode)
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("a login to a privileged local account was recorded as successful (#159)")
+		}
+	}
+
+	authorizedKeys := filepath.Join(env.homeDir, account, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a refused privileged login installed a login key:\n%s", data)
+	}
+
+	// And with the account explicitly allowed, the same flow succeeds — the guard is
+	// an override, not a wall.
+	allowed := newPollTestEnv(t)
+	allowed.session.UserID = account
+	allowed.broker.config.Authentication.AllowPrivilegedAccounts = []string{account}
+	allowed.idp.SetClaims(map[string]any{
+		"sub":                "sub-deploy",
+		"preferred_username": account,
+		"email":              account + "@example.org",
+		"groups":             []string{"researchers"},
+	})
+	allowed.idp.Script(testoidc.Grant)
+
+	allowed.run(t)
+
+	if session := allowed.activeSession(); session == nil {
+		t.Error("allow_privileged_accounts did not permit the login it names")
 	}
 }

--- a/pkg/auth/identity_binding_test.go
+++ b/pkg/auth/identity_binding_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
@@ -15,63 +17,142 @@ func providerWithClaim(claim string) *OIDCProvider {
 	}
 }
 
+// providerWithMapping builds a provider with a full user mapping, for the cases
+// that turn on username_claim_strip_domain / allowed_email_domains.
+func providerWithMapping(claim string, strip bool, domains ...string) *OIDCProvider {
+	return &OIDCProvider{
+		Config: config.OIDCProvider{
+			Name: "test",
+			UserMapping: config.UserMapping{
+				UsernameClaim:       claim,
+				StripEmailDomain:    strip,
+				AllowedEmailDomains: domains,
+			},
+		},
+	}
+}
+
+// testPasswd is the local passwd table the identity-binding tests run against.
+// Injected rather than read from the host so that a uid the suite depends on is
+// not whatever the machine running it happens to assign.
+var testPasswd = map[string]int{
+	"root":     0,
+	"daemon":   1,
+	"bin":      2,
+	"nobody":   65534,
+	"alice":    1001,
+	"testuser": 1500,
+	"bob":      1002,
+	"deploy":   400,
+	"builder":  999,
+}
+
+func testLookupUID(name string) (int, bool, error) {
+	uid, ok := testPasswd[name]
+	return uid, ok, nil
+}
+
+// brokerForBinding returns a broker whose privileged-account guard reads
+// testPasswd, optionally allowing some privileged accounts by config.
+func brokerForBinding(allowPrivileged ...string) *Broker {
+	return &Broker{
+		config: &config.Config{
+			Authentication: config.AuthenticationConfig{
+				AllowPrivilegedAccounts: allowPrivileged,
+			},
+		},
+		lookupLocalUID: testLookupUID,
+	}
+}
+
 // TestVerifyIdentityBinding covers the C-1 fix: an authenticated OIDC identity
 // must map to the requested local username, and the check must fail closed.
 func TestVerifyIdentityBinding(t *testing.T) {
-	b := &Broker{config: &config.Config{}}
+	b := brokerForBinding()
 
 	tests := []struct {
 		name      string
-		claim     string
+		provider  *OIDCProvider
 		userInfo  *UserInfo
 		requested string
 		wantErr   bool
 	}{
 		{
 			name:      "preferred_username matches",
-			claim:     "preferred_username",
+			provider:  providerWithClaim("preferred_username"),
 			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}},
 			requested: "alice",
 			wantErr:   false,
 		},
 		{
-			name:      "email local-part matches requested user",
-			claim:     "email",
+			// (#159) This case used to pass with no opt-in at all, and asserting that
+			// it did is what made the local-part branch look intentional.
+			name:      "email local-part does NOT match by default",
+			provider:  providerWithClaim("email"),
+			userInfo:  &UserInfo{Email: "alice@example.com", Claims: map[string]interface{}{"email": "alice@example.com"}},
+			requested: "alice",
+			wantErr:   true,
+		},
+		{
+			name:      "email local-part matches when opted in and the domain is pinned",
+			provider:  providerWithMapping("email", true, "example.com"),
 			userInfo:  &UserInfo{Email: "alice@example.com", Claims: map[string]interface{}{"email": "alice@example.com"}},
 			requested: "alice",
 			wantErr:   false,
 		},
 		{
+			name:      "local-part opt-in without pinned domains is refused",
+			provider:  providerWithMapping("email", true),
+			userInfo:  &UserInfo{Email: "alice@example.com", Claims: map[string]interface{}{"email": "alice@example.com"}},
+			requested: "alice",
+			wantErr:   true,
+		},
+		{
+			// The guest/B2B case: a different tenant's alice is not this host's alice.
+			name:      "local-part from an unpinned domain is refused",
+			provider:  providerWithMapping("email", true, "example.com"),
+			userInfo:  &UserInfo{Email: "alice@partner.com", Claims: map[string]interface{}{"email": "alice@partner.com"}},
+			requested: "alice",
+			wantErr:   true,
+		},
+		{
+			name:      "pinned domain comparison is case-insensitive",
+			provider:  providerWithMapping("email", true, "Example.COM"),
+			userInfo:  &UserInfo{Email: "Alice@EXAMPLE.com", Claims: map[string]interface{}{"email": "Alice@EXAMPLE.com"}},
+			requested: "alice",
+			wantErr:   false,
+		},
+		{
 			name:      "case-insensitive match",
-			claim:     "preferred_username",
+			provider:  providerWithClaim("preferred_username"),
 			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "Alice"}},
 			requested: "alice",
 			wantErr:   false,
 		},
 		{
 			name:      "mismatch is rejected (impersonation attempt)",
-			claim:     "preferred_username",
+			provider:  providerWithClaim("preferred_username"),
 			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "attacker"}},
-			requested: "root",
+			requested: "bob",
 			wantErr:   true,
 		},
 		{
 			name:      "missing claim configured fails closed",
-			claim:     "",
+			provider:  providerWithClaim(""),
 			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}},
 			requested: "alice",
 			wantErr:   true,
 		},
 		{
 			name:      "claim absent in token fails closed",
-			claim:     "preferred_username",
+			provider:  providerWithClaim("preferred_username"),
 			userInfo:  &UserInfo{Claims: map[string]interface{}{"email": "alice@example.com"}},
 			requested: "alice",
 			wantErr:   true,
 		},
 		{
 			name:      "empty requested user rejected",
-			claim:     "preferred_username",
+			provider:  providerWithClaim("preferred_username"),
 			userInfo:  &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}},
 			requested: "",
 			wantErr:   true,
@@ -80,7 +161,7 @@ func TestVerifyIdentityBinding(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := b.verifyIdentityBinding(providerWithClaim(tc.claim), tc.userInfo, tc.requested)
+			err := b.verifyIdentityBinding(tc.provider, tc.userInfo, tc.requested)
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -88,6 +169,136 @@ func TestVerifyIdentityBinding(t *testing.T) {
 				t.Fatalf("expected nil error, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestRootIsNotBindableViaEmailLocalPart is the headline case of #159: with the
+// local-part branch unconditional, an identity provider that lets a user choose
+// the local part of their address let that user choose to be root.
+//
+// The attack needed nothing but a mail alias: set the address to root@<anything>,
+// run `ssh root@host`, approve the device flow with your own credentials.
+// verifyIdentityBinding returned nil, and `auth sufficient pam_oidc.so`
+// short-circuited the rest of the stack.
+func TestRootIsNotBindableViaEmailLocalPart(t *testing.T) {
+	b := brokerForBinding()
+
+	// Every configuration an operator might plausibly have, including the two that
+	// try hardest to make this work.
+	providers := []struct {
+		name     string
+		provider *OIDCProvider
+	}{
+		{"default (no opt-in)", providerWithClaim("email")},
+		{"strip-domain opt-in, unpinned", providerWithMapping("email", true)},
+		{"strip-domain opt-in, attacker's domain pinned", providerWithMapping("email", true, "evil.tld")},
+		{"preferred_username is a UPN, as on Entra ID", providerWithMapping("preferred_username", true, "evil.tld")},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			claim := p.provider.Config.UserMapping.UsernameClaim
+			userInfo := &UserInfo{
+				Email:  "root@evil.tld",
+				Claims: map[string]interface{}{claim: "root@evil.tld"},
+			}
+			err := b.verifyIdentityBinding(p.provider, userInfo, "root")
+			if err == nil {
+				t.Fatal("root@evil.tld was bound to local root: this is the #159 privilege escalation")
+			}
+			if !strings.Contains(err.Error(), "uid 0") {
+				t.Errorf("refused, but not as a privileged account: %v", err)
+			}
+		})
+	}
+
+	// The same identity claiming a system account is refused for the same reason.
+	for _, account := range []string{"daemon", "bin", "builder", "deploy"} {
+		t.Run("system account "+account, func(t *testing.T) {
+			userInfo := &UserInfo{Claims: map[string]interface{}{"preferred_username": account}}
+			if err := b.verifyIdentityBinding(providerWithClaim("preferred_username"), userInfo, account); err == nil {
+				t.Errorf("an OIDC identity was bound to system account %q (uid %d)", account, testPasswd[account])
+			}
+		})
+	}
+}
+
+// TestPrivilegedAccountGuardIsIndependentOfTheClaim covers the second acceptance
+// criterion of #159: the uid guard holds even when the claim is an exact match and
+// nothing about the mapping is misconfigured. It is the check that survives the
+// operator getting username_claim or allowed_email_domains wrong.
+func TestPrivilegedAccountGuardIsIndependentOfTheClaim(t *testing.T) {
+	// An exact, unambiguous claim — no domain, no stripping, no ambiguity.
+	provider := providerWithClaim("preferred_username")
+	userInfo := &UserInfo{Claims: map[string]interface{}{"preferred_username": "deploy"}}
+
+	if err := brokerForBinding().verifyIdentityBinding(provider, userInfo, "deploy"); err == nil {
+		t.Fatal("uid 400 was bindable on an exact claim match; the guard must not depend on the claim")
+	}
+
+	// And it is overridable, deliberately and by name.
+	if err := brokerForBinding("deploy").verifyIdentityBinding(provider, userInfo, "deploy"); err != nil {
+		t.Fatalf("allow_privileged_accounts: [deploy] did not permit the binding: %v", err)
+	}
+
+	// The override is specific to the account named. Allowing "deploy" does not
+	// allow root.
+	rootInfo := &UserInfo{Claims: map[string]interface{}{"preferred_username": "root"}}
+	if err := brokerForBinding("deploy").verifyIdentityBinding(provider, rootInfo, "root"); err == nil {
+		t.Error("allow_privileged_accounts: [deploy] also permitted root")
+	}
+	if err := brokerForBinding("root").verifyIdentityBinding(provider, rootInfo, "root"); err != nil {
+		t.Errorf("allow_privileged_accounts: [root] did not permit root: %v", err)
+	}
+}
+
+// TestUnprivilegedAndUnknownAccountsStillBind guards against the fix locking out
+// the logins it is not about: ordinary users, and accounts that do not exist
+// locally (where there is no privilege to escalate to and the login cannot succeed
+// anyway).
+func TestUnprivilegedAndUnknownAccountsStillBind(t *testing.T) {
+	b := brokerForBinding()
+	provider := providerWithClaim("preferred_username")
+
+	for _, account := range []string{"alice", "bob", "nobody", "no-such-local-account"} {
+		userInfo := &UserInfo{Claims: map[string]interface{}{"preferred_username": account}}
+		if err := b.verifyIdentityBinding(provider, userInfo, account); err != nil {
+			t.Errorf("binding %q was refused: %v", account, err)
+		}
+	}
+}
+
+// TestPrivilegedGuardFailsClosedOnLookupError: if we cannot tell whether the
+// account is privileged, we have not performed the check, so we do not pass it.
+func TestPrivilegedGuardFailsClosedOnLookupError(t *testing.T) {
+	b := &Broker{
+		config: &config.Config{},
+		lookupLocalUID: func(string) (int, bool, error) {
+			return 0, false, errNoPasswd
+		},
+	}
+	userInfo := &UserInfo{Claims: map[string]interface{}{"preferred_username": "alice"}}
+	if err := b.verifyIdentityBinding(providerWithClaim("preferred_username"), userInfo, "alice"); err == nil {
+		t.Fatal("a passwd lookup failure was treated as 'not privileged'")
+	}
+}
+
+// TestRealLookupResolvesRoot checks the production lookup against the one uid that
+// is 0 on every Unix, so the injected table in the tests above is not the only
+// thing ever exercised.
+func TestRealLookupResolvesRoot(t *testing.T) {
+	uid, exists, err := lookupLocalUID("root")
+	if err != nil {
+		t.Fatalf("lookupLocalUID(root): %v", err)
+	}
+	if !exists || uid != 0 {
+		t.Fatalf("lookupLocalUID(root) = (%d, %v), want (0, true)", uid, exists)
+	}
+
+	// A name that cannot exist must be reported as absent, not as an error: that
+	// distinction is what keeps unknown accounts bindable.
+	if _, exists, err := lookupLocalUID("oidc-pam-no-such-user-159"); err != nil || exists {
+		t.Fatalf("lookup of a nonexistent user = (exists=%v, err=%v), want (false, nil)", exists, err)
 	}
 }
 
@@ -120,3 +331,7 @@ func TestVerifyRequiredGroups(t *testing.T) {
 		})
 	}
 }
+
+// errNoPasswd stands in for a passwd lookup that failed for a reason other than
+// "no such user" — an unreachable LDAP/SSSD backend, most realistically.
+var errNoPasswd = errors.New("passwd backend unavailable")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,15 +66,28 @@ type OIDCProvider struct {
 
 // UserMapping defines how to map OIDC claims to user attributes
 type UserMapping struct {
-	UsernameClaim       string            `mapstructure:"username_claim"`
-	EmailClaim          string            `mapstructure:"email_claim"`
-	NameClaim           string            `mapstructure:"name_claim"`
-	GroupsClaim         string            `mapstructure:"groups_claim"`
-	RolesClaim          string            `mapstructure:"roles_claim"`
-	DepartmentClaim     string            `mapstructure:"department_claim"`
-	OrganizationClaim   string            `mapstructure:"organization_claim"`
-	InstitutionClaim    string            `mapstructure:"institution_claim"`
-	OrcidClaim          string            `mapstructure:"orcid_claim"`
+	UsernameClaim     string `mapstructure:"username_claim"`
+	EmailClaim        string `mapstructure:"email_claim"`
+	NameClaim         string `mapstructure:"name_claim"`
+	GroupsClaim       string `mapstructure:"groups_claim"`
+	RolesClaim        string `mapstructure:"roles_claim"`
+	DepartmentClaim   string `mapstructure:"department_claim"`
+	OrganizationClaim string `mapstructure:"organization_claim"`
+	InstitutionClaim  string `mapstructure:"institution_claim"`
+	OrcidClaim        string `mapstructure:"orcid_claim"`
+	// StripEmailDomain allows the local part of an email-shaped username claim to
+	// bind to a local account: "alice@example.com" may log in as "alice". It is off
+	// by default and requires AllowedEmailDomains to be set, because on its own it
+	// lets anyone who can choose the local part of their address — a guest identity,
+	// a second verified domain, self-service alias editing — pick which local
+	// account they bind to. See Broker.verifyIdentityBinding (#159).
+	StripEmailDomain bool `mapstructure:"username_claim_strip_domain"`
+
+	// AllowedEmailDomains pins the domains whose local part may be stripped. A
+	// claim from any other domain is refused even when StripEmailDomain is set.
+	// Required when StripEmailDomain is set; ignored otherwise.
+	AllowedEmailDomains []string `mapstructure:"allowed_email_domains"`
+
 	UsernameTemplate    string            `mapstructure:"username_template"`
 	DisplayNameTemplate string            `mapstructure:"display_name_template"`
 	GroupPrefix         string            `mapstructure:"group_prefix"`
@@ -122,6 +135,14 @@ type AuthenticationConfig struct {
 	RiskPolicies          []RiskPolicy                    `mapstructure:"risk_policies"`
 	GeoIPDatabasePath     string                          `mapstructure:"geoip_database_path"`
 	LocationHistory       LocationHistoryConfig           `mapstructure:"location_history"`
+
+	// AllowPrivilegedAccounts names the privileged local accounts an OIDC identity
+	// may log in as. By default no identity may bind to uid 0 or to any account with
+	// uid < PrivilegedUIDThreshold, whatever the token says, because that binding is
+	// the highest-value target on the host and every other check in front of it is
+	// operator-configurable. Listing an account here is a deliberate exception.
+	// See Broker.verifyLocalAccountIsBindable (#159).
+	AllowPrivilegedAccounts []string `mapstructure:"allow_privileged_accounts"`
 }
 
 // AuthenticationPolicy defines access control policies
@@ -384,6 +405,12 @@ func loadFromEnvironment(v *viper.Viper) (*Config, error) {
 				ClientID: clientID,
 				Scopes:   []string{"openid", "email", "profile"},
 				UserMapping: UserMapping{
+					// (#159) No StripEmailDomain here, deliberately. Enabling it requires
+					// pinning allowed_email_domains, and an environment-derived config has
+					// no way to know the operator's domain. So an "email" claim must equal
+					// the local account name; if it does not, verifyIdentityBinding refuses
+					// the login and names the two keys to set. That is the fail-closed
+					// direction: the alternative is guessing a domain pin.
 					UsernameClaim: "email",
 					EmailClaim:    "email",
 					NameClaim:     "name",
@@ -492,6 +519,37 @@ func (c *Config) Validate() error {
 		}
 		if !hasOpenID {
 			return fmt.Errorf("provider[%d].scopes must include 'openid'", i)
+		}
+
+		// (#159) Stripping the domain off an email-shaped claim lets the identity
+		// provider decide which local account a login binds to, so the domains it may
+		// come from have to be pinned. Refused here rather than at first login: an
+		// operator who mis-set this should find out when the broker starts, not when
+		// somebody discovers what it admits.
+		m := provider.UserMapping
+		if m.StripEmailDomain && len(m.AllowedEmailDomains) == 0 {
+			return fmt.Errorf("provider[%d] (%s) sets username_claim_strip_domain but no allowed_email_domains; "+
+				"pin the domains whose local part may become a local username", i, provider.Name)
+		}
+		for _, d := range m.AllowedEmailDomains {
+			if strings.TrimSpace(d) == "" {
+				return fmt.Errorf("provider[%d] (%s) has an empty entry in allowed_email_domains", i, provider.Name)
+			}
+			if strings.ContainsAny(d, "*?") {
+				return fmt.Errorf("provider[%d] (%s) allowed_email_domains entry %q contains a wildcard; "+
+					"domains are matched exactly, since a wildcard re-opens the subdomain an attacker can "+
+					"get a verified address under", i, provider.Name, d)
+			}
+			if strings.Contains(d, "@") {
+				return fmt.Errorf("provider[%d] (%s) allowed_email_domains entry %q looks like an address; "+
+					"list the domain part only", i, provider.Name, d)
+			}
+		}
+	}
+
+	for _, account := range c.Authentication.AllowPrivilegedAccounts {
+		if strings.TrimSpace(account) == "" {
+			return fmt.Errorf("authentication.allow_privileged_accounts has an empty entry")
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -806,3 +806,113 @@ func TestDevelopmentModeDetection(t *testing.T) {
 		})
 	}
 }
+
+// TestUserMappingDomainPinValidation covers the config half of #159: an operator
+// who turns on local-part binding without pinning the domains it may come from has
+// re-opened the hole the pin exists to close, and finds out when the broker starts
+// rather than when someone discovers what it admits.
+func TestUserMappingDomainPinValidation(t *testing.T) {
+	withMapping := func(m UserMapping) *Config {
+		return &Config{
+			Server: ServerConfig{SocketPath: "/tmp/test.sock"},
+			OIDC: OIDCConfig{Providers: []OIDCProvider{{
+				Name:        "test",
+				Issuer:      "https://test.example.com",
+				ClientID:    "test-client",
+				Scopes:      []string{"openid"},
+				UserMapping: m,
+			}}},
+			Authentication: AuthenticationConfig{
+				TokenLifetime:         time.Hour,
+				RefreshThreshold:      time.Minute,
+				MaxConcurrentSessions: 5,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mapping UserMapping
+		wantErr string
+	}{
+		{
+			name:    "off by default needs no domains",
+			mapping: UserMapping{UsernameClaim: "email"},
+		},
+		{
+			name:    "opted in with a pinned domain",
+			mapping: UserMapping{UsernameClaim: "email", StripEmailDomain: true, AllowedEmailDomains: []string{"example.com"}},
+		},
+		{
+			name:    "opted in with no domains",
+			mapping: UserMapping{UsernameClaim: "email", StripEmailDomain: true},
+			wantErr: "no allowed_email_domains",
+		},
+		{
+			name:    "wildcard domain refused",
+			mapping: UserMapping{UsernameClaim: "email", StripEmailDomain: true, AllowedEmailDomains: []string{"*.example.com"}},
+			wantErr: "wildcard",
+		},
+		{
+			name:    "an address instead of a domain",
+			mapping: UserMapping{UsernameClaim: "email", StripEmailDomain: true, AllowedEmailDomains: []string{"alice@example.com"}},
+			wantErr: "looks like an address",
+		},
+		{
+			name:    "empty domain entry",
+			mapping: UserMapping{UsernameClaim: "email", StripEmailDomain: true, AllowedEmailDomains: []string{"example.com", "  "}},
+			wantErr: "empty entry",
+		},
+		{
+			// Domains listed without the opt-in are inert, not an error: an operator
+			// staging the pin before flipping the switch is not misconfigured.
+			name:    "domains without the opt-in are allowed",
+			mapping: UserMapping{UsernameClaim: "email", AllowedEmailDomains: []string{"example.com"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := withMapping(tc.mapping).Validate()
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Validate() = nil, want an error mentioning %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("Validate() = %v, want an error mentioning %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestShippedConfigsPinTheirDomains asserts the configs in configs/ satisfy the
+// rule above. They were all written when local-part binding was unconditional, so
+// they are exactly the population at risk of shipping a config that either cannot
+// log anyone in or admits any domain.
+func TestShippedConfigsPinTheirDomains(t *testing.T) {
+	paths, err := filepath.Glob("../../configs/**/*.yaml")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	more, _ := filepath.Glob("../../configs/*.yaml")
+	paths = append(paths, more...)
+	if len(paths) == 0 {
+		t.Skip("no shipped configs found from this working directory")
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		text := string(data)
+		if !strings.Contains(text, "username_claim_strip_domain") {
+			continue
+		}
+		if !strings.Contains(text, "allowed_email_domains") {
+			t.Errorf("%s enables username_claim_strip_domain without allowed_email_domains", path)
+		}
+	}
+}

--- a/test/e2e/Dockerfile.broker
+++ b/test/e2e/Dockerfile.broker
@@ -46,4 +46,17 @@ COPY test/e2e/broker.yaml /etc/oidc-auth/broker.yaml
 # docker-compose.yml mounts as a volume shared with the client container.
 RUN mkdir -p /var/lib/oidc-pam/ssh-keys /var/log/oidc-auth /harness/audit
 
+# The same local accounts the client image has, at the same uids, without home
+# directories (the shared /home volume owns those).
+#
+# The harness splits broker and sshd into two containers to model the IPC trust
+# boundary, but a real deployment runs them on one host with one passwd file, and
+# the broker relies on that: the privileged-account guard (#159) resolves the
+# requested account with getpwnam *in the broker*. If svcacct exists only in the
+# client image, the broker sees an account that does not exist locally, allows the
+# binding, and the case asserting the guard fires passes nothing.
+RUN useradd --no-create-home --shell /usr/sbin/nologin --uid 1001 alice \
+    && useradd --no-create-home --shell /usr/sbin/nologin --uid 1002 bob \
+    && useradd --no-create-home --shell /usr/sbin/nologin --uid 400 svcacct
+
 CMD ["/usr/local/bin/oidc-auth-broker", "--config", "/etc/oidc-auth/broker.yaml", "--log-level", "debug"]

--- a/test/e2e/Dockerfile.client
+++ b/test/e2e/Dockerfile.client
@@ -55,14 +55,20 @@ RUN moddir="$(dirname "$(dpkg -L libpam-modules | grep -m1 '/pam_permit\.so$')")
     && echo "installed pam_oidc.so into ${moddir}"
 
 # Two unprivileged accounts: alice is who the harness logs in as, bob exists so
-# a case can tell "refused" apart from "no such user".
+# a case can tell "refused" apart from "no such user". svcacct is below the
+# privileged-uid threshold, for the case that asserts an OIDC identity cannot
+# bind to a service account (#159).
 #
 # --password '*' leaves the account without a usable password but *not* locked.
 # The obvious '!' marks it locked, and some sshd builds refuse a locked account
 # before PAM is ever consulted — which would make every case pass for the wrong
 # reason.
-RUN useradd --create-home --shell /bin/bash --password '*' alice \
-    && useradd --create-home --shell /bin/bash --password '*' bob \
+#
+# The uids are pinned rather than left to useradd because Dockerfile.broker
+# creates the same three accounts, and the privileged-account guard runs in the
+# broker: the two passwd tables have to agree. See the comment there.
+RUN useradd --create-home --shell /bin/bash --password '*' --uid 1001 alice \
+    && useradd --create-home --shell /bin/bash --password '*' --uid 1002 bob \
     && useradd --create-home --shell /bin/bash --password '*' --uid 400 svcacct
 
 COPY test/e2e/sshd_config.d/oidc-pam.conf /etc/ssh/sshd_config.d/oidc-pam.conf

--- a/test/e2e/Dockerfile.client
+++ b/test/e2e/Dockerfile.client
@@ -62,7 +62,8 @@ RUN moddir="$(dirname "$(dpkg -L libpam-modules | grep -m1 '/pam_permit\.so$')")
 # before PAM is ever consulted — which would make every case pass for the wrong
 # reason.
 RUN useradd --create-home --shell /bin/bash --password '*' alice \
-    && useradd --create-home --shell /bin/bash --password '*' bob
+    && useradd --create-home --shell /bin/bash --password '*' bob \
+    && useradd --create-home --shell /bin/bash --password '*' --uid 400 svcacct
 
 COPY test/e2e/sshd_config.d/oidc-pam.conf /etc/ssh/sshd_config.d/oidc-pam.conf
 COPY test/e2e/pam-sshd /etc/pam.d/sshd

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -65,6 +65,8 @@ recorded — not only on what `ssh` did.
 | `denied_by_provider` | A provider refusal is terminal (RFC 8628) and the login is refused *because of it* — asserted from the module log and audit trail, not the clock. |
 | `identity_mismatch` | **#90.** An ID token for `carol` cannot log in as `alice`, however valid it is. |
 | `group_denied` | **#92.** `require_groups` is enforced. |
+| `privileged_account_refused` | **#159.** An exactly-matching identity still cannot log in as a uid < 1000 account. |
+| `email_local_part_refused` | **#159.** `alice@example.org` does not bind to local `alice` without the domain-pinned opt-in. |
 | `account_stack_denies` | **#122.** The account phase still decides: the auth phase genuinely succeeds here and the login is refused anyway. |
 | `nonroot_ipc_rejected` | The IPC socket is root-only by broker decision, not by file mode. |
 | `broker_down` | No broker → refused at once with `PAM_AUTHINFO_UNAVAIL`, not after the device-flow budget. |

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -368,6 +368,42 @@ case_identity_mismatch() {
     expect_no_oidc_key_for alice
 }
 
+# #159: no OIDC identity binds to a privileged local account. svcacct has uid
+# 400, and the identity here matches it *exactly* — same preferred_username, in
+# the required group, approved by the user. The only thing wrong with this login
+# is the account it wants to be, which is the whole point: this is the check that
+# still holds when username_claim or allowed_email_domains is misconfigured.
+#
+# Deliberately not root: sshd_config.d/oidc-pam.conf sets PermitRootLogin no, so
+# `ssh root@` never reaches PAM and the case would pass without testing anything.
+# A uid < 1000 account that sshd will accept is what exercises the guard.
+case_privileged_account_refused() {
+    reset_state svcacct || return 1
+
+    control approve >/dev/null
+    attempt_login svcacct
+
+    expect_login_refused "svcacct is uid 400, below the privileged threshold"
+    expect_audit PRIVILEGED_ACCOUNT_DENIED
+    expect_no_oidc_key_for svcacct
+}
+
+# #159: the local part of an email-shaped claim does not bind on its own. The
+# identity is alice@example.org and the login is for alice; broker.yaml does not
+# set username_claim_strip_domain, so this is refused. Before #159 the local part
+# matched unconditionally, which is what let root@anything log in as root.
+case_email_local_part_refused() {
+    reset_state alice || return 1
+    control 'identity?username=alice@example.org' >/dev/null
+
+    control approve >/dev/null
+    attempt_login alice
+
+    expect_login_refused "alice@example.org must not bind to local alice without the opt-in"
+    expect_audit IDENTITY_MISMATCH
+    expect_no_oidc_key_for alice
+}
+
 # #92: require_groups is enforced. Same user, same approval, no group.
 case_group_denied() {
     reset_state alice || return 1
@@ -486,13 +522,35 @@ CASES=(
     never_approved
     denied_by_provider
     identity_mismatch
+    privileged_account_refused
+    email_local_part_refused
     group_denied
     account_stack_denies
     nonroot_ipc_rejected
     broker_down
 )
 
+# CASES is ordered deliberately (simplest flow first), so it is written out
+# rather than derived. That means it can fall out of step with the functions
+# actually defined, and a case missing from it is silently never run — which is
+# exactly the kind of gap this harness exists to catch. So check.
+check_cases_are_registered() {
+    local fn name missing=()
+    for fn in $(compgen -A function case_); do
+        name="${fn#case_}"
+        # shellcheck disable=SC2076
+        if [[ ! " ${CASES[*]} " =~ " ${name} " ]]; then
+            missing+=("${name}")
+        fi
+    done
+    if [[ "${#missing[@]}" -ne 0 ]]; then
+        echo "cases.sh: defined but not in CASES, so never run: ${missing[*]}" >&2
+        return 1
+    fi
+}
+
 if [[ "${1:-}" == "--list" ]]; then
+    check_cases_are_registered || exit 2
     printf '%s\n' "${CASES[@]}"
     exit 0
 fi

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -377,6 +377,11 @@ case_identity_mismatch() {
 # Deliberately not root: sshd_config.d/oidc-pam.conf sets PermitRootLogin no, so
 # `ssh root@` never reaches PAM and the case would pass without testing anything.
 # A uid < 1000 account that sshd will accept is what exercises the guard.
+#
+# svcacct has to exist in *both* images at the same uid. The guard resolves the
+# account in the broker, so with the account only in the client image the broker
+# sees no such user, allows the binding, and this case passes the login it is
+# supposed to refuse. Dockerfile.broker creates it for that reason.
 case_privileged_account_refused() {
     reset_state svcacct || return 1
 


### PR DESCRIPTION
Fixes #159. Contains a **breaking configuration change** — see below.

## The bug

`verifyIdentityBinding` accepted the **local part** of an email-shaped claim as a match for the requested local account:

```go
if local, _, found := strings.Cut(mapped, "@"); found && local == requested {
    return nil
}
```

So an OIDC identity of `root@evil.tld` running `ssh root@host`, approving the device flow with its own credentials, was bound and approved. With the shipped `auth sufficient pam_oidc.so` that short-circuits the rest of the auth stack.

Reaching it needed only the ability to choose the local part of one's own address — a mail alias, a second verified domain, a B2B guest identity from another tenant. And the branch was live in **every** shipped configuration: `username_claim: "email"` in four of them, and `preferred_username` — which *is* the UPN on Entra ID — in two more.

The weaker variant needed no provider control at all: guest `alice@partner.example` and employee `alice@example.com` both bound to local `alice`.

## Two independent fixes

Either one stops the escalation on its own, which is the point — the first depends on the operator configuring the mapping correctly, and the second does not.

**1. The whole claim value must equal the requested account.** Local-part matching is opt-in per provider and requires the domains it may come from to be pinned:

```yaml
user_mapping:
  username_claim: "email"
  username_claim_strip_domain: true
  allowed_email_domains: ["example.com"]
```

Enabling the first without the second is a **startup** error, not a first-login error. Domains match exactly — a wildcard would re-open the subdomain an attacker can get a verified address under.

**2. No OIDC identity binds to a privileged account.** uid 0, or any uid < 1000, regardless of the token and regardless of the mapping. This runs *before* the claim comparison, so it holds on an exact match, and it is the check that survives `username_claim` or `allowed_email_domains` being misconfigured — whether `root` is a legitimate destination for a federated login does not depend on the mapping being right. Exceptions are named one at a time:

```yaml
authentication:
  allow_privileged_accounts: ["deploy"]
```

Allowing `deploy` does not allow `root`, and every use is logged.

Refusals of the second kind are audited as `PRIVILEGED_ACCOUNT_DENIED`. The identity *matched*; recording `IDENTITY_MISMATCH` would send an operator looking for a claim problem that is not there.

## ⚠️ Breaking change

**Anyone using an email-shaped `username_claim` must add the two new keys or logins will be refused.** The refusal message names both keys and the domain it saw:

```
authenticated identity "alice@example.com" (claim "email") does not match requested local user
"alice"; its local part does, but binding on the local part is off by default because it lets the
identity provider choose the local account. To allow it, set username_claim_strip_domain: true and
allowed_email_domains: ["example.com"] on provider "primary"
```

The six affected shipped configs are updated with the opt-in and a placeholder domain. The environment-variable-derived config deliberately does **not** enable it — it cannot know the operator's domain, and guessing a domain pin is the wrong direction to fail.

## Tests

The previous suite **asserted the vulnerable behaviour was correct** (`email: alice@example.com` + requested `alice` ⇒ no error), which is why this survived a security audit and the #90 remediation. That case now asserts the refusal and moves under the opt-in.

- `root@evil.tld` tested against all four plausible provider configurations, including the two that try hardest to make it work (`strip_domain` on with the attacker's own domain pinned).
- The uid guard tested on an exact, unambiguous claim match, plus the override, plus that the override is specific to the account named.
- Both driven through the **full device flow**, not just the binding function — #120 showed the wiring can be wrong even when the check is right.
- Fails closed on a passwd lookup error: if we could not tell whether the account is privileged, we did not perform the check, so we do not pass it.
- Config validation: opt-in without domains, wildcards, addresses-instead-of-domains, empty entries. Plus a test asserting the shipped configs satisfy the rule.

Verified as a regression gate in both directions. Removing the uid guard:

```
--- FAIL: TestRootIsNotBindableViaEmailLocalPart/default_(no_opt-in)
--- FAIL: TestRootIsNotBindableViaEmailLocalPart/strip-domain_opt-in,_unpinned
--- FAIL: TestRootIsNotBindableViaEmailLocalPart/strip-domain_opt-in,_attacker's_domain_pinned
```

Restoring the unconditional local-part match:

```
--- FAIL: TestVerifyIdentityBinding/email_local-part_does_NOT_match_by_default
--- FAIL: TestVerifyIdentityBinding/local-part_opt-in_without_pinned_domains_is_refused
--- FAIL: TestVerifyIdentityBinding/local-part_from_an_unpinned_domain_is_refused
```

## e2e

Two cases, plus a harness fix.

`privileged_account_refused` uses a **uid-400 account, not root**: `sshd_config.d/oidc-pam.conf` sets `PermitRootLogin no`, so `ssh root@` never reaches PAM and a root-based case would pass without testing anything. The identity matches `svcacct` exactly, is in the required group, and is approved by the user — the only thing wrong with the login is the account it wants to be.

`email_local_part_refused` logs in as `alice` with an identity of `alice@example.org`, which the e2e `broker.yaml` does not opt in for.

`cases.sh --list` now fails if a defined `case_*` function is missing from the hand-ordered `CASES` array. That array is written out rather than derived (the order is deliberate, simplest flow first), which means it can silently drift — and a case that is never run is exactly the gap this harness exists to catch.

Local: `make fmt`, `go build ./...`, `go vet ./pkg/... ./internal/...`, `go test -race ./pkg/... ./internal/...`, `golangci-lint run ./pkg/... ./internal/...` (0 issues), `shellcheck -S warning` on the harness — all clean.