### PR TITLE
fix(ipc): key the request budget on the account, not on a uid that is always 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **High (#160): one unauthenticated remote client could make a host
+  unloginnable.** The IPC rate limit was documented and named as per-UID, but the
+  UID it was keyed on can only ever be 0 — `verifyPeerCredentials` rejects every
+  peer that is not root — so there was a single bucket for the whole machine and
+  `max_requests_per_minute` was a *host-wide* budget. One PAM login spends about
+  19 requests (one `authenticate` plus a `check_session` per poll), so the shipped
+  budgets of 30–60 covered under three concurrent logins. Opening SSH connections
+  to any syntactically valid username at roughly one per second emptied it, after
+  which every login on the host was refused with `RATE_LIMIT_EXCEEDED` →
+  `PAM_MAXTRIES`, and the shipped stack (`auth sufficient pam_oidc.so` followed by
+  `auth requisite pam_deny.so`) has no password fallback. The bucket refilled at
+  30–60 tokens per minute, so a slow trickle sustained it.
+
+  - The limits are now keyed on the **account a request names**, so one account's
+    traffic cannot spend another's budget. `max_requests_per_minute` is therefore
+    now a per-account figure; the shipped values are unchanged and are generous
+    for one account.
+  - `check_session`, `refresh_session` and `revoke_session` are charged against a
+    separate, larger budget (20× the authenticate budget, one per poll of one
+    login). Sharing one budget meant that exhausting it refused the polls of
+    logins already in flight: the broker permitted the login, chose the polling
+    interval itself, and then denied the login for continuing.
+  - The limiter runs after the request is decoded and validated, since that is
+    when the account is known. As the compensating bound, `maxRequestSize` drops
+    from 1 MiB to 64 KiB — the largest request these validation limits permit is
+    about 40 KiB — so what an unlimited peer can make the broker allocate is
+    8 MiB rather than 128 MiB.
+  - The bucket map is bounded (4096 entries, LRU eviction), because its keys now
+    come from requests. Eviction cannot be turned into a lockout: draining a given
+    account's budget requires naming it, which keeps that bucket the most recently
+    used and so the last evicted.
+  - Administrative reads (`status`, `sessions_list`, `keys_list`) are not charged.
+    They name no account, so they would all share one bucket — the shape of this
+    bug — and an `oidc-admin status` refused during an incident is a real cost
+    where an operator looping the command is not a threat.
+
+  This does not stop an attacker from spending the budget of an account they name
+  deliberately; that needs a second key the client does not choose (`source_ip`,
+  #169) and the pending-flow accounting in #163.
+
+  Coverage: `ratelimit_test.go` drove the limiter with synthetic uids 1000/2000/3000
+  — a state unreachable in production, and the reason a host-wide bucket looked
+  per-user in the tests. It is rewritten around account names, with the attack as
+  a test (400 requests naming 100 accounts, then a login for an unnamed account
+  still succeeds) and one asserting an in-flight login's polls survive an
+  exhausted authenticate budget.
+
 - **High (#159): an identity provider could choose which local account a login
   became, including root.** Identity binding accepted the **local part** of an
   email-shaped claim as a match for the requested account, so `root@evil.tld`

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -138,7 +138,11 @@ security:
     pin_certificates: false
     skip_tls_verify: false
     
-  # Rate limiting
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: 60
     max_concurrent_auths: 10

--- a/configs/production/broker-cloud.yaml
+++ b/configs/production/broker-cloud.yaml
@@ -99,7 +99,11 @@ security:
     pin_certificates: "${TLS_PIN_CERTIFICATES:-false}"
     skip_tls_verify: "${TLS_SKIP_VERIFY:-false}"
   
-  # Rate limiting
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: "${RATE_LIMIT_RPM:-60}"
     max_concurrent_auths: "${RATE_LIMIT_CONCURRENT:-10}"

--- a/configs/production/broker-enterprise.yaml
+++ b/configs/production/broker-enterprise.yaml
@@ -249,7 +249,11 @@ security:
     trusted_ca_bundle: "/etc/ssl/certs/company-ca-bundle.pem"
     skip_tls_verify: false
   
-  # Strict rate limiting
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: 30
     max_concurrent_auths: 5

--- a/configs/production/broker-minimal.yaml
+++ b/configs/production/broker-minimal.yaml
@@ -71,7 +71,11 @@ security:
   # Used directly as the AES-256 key; a passphrase/wrong length is rejected.
   token_encryption_key: "REPLACE-with-output-of-oidc-admin-gen-key"
   
-  # Rate limiting
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: 60
     max_concurrent_auths: 10

--- a/configs/providers/azure-ad.yaml
+++ b/configs/providers/azure-ad.yaml
@@ -105,6 +105,11 @@ security:
     pin_certificates: false
     skip_tls_verify: false
   
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: 60
     max_concurrent_auths: 10

--- a/configs/providers/keycloak.yaml
+++ b/configs/providers/keycloak.yaml
@@ -102,6 +102,11 @@ security:
     pin_certificates: false
     skip_tls_verify: false  # Set to true only for development
   
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: 60
     max_concurrent_auths: 10

--- a/configs/providers/okta.yaml
+++ b/configs/providers/okta.yaml
@@ -105,6 +105,11 @@ security:
     pin_certificates: false
     skip_tls_verify: false
   
+  # Rate limiting. max_requests_per_minute is the budget for *starting* an
+  # authentication, per requested account — not a host-wide total, so traffic for
+  # one account cannot deny logins to another. check_session polls are charged
+  # against a separate budget 20x this size, so a login that has been allowed to
+  # start can always finish polling.
   rate_limiting:
     max_requests_per_minute: 60
     max_concurrent_auths: 10

--- a/internal/ipc/ratelimit.go
+++ b/internal/ipc/ratelimit.go
@@ -8,21 +8,83 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// bucket tracks tokens for a single UID using a token-bucket algorithm.
+// RateClass is which budget a request is charged against.
+//
+// (#160) The two exist because they are driven by different things. A client
+// chooses when to send `authenticate`; the *broker* decides how often a client
+// sends `check_session`, by handing it a polling interval and a device code that
+// is not valid until the user has approved it. Charging both to one budget meant
+// that exhausting it refused the polls of logins already in flight — the login had
+// already been permitted, and was then denied for continuing.
+type RateClass string
+
+const (
+	// ClassAuthenticate is the budget for starting a new authentication.
+	ClassAuthenticate RateClass = "auth"
+
+	// ClassSession is the budget for check_session, refresh_session and
+	// revoke_session: requests about a session that already exists.
+	ClassSession RateClass = "session"
+)
+
+const (
+	// pollsPerAuthentication is how many check_session requests one device-flow
+	// login makes: the C module's DEFAULT_AUTH_TIMEOUT (90 s) divided by its
+	// DEFAULT_POLL_INTERVAL (5 s), rounded up, plus headroom for a client that
+	// polls faster because the provider asked it to.
+	//
+	// The session budget is this multiple of the authenticate budget, so that every
+	// login the authenticate budget admits can also finish polling. That is the
+	// property whose absence is the bug: the budget let a login start and then
+	// refused it partway through.
+	pollsPerAuthentication = 20
+
+	// maxTrackedAccounts bounds the bucket map. The keys are attacker-influenced
+	// (a request names the account it wants to log in as), so the map needs a
+	// ceiling; validateRequest already bounds each key to 32 characters of
+	// [a-z0-9_-].
+	//
+	// When full, the least recently used bucket is evicted. That cannot be turned
+	// into a lockout: to exhaust some account's budget an attacker has to keep
+	// naming that account, which keeps its bucket the *most* recently used, and so
+	// the last one evicted. Cycling through names to avoid eviction hands each name
+	// a fresh budget — which is what per-account budgets do anyway.
+	maxTrackedAccounts = 4096
+
+	// bucketIdleTimeout is how long an unused bucket is kept. A bucket idle for
+	// longer than the time it takes to refill completely carries no information.
+	bucketIdleTimeout = 5 * time.Minute
+)
+
+// bucket tracks tokens for a single (class, account) pair using a token bucket.
 type bucket struct {
 	tokens     float64
 	lastRefill time.Time
 }
 
-// RateLimiter enforces per-UID request rate limits and a global concurrent
+// RateLimiter enforces per-account request rate limits and a global concurrent
 // authentication limit. It is safe for concurrent use.
+//
+// The limits are keyed on the account a request names, not on the peer that sent
+// it. Every peer is root — verifyPeerCredentials rejects anything else — so the
+// peer identifies the PAM stack, which is the same for every login on the host.
+// Keying on it produced one bucket for the whole machine, which meant any one
+// caller could spend every other login's budget (#160).
+//
+// Per-account keying bounds a single account's request rate, and stops one
+// account's traffic from denying another's. It does not stop an attacker from
+// spending the budget of an account they name deliberately; closing that needs a
+// second key the client does not choose (source_ip, #169) and the pending-flow
+// accounting in #163.
 type RateLimiter struct {
-	// Per-UID token bucket parameters
-	maxTokens  float64 // burst size (== MaxRequestsPerMinute)
-	refillRate float64 // tokens per second
+	// Token bucket parameters, per class.
+	maxTokens         float64 // burst size (== MaxRequestsPerMinute)
+	refillRate        float64 // tokens per second
+	sessionMaxTokens  float64
+	sessionRefillRate float64
 
 	mu      sync.Mutex
-	buckets map[uint32]*bucket
+	buckets map[string]*bucket
 
 	// Concurrent auth semaphore
 	maxConcurrentAuths int32
@@ -35,12 +97,20 @@ type RateLimiter struct {
 
 // NewRateLimiter creates a RateLimiter. If maxRequestsPerMinute or
 // maxConcurrentAuths is <= 0, that particular limit is disabled (always
-// allows). A background goroutine evicts stale UID entries every 5 minutes.
+// allows). A background goroutine evicts idle buckets every 5 minutes.
+//
+// maxRequestsPerMinute is the budget for new authentications, per account.
+// Session requests get pollsPerAuthentication times as many, since one
+// authentication is followed by many of them.
 func NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths int) *RateLimiter {
+	sessionPerMinute := float64(maxRequestsPerMinute) * pollsPerAuthentication
+
 	rl := &RateLimiter{
 		maxTokens:          float64(maxRequestsPerMinute),
 		refillRate:         float64(maxRequestsPerMinute) / 60.0,
-		buckets:            make(map[uint32]*bucket),
+		sessionMaxTokens:   sessionPerMinute,
+		sessionRefillRate:  sessionPerMinute / 60.0,
+		buckets:            make(map[string]*bucket),
 		maxConcurrentAuths: int32(maxConcurrentAuths),
 		stopChan:           make(chan struct{}),
 	}
@@ -51,24 +121,37 @@ func NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths int) *RateLimiter {
 	return rl
 }
 
-// AllowRequest consumes one token from the bucket for uid. Returns false if
-// the bucket is empty (rate limit exceeded). If rate limiting is disabled
+// Allow consumes one token from the bucket for (class, account). It returns false
+// if the bucket is empty (rate limit exceeded). If rate limiting is disabled
 // (maxTokens <= 0), it always returns true.
-func (rl *RateLimiter) AllowRequest(uid uint32) bool {
-	if rl.maxTokens <= 0 {
+//
+// An empty account is a valid key: it is the one every request that names no
+// account shares, and there is no reason to exempt it.
+func (rl *RateLimiter) Allow(class RateClass, account string) bool {
+	maxTokens, refillRate := rl.maxTokens, rl.refillRate
+	if class == ClassSession {
+		maxTokens, refillRate = rl.sessionMaxTokens, rl.sessionRefillRate
+	}
+	if maxTokens <= 0 {
 		return true
 	}
 
+	// The class is part of the key, not just of the parameters: an exhausted
+	// authenticate budget must not drain the session budget of the same account.
+	key := string(class) + ":" + account
 	now := time.Now()
 
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	b, ok := rl.buckets[uid]
+	b, ok := rl.buckets[key]
 	if !ok {
-		// First request from this UID — create a full bucket minus one token.
-		rl.buckets[uid] = &bucket{
-			tokens:     rl.maxTokens - 1,
+		if len(rl.buckets) >= maxTrackedAccounts {
+			rl.makeRoom()
+		}
+		// First request for this key — create a full bucket minus one token.
+		rl.buckets[key] = &bucket{
+			tokens:     maxTokens - 1,
 			lastRefill: now,
 		}
 		return true
@@ -76,9 +159,9 @@ func (rl *RateLimiter) AllowRequest(uid uint32) bool {
 
 	// Refill tokens based on elapsed time.
 	elapsed := now.Sub(b.lastRefill).Seconds()
-	b.tokens += elapsed * rl.refillRate
-	if b.tokens > rl.maxTokens {
-		b.tokens = rl.maxTokens
+	b.tokens += elapsed * refillRate
+	if b.tokens > maxTokens {
+		b.tokens = maxTokens
 	}
 	b.lastRefill = now
 
@@ -88,6 +171,28 @@ func (rl *RateLimiter) AllowRequest(uid uint32) bool {
 
 	b.tokens--
 	return true
+}
+
+// makeRoom frees a slot in a full bucket map: idle buckets first, and failing
+// that the least recently used one. Callers hold rl.mu.
+func (rl *RateLimiter) makeRoom() {
+	if rl.evictIdleLocked() > 0 {
+		return
+	}
+
+	var oldestKey string
+	var oldest time.Time
+	for key, b := range rl.buckets {
+		if oldestKey == "" || b.lastRefill.Before(oldest) {
+			oldestKey, oldest = key, b.lastRefill
+		}
+	}
+	if oldestKey != "" {
+		delete(rl.buckets, oldestKey)
+		log.Debug().
+			Int("tracked", len(rl.buckets)).
+			Msg("Rate-limit bucket map full; evicted the least recently used bucket")
+	}
 }
 
 // AcquireAuth attempts to increment the concurrent auth counter. Returns false
@@ -121,12 +226,12 @@ func (rl *RateLimiter) Stop() {
 	rl.wg.Wait()
 }
 
-// cleanupLoop periodically evicts UID buckets that have been idle for more
-// than 5 minutes (fully refilled and unused).
+// cleanupLoop periodically evicts buckets that have been idle for more than
+// bucketIdleTimeout (fully refilled and unused).
 func (rl *RateLimiter) cleanupLoop() {
 	defer rl.wg.Done()
 
-	ticker := time.NewTicker(5 * time.Minute)
+	ticker := time.NewTicker(bucketIdleTimeout)
 	defer ticker.Stop()
 
 	for {
@@ -139,25 +244,31 @@ func (rl *RateLimiter) cleanupLoop() {
 	}
 }
 
-// evictStale removes buckets that have not been used in more than 5 minutes.
+// evictStale removes buckets that have not been used in more than
+// bucketIdleTimeout.
 func (rl *RateLimiter) evictStale() {
-	cutoff := time.Now().Add(-5 * time.Minute)
-
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	before := len(rl.buckets)
-	for uid, b := range rl.buckets {
-		if b.lastRefill.Before(cutoff) {
-			delete(rl.buckets, uid)
-		}
-	}
-	after := len(rl.buckets)
-
-	if evicted := before - after; evicted > 0 {
+	if evicted := rl.evictIdleLocked(); evicted > 0 {
 		log.Debug().
 			Int("evicted", evicted).
-			Int("remaining", after).
-			Msg("Evicted stale rate-limit buckets")
+			Int("remaining", len(rl.buckets)).
+			Msg("Evicted idle rate-limit buckets")
 	}
+}
+
+// evictIdleLocked deletes every bucket idle for longer than bucketIdleTimeout and
+// reports how many went. Callers hold rl.mu.
+func (rl *RateLimiter) evictIdleLocked() int {
+	cutoff := time.Now().Add(-bucketIdleTimeout)
+
+	evicted := 0
+	for key, b := range rl.buckets {
+		if b.lastRefill.Before(cutoff) {
+			delete(rl.buckets, key)
+			evicted++
+		}
+	}
+	return evicted
 }

--- a/internal/ipc/ratelimit_test.go
+++ b/internal/ipc/ratelimit_test.go
@@ -1,87 +1,169 @@
 package ipc
 
 import (
+	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 )
 
-func TestAllowRequest(t *testing.T) {
+// The keys these tests use are account names, because that is what the limiter is
+// keyed on in production. The previous version of this file drove the limiter with
+// synthetic uids 1000/2000/3000 — a state that could not occur, since
+// verifyPeerCredentials rejects every peer whose uid is not 0. The bucket map had
+// exactly one entry on a real host, and the tests could not see it (#160).
+
+// TestOneAccountCannotSpendAnothersBudget is the first acceptance criterion of
+// #160: the attack was an unauthenticated client opening SSH connections to any
+// syntactically valid username until the single host-wide bucket was empty, at
+// which point every login on the machine was refused.
+func TestOneAccountCannotSpendAnothersBudget(t *testing.T) {
+	rl := NewRateLimiter(4, 0)
+	defer rl.Stop()
+
+	// The attacker names one account, or a hundred, and empties what they can.
+	for i := 0; i < 400; i++ {
+		rl.Allow(ClassAuthenticate, fmt.Sprintf("victim%d", i%100))
+	}
+	if rl.Allow(ClassAuthenticate, "victim0") {
+		t.Fatal("victim0's own budget should be spent after 4 requests naming it")
+	}
+
+	// The user who was not named still has their full burst.
+	for i := 0; i < 4; i++ {
+		if !rl.Allow(ClassAuthenticate, "alice") {
+			t.Fatalf("alice's login %d was refused because of traffic for other accounts", i+1)
+		}
+	}
+}
+
+// TestPollsSurviveAnExhaustedAuthenticateBudget is the second acceptance criterion.
+// A login that has already been permitted must be able to finish: the broker itself
+// chose the polling interval, so refusing the polls denies a login it just started.
+func TestPollsSurviveAnExhaustedAuthenticateBudget(t *testing.T) {
+	rl := NewRateLimiter(2, 0)
+	defer rl.Stop()
+
+	if !rl.Allow(ClassAuthenticate, "alice") {
+		t.Fatal("first authenticate refused")
+	}
+	// Empty alice's authenticate budget.
+	for rl.Allow(ClassAuthenticate, "alice") {
+	}
+
+	// The device flow started above still has to complete. One login is
+	// pollsPerAuthentication polls; the budget has to cover at least that.
+	for i := 0; i < pollsPerAuthentication; i++ {
+		if !rl.Allow(ClassSession, "alice") {
+			t.Fatalf("check_session %d/%d refused while the login was in flight", i+1, pollsPerAuthentication)
+		}
+	}
+}
+
+// TestSessionBudgetIsSeparateFromAuthenticate: spending one must not spend the
+// other, in either direction. The class is part of the bucket key for this reason.
+func TestSessionBudgetIsSeparateFromAuthenticate(t *testing.T) {
+	rl := NewRateLimiter(3, 0)
+	defer rl.Stop()
+
+	for rl.Allow(ClassSession, "alice") {
+	}
+	for i := 0; i < 3; i++ {
+		if !rl.Allow(ClassAuthenticate, "alice") {
+			t.Fatalf("authenticate %d refused after the session budget was spent", i+1)
+		}
+	}
+}
+
+func TestAllowBurstThenDeny(t *testing.T) {
 	// 6 requests/minute = 1 token every 10 seconds, burst of 6
 	rl := NewRateLimiter(6, 0)
 	defer rl.Stop()
 
-	uid := uint32(1000)
-
-	// Should allow 6 requests (full burst)
 	for i := 0; i < 6; i++ {
-		if !rl.AllowRequest(uid) {
+		if !rl.Allow(ClassAuthenticate, "alice") {
 			t.Fatalf("request %d should have been allowed", i+1)
 		}
 	}
 
-	// 7th should be denied
-	if rl.AllowRequest(uid) {
+	if rl.Allow(ClassAuthenticate, "alice") {
 		t.Fatal("request should have been denied after burst exhausted")
 	}
 }
 
-func TestAllowRequestRefill(t *testing.T) {
+func TestAllowRefill(t *testing.T) {
 	// 60 requests/minute = 1 token/second
 	rl := NewRateLimiter(60, 0)
 	defer rl.Stop()
 
-	uid := uint32(1000)
-
-	// Exhaust all tokens
 	for i := 0; i < 60; i++ {
-		rl.AllowRequest(uid)
+		rl.Allow(ClassAuthenticate, "alice")
 	}
-	if rl.AllowRequest(uid) {
+	if rl.Allow(ClassAuthenticate, "alice") {
 		t.Fatal("should be denied when exhausted")
 	}
 
 	// Manually advance the bucket's lastRefill to simulate time passing.
 	rl.mu.Lock()
-	b := rl.buckets[uid]
+	b := rl.buckets[string(ClassAuthenticate)+":alice"]
 	b.lastRefill = b.lastRefill.Add(-2 * time.Second)
 	rl.mu.Unlock()
 
 	// Should now have ~2 tokens refilled
-	if !rl.AllowRequest(uid) {
+	if !rl.Allow(ClassAuthenticate, "alice") {
 		t.Fatal("should be allowed after refill")
 	}
 }
 
-func TestAllowRequestPerUID(t *testing.T) {
-	rl := NewRateLimiter(2, 0)
-	defer rl.Stop()
-
-	uid1 := uint32(1000)
-	uid2 := uint32(2000)
-
-	// Exhaust UID 1
-	rl.AllowRequest(uid1)
-	rl.AllowRequest(uid1)
-	if rl.AllowRequest(uid1) {
-		t.Fatal("uid1 should be denied")
-	}
-
-	// UID 2 should still be fine
-	if !rl.AllowRequest(uid2) {
-		t.Fatal("uid2 should be allowed (independent bucket)")
-	}
-}
-
-func TestAllowRequestDisabled(t *testing.T) {
+func TestAllowDisabled(t *testing.T) {
 	rl := NewRateLimiter(0, 0)
 	defer rl.Stop()
 
-	// Should always allow when disabled
+	// Should always allow when disabled, in both classes.
 	for i := 0; i < 100; i++ {
-		if !rl.AllowRequest(uint32(1000)) {
+		if !rl.Allow(ClassAuthenticate, "alice") || !rl.Allow(ClassSession, "alice") {
 			t.Fatal("should always allow when rate limiting is disabled")
 		}
+	}
+}
+
+// TestBucketMapIsBounded: the keys are account names taken from requests, so an
+// attacker naming a new account every time must not grow the map without limit.
+func TestBucketMapIsBounded(t *testing.T) {
+	rl := NewRateLimiter(10, 0)
+	defer rl.Stop()
+
+	for i := 0; i < maxTrackedAccounts+500; i++ {
+		rl.Allow(ClassAuthenticate, fmt.Sprintf("u%d", i))
+	}
+
+	rl.mu.Lock()
+	tracked := len(rl.buckets)
+	rl.mu.Unlock()
+
+	if tracked > maxTrackedAccounts {
+		t.Fatalf("bucket map grew to %d entries, above the %d cap", tracked, maxTrackedAccounts)
+	}
+}
+
+// TestEvictionKeepsTheAccountUnderAttack: filling the map must not be a way to
+// clear the bucket of an account whose budget is being spent, since that would hand
+// the attacker an unlimited budget against a chosen victim. The bucket being drained
+// is the most recently used one, so it is the last to go.
+func TestEvictionKeepsTheAccountUnderAttack(t *testing.T) {
+	rl := NewRateLimiter(4, 0)
+	defer rl.Stop()
+
+	// Spend victim's budget, then flood with distinct names, touching victim as an
+	// attacker would keep doing.
+	for i := 0; i < maxTrackedAccounts*2; i++ {
+		rl.Allow(ClassAuthenticate, fmt.Sprintf("filler%d", i))
+		rl.Allow(ClassAuthenticate, "victim")
+	}
+
+	if rl.Allow(ClassAuthenticate, "victim") {
+		t.Fatal("victim's bucket was evicted by the flood, refilling the attacker's budget")
 	}
 }
 
@@ -158,20 +240,18 @@ func TestRateLimiterCleanup(t *testing.T) {
 	rl := NewRateLimiter(10, 0)
 	defer rl.Stop()
 
-	// Add some entries
-	rl.AllowRequest(1000)
-	rl.AllowRequest(2000)
-	rl.AllowRequest(3000)
+	rl.Allow(ClassAuthenticate, "alice")
+	rl.Allow(ClassAuthenticate, "bob")
+	rl.Allow(ClassSession, "alice")
 
 	// Manually age the buckets
 	rl.mu.Lock()
-	staleTime := time.Now().Add(-10 * time.Minute)
+	staleTime := time.Now().Add(-2 * bucketIdleTimeout)
 	for _, b := range rl.buckets {
 		b.lastRefill = staleTime
 	}
 	rl.mu.Unlock()
 
-	// Run eviction directly
 	rl.evictStale()
 
 	rl.mu.Lock()
@@ -187,38 +267,62 @@ func TestRateLimiterCleanupKeepsFresh(t *testing.T) {
 	rl := NewRateLimiter(10, 0)
 	defer rl.Stop()
 
-	rl.AllowRequest(1000) // fresh
-	rl.AllowRequest(2000) // will be aged
+	rl.Allow(ClassAuthenticate, "alice") // fresh
+	rl.Allow(ClassAuthenticate, "bob")   // will be aged
 
-	// Age only UID 2000
 	rl.mu.Lock()
-	rl.buckets[2000].lastRefill = time.Now().Add(-10 * time.Minute)
+	rl.buckets[string(ClassAuthenticate)+":bob"].lastRefill = time.Now().Add(-2 * bucketIdleTimeout)
 	rl.mu.Unlock()
 
 	rl.evictStale()
 
 	rl.mu.Lock()
-	_, has1000 := rl.buckets[1000]
-	_, has2000 := rl.buckets[2000]
+	_, hasAlice := rl.buckets[string(ClassAuthenticate)+":alice"]
+	_, hasBob := rl.buckets[string(ClassAuthenticate)+":bob"]
 	rl.mu.Unlock()
 
-	if !has1000 {
-		t.Fatal("fresh bucket for UID 1000 should not be evicted")
+	if !hasAlice {
+		t.Fatal("fresh bucket for alice should not be evicted")
 	}
-	if has2000 {
-		t.Fatal("stale bucket for UID 2000 should be evicted")
+	if hasBob {
+		t.Fatal("idle bucket for bob should be evicted")
 	}
 }
 
-func BenchmarkAllowRequest(b *testing.B) {
+// TestRateClassFor pins which request types are charged, and to which budget.
+func TestRateClassFor(t *testing.T) {
+	tests := []struct {
+		requestType string
+		wantClass   RateClass
+		wantLimited bool
+	}{
+		{"authenticate", ClassAuthenticate, true},
+		{"check_session", ClassSession, true},
+		{"refresh_session", ClassSession, true},
+		{"revoke_session", ClassSession, true},
+		{"status", "", false},
+		{"sessions_list", "", false},
+		{"keys_list", "", false},
+		{"nonsense", "", false},
+	}
+	for _, tc := range tests {
+		class, limited := rateClassFor(tc.requestType)
+		if class != tc.wantClass || limited != tc.wantLimited {
+			t.Errorf("rateClassFor(%q) = (%q, %v), want (%q, %v)",
+				tc.requestType, class, limited, tc.wantClass, tc.wantLimited)
+		}
+	}
+}
+
+func BenchmarkAllow(b *testing.B) {
 	rl := NewRateLimiter(10000, 0)
 	defer rl.Stop()
 
 	b.RunParallel(func(pb *testing.PB) {
-		uid := uint32(0)
+		i := 0
 		for pb.Next() {
-			rl.AllowRequest(uid % 100) // spread across 100 UIDs
-			uid++
+			rl.Allow(ClassAuthenticate, fmt.Sprintf("user%d", i%100))
+			i++
 		}
 	})
 }
@@ -234,4 +338,44 @@ func BenchmarkAcquireReleaseAuth(b *testing.B) {
 			}
 		}
 	})
+}
+
+// TestHandleRequestChargesTheAccountNamedInTheRequest checks the wiring: the
+// limiter is consulted with the account from the request, and refusal happens
+// before the request reaches the broker.
+//
+// Only the refusal path is exercised here. The path where the limiter allows the
+// request needs a working broker — auth.NewBroker reaches the provider's discovery
+// endpoint, which this test cannot do — so "bob is unaffected by alice's traffic"
+// and "alice's polls are unaffected" are asserted against the limiter above.
+func TestHandleRequestChargesTheAccountNamedInTheRequest(t *testing.T) {
+	server, err := NewServer(filepath.Join(t.TempDir(), "test.sock"), nil, 0660, "", false, 2, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer server.rateLimiter.Stop()
+
+	// Spend alice's authenticate budget, as two earlier logins would.
+	for server.rateLimiter.Allow(ClassAuthenticate, "alice") {
+	}
+
+	response := authResponse(t, server.handleRequest(&Request{Type: "authenticate", UserID: "alice"}))
+	if response.Success {
+		t.Error("a request over the account's budget was allowed")
+	}
+	if response.ErrorCode != "RATE_LIMIT_EXCEEDED" {
+		t.Errorf("ErrorCode = %q, want RATE_LIMIT_EXCEEDED", response.ErrorCode)
+	}
+
+	// bob's budget was not spent by alice's traffic — the point of the fix. (Had it
+	// been shared, the loop above would have emptied it too.)
+	if !server.rateLimiter.Allow(ClassAuthenticate, "bob") {
+		t.Error("bob's login was refused because of requests naming alice")
+	}
+
+	// Nor was alice's session budget: the polls of the login she just started have
+	// to be able to complete.
+	if !server.rateLimiter.Allow(ClassSession, "alice") {
+		t.Error("alice's check_session was refused after her authenticate budget was spent")
+	}
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -72,7 +72,7 @@ type Response struct {
 }
 
 // NewServer creates a new IPC server. maxRequestsPerMinute and
-// maxConcurrentAuths configure per-UID rate limiting and the global
+// maxConcurrentAuths configure per-account rate limiting and the global
 // concurrent auth cap respectively. Values <= 0 disable that limit.
 func NewServer(socketPath string, broker *auth.Broker, socketMode os.FileMode, socketGroup string, requirePeerAuth bool, maxRequestsPerMinute, maxConcurrentAuths int) (*Server, error) {
 	return &Server{
@@ -250,7 +250,6 @@ func (s *Server) handleConnection(conn net.Conn) {
 	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Verify peer credentials if required
-	var peerUID uint32
 	if s.requirePeerAuth {
 		uid, gid, err := getPeerCredentials(conn)
 		if err != nil {
@@ -268,21 +267,16 @@ func (s *Server) handleConnection(conn net.Conn) {
 			s.sendErrorResponse(conn, "PEER_AUTH_DENIED", "Only root processes are allowed to connect")
 			return
 		}
-		peerUID = uid
 		log.Debug().
 			Uint32("uid", uid).
 			Uint32("gid", gid).
 			Msg("Peer credentials verified")
 	}
 
-	// Apply per-UID rate limiting
-	if !s.rateLimiter.AllowRequest(peerUID) {
-		log.Warn().
-			Uint32("uid", peerUID).
-			Msg("Rate limit exceeded for UID")
-		s.sendErrorResponse(conn, "RATE_LIMIT_EXCEEDED", clientErrorMessage("RATE_LIMIT_EXCEEDED"))
-		return
-	}
+	// Rate limiting happens in handleRequest, once the request has been decoded and
+	// validated: the limits are keyed on the account a request names, which is not
+	// known before then. It used to happen here, keyed on the peer uid — a value
+	// that can only ever be 0, so the whole host shared one bucket (#160).
 
 	log.Debug().
 		Str("remote_addr", conn.RemoteAddr().String()).
@@ -350,6 +344,20 @@ func responseSucceeded(response any) bool {
 // in internal/adminapi: a session listing does not fit into the fields of an
 // authentication response.
 func (s *Server) handleRequest(request *Request) any {
+	if class, limited := rateClassFor(request.Type); limited {
+		if !s.rateLimiter.Allow(class, request.UserID) {
+			log.Warn().
+				Str("request_type", request.Type).
+				Str("user_id", request.UserID).
+				Msg("Rate limit exceeded for account")
+			return &Response{
+				Success:      false,
+				ErrorCode:    "RATE_LIMIT_EXCEEDED",
+				ErrorMessage: clientErrorMessage("RATE_LIMIT_EXCEEDED"),
+			}
+		}
+	}
+
 	switch request.Type {
 	case "authenticate":
 		if !s.rateLimiter.AcquireAuth() {
@@ -383,6 +391,26 @@ func (s *Server) handleRequest(request *Request) any {
 			ErrorCode:    "INVALID_REQUEST_TYPE",
 			ErrorMessage: clientErrorMessage("INVALID_REQUEST_TYPE"),
 		}
+	}
+}
+
+// rateClassFor maps a request type to the budget it is charged against, and
+// reports whether it is charged at all.
+//
+// The administrative reads (status, sessions_list, keys_list) are not: they name no
+// account, so every one of them would share a single bucket, which is the shape of
+// the bug this replaced. They are already bounded by being root-only on a
+// local socket, and an operator running `oidc-admin` in a loop is not a threat
+// model — whereas an operator whose `oidc-admin status` is refused while they are
+// diagnosing an incident is a real cost.
+func rateClassFor(requestType string) (RateClass, bool) {
+	switch requestType {
+	case "authenticate":
+		return ClassAuthenticate, true
+	case "check_session", "refresh_session", "revoke_session":
+		return ClassSession, true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/ipc/validate.go
+++ b/internal/ipc/validate.go
@@ -8,8 +8,17 @@ import (
 )
 
 const (
-	// maxRequestSize is the maximum allowed size for a JSON request (1 MB).
-	maxRequestSize = 1 << 20
+	// maxRequestSize is the maximum allowed size for a JSON request (64 KiB).
+	//
+	// The largest request these limits permit is around 40 KiB: 32 metadata entries
+	// of maxMetadataKeyLen + maxMetadataValueLen, plus the fixed fields. 64 KiB
+	// leaves room for JSON syntax and for a field to grow, and nothing legitimate
+	// comes close.
+	//
+	// It was 1 MiB, which mattered once rate limiting moved to after the decode
+	// (#160): this bound times maxConcurrentConnections is how much a peer can make
+	// the broker allocate before any limit has an opinion. 8 MiB, not 128 MiB.
+	maxRequestSize = 64 << 10
 
 	// maxUserIDLen is the maximum length for a Unix user ID.
 	maxUserIDLen = 32

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -247,8 +247,16 @@ type TLSVerification struct {
 
 // RateLimiting contains rate limiting settings
 type RateLimiting struct {
+	// MaxRequestsPerMinute is the budget for starting an authentication, per
+	// requested account — not a host-wide total. (#160) It was applied per peer
+	// uid, which is always 0 on a socket that only root may use, so a single
+	// bucket governed the whole machine and any caller could spend every login's
+	// budget. Requests about an existing session (check_session and friends) draw
+	// on a separate, larger budget so that a login already in flight can finish.
 	MaxRequestsPerMinute int `mapstructure:"max_requests_per_minute"`
-	MaxConcurrentAuths   int `mapstructure:"max_concurrent_auths"`
+
+	// MaxConcurrentAuths caps authentications in progress at once, host-wide.
+	MaxConcurrentAuths int `mapstructure:"max_concurrent_auths"`
 }
 
 // CloudConfig contains cloud provider integration settings

--- a/test/e2e/broker.yaml
+++ b/test/e2e/broker.yaml
@@ -61,7 +61,14 @@ security:
     # broker trusts exactly this one certificate, and nothing else.
     trusted_ca_bundle: "/etc/oidc-auth/fakeoidc.crt"
   rate_limiting:
-    max_requests_per_minute: 600
+    # Low enough that a case can spend one account's budget and show it does not
+    # touch another's (#160): case_rate_limit_is_per_account sends this many
+    # requests plus one, and asserts the last is refused. The broker is restarted
+    # before every case, so each case starts with a full bucket for every account.
+    #
+    # Production ships 30–60. The figure is per account, so it is not comparable
+    # to the 600 that was here when it was a host-wide budget.
+    max_requests_per_minute: 12
     max_concurrent_auths: 20
 
 audit:

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -498,6 +498,52 @@ case_nonroot_ipc_rejected() {
     expect_no_audit authentication_successful
 }
 
+# #160: the request budget is per account, not per host. It used to be keyed on
+# the peer's uid, which is 0 for every caller on a root-only socket, so one bucket
+# governed the whole machine: an unauthenticated client opening SSH connections to
+# any syntactically valid username emptied it, and every login on the host was then
+# refused with PAM_MAXTRIES — with no password fallback in the shipped stack.
+#
+# The requests here name bob and go straight to the socket, because that is the
+# cheap version of the attack: no SSH, no credentials, nothing but a username.
+#
+# This runs after case_nonroot_ipc_rejected on purpose. It leaves pending device
+# flows behind, and that case asserts the issuer has not been polled at all.
+case_rate_limit_is_per_account() {
+    reset_state alice || return 1
+
+    # Must match max_requests_per_minute in broker.yaml, which is deliberately low
+    # so this case is quick. One request over the budget, so the last is refused —
+    # which is also what makes the assertion below fail loudly rather than quietly
+    # pass if that figure changes.
+    local budget=12
+    local request='{"type":"authenticate","user_id":"bob","login_type":"ssh","target_host":"client"}'
+    local response="" i
+    for ((i = 0; i <= budget; i++)); do
+        response="$(printf '%s' "${request}" | timeout 5 nc -U "${SOCKET}")"
+    done
+
+    if grep -q 'RATE_LIMIT_EXCEEDED' <<<"${response}"; then
+        log "bob's budget is spent after $((budget + 1)) requests naming him"
+    else
+        fail "$((budget + 1)) requests naming bob did not exhaust his budget: ${response:-<nothing>}"
+        return 1
+    fi
+
+    # And alice, who was never named, logs in normally. This is the assertion the
+    # unfixed broker fails: her authenticate drew on the same bucket bob's requests
+    # had just emptied.
+    #
+    # The approval also completes bob's pending flows, which are refused as
+    # IDENTITY_MISMATCH — the identity is alice's — and so write no keys.
+    control approve >/dev/null
+    attempt_login alice
+
+    expect_login_ok || return 1
+    expect_audit authentication_successful
+    expect_oidc_key_for alice
+}
+
 # With no broker there is no opinion to be had: the module must report that it
 # could not reach one (PAM_AUTHINFO_UNAVAIL) and the login must be refused, at
 # once rather than after the device-flow budget.
@@ -532,6 +578,7 @@ CASES=(
     group_denied
     account_stack_denies
     nonroot_ipc_rejected
+    rate_limit_is_per_account
     broker_down
 )
 


### PR DESCRIPTION
Fixes #160.

The IPC rate limit was documented and named as per-UID, but the UID it was keyed on can only ever be `0` — `verifyPeerCredentials` rejects every peer that is not root — so there was a single bucket for the whole machine and `max_requests_per_minute` was a **host-wide** budget. One PAM login spends ~19 requests (one `authenticate` plus a `check_session` per poll), so the shipped budgets of 30–60 covered under three concurrent logins. Opening SSH connections to any syntactically valid username at ~1/s emptied it, after which every login on the host was refused with `RATE_LIMIT_EXCEEDED` → `PAM_MAXTRIES`, and the shipped stack (`auth sufficient pam_oidc.so` then `auth requisite pam_deny.so`) has no password fallback.

## What changed

- **Keyed on the account a request names.** One account's traffic can no longer spend another's budget. `max_requests_per_minute` is now a per-account figure; shipped values are unchanged and are generous for a single account.
- **`check_session`/`refresh_session`/`revoke_session` get their own, larger budget** (20× the authenticate budget — one login's worth of polls). Sharing one budget meant exhausting it refused the polls of logins already in flight: the broker permitted the login, chose the polling interval itself, then denied it for continuing.
- **The limiter runs after decode + validation**, since that is when the account is known. As the compensating bound, `maxRequestSize` drops from 1 MiB to 64 KiB (the largest request the validation limits permit is ~40 KiB), so what an unlimited peer can make the broker allocate is 8 MiB rather than 128 MiB.
- **The bucket map is bounded** (4096, LRU), because its keys now come from requests. Eviction cannot be turned into a lockout: draining a chosen account's budget requires naming it, which keeps that bucket the most recently used and so the last evicted.
- **Administrative reads are not charged.** They name no account, so they would all share one bucket — the shape of this bug — and an `oidc-admin status` refused mid-incident is a real cost where an operator looping the command is not a threat.

Still open, and noted in the code: an attacker can spend the budget of an account they name deliberately. Closing that needs a second key the client does not choose (`source_ip`, #169) and the pending-flow accounting in #163.

## Coverage

`ratelimit_test.go` drove the limiter with synthetic uids 1000/2000/3000 — a state unreachable in production, and the reason a host-wide bucket looked per-user under test. Rewritten around account names, with:

- the attack as a test: 400 requests naming 100 accounts, then a login for an unnamed account still succeeds;
- an in-flight login's polls surviving an exhausted authenticate budget;
- the bucket map staying bounded, and the account under attack not being evicted by a flood.

New e2e case `rate_limit_is_per_account`: spend bob's budget over the socket with `nc` (no SSH, no credentials, just a username — the cheap version of the attack), assert the last request is refused, then alice logs in for real and gets her key. Both new tests were confirmed to fail against a reintroduced single bucket — the e2e case refuses alice in under a second, which is the bug.

Local: `go build`, `go vet`, `go test -race ./pkg/... ./internal/...`, `golangci-lint run` (0 issues), `shellcheck -S warning`, and the full e2e harness at 12/12.