### PR TITLE
fix(ssh): move authorized_keys locks out of user homes and bound acquisition (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **High (#161): any local user could stop session expiry and key revocation for
+  the whole host.** The broker serialized its `authorized_keys` writes on
+  `~/.ssh/authorized_keys.lock` — a path inside the home directory of the very
+  account it was protecting — and took it with a *blocking* `flock(LOCK_EX)`. So
+  `flock ~/.ssh/authorized_keys.lock -c 'sleep infinity'`, which needs no
+  privileges, parked the broker's only cleanup goroutine indefinitely: from then on
+  no session expired, no key was revoked for *any* user, and `Broker.Stop()` — which
+  waits on that goroutine — hung, so `systemctl restart` waited out
+  `TimeoutStopSec` and ended in SIGKILL. A login's `AddPublicKey` blocked the same
+  way, holding the authentication open until sshd's `LoginGraceTime` killed it.
+
+  - The lock moved out of the user's home to `/var/lib/oidc-pam/locks/<user>.lock`
+    (`ssh.DefaultLockDir`), a root-owned 0700 directory. A lock whose only job is
+    to serialize the broker against itself has no business being reachable by the
+    account it protects. The broker refuses to use a lock directory that is a
+    symlink, is not a directory, is group- or world-writable, or is owned by
+    another uid.
+  - Acquisition is now `LOCK_EX|LOCK_NB` with a bounded retry (5 s, 50 ms apart)
+    and returns `ssh.ErrLockUnavailable` instead of waiting. This is what makes the
+    fix durable: no future lock location, and no misconfigured state directory, can
+    park the daemon again. A failed acquisition skips that one user's write — the
+    sweep is best-effort and is retried on the next pass — rather than writing
+    without the lock.
+  - `NewAuthorizedKeysManager` takes the lock directory as a second argument. It is
+    required rather than defaulted, so a caller cannot arrive at a lock directory
+    inside a user's home by omission.
+  - `configs/systemd/oidc-auth-broker.service` adds `/var/lib/oidc-pam` to
+    `ReadWritePaths` (`ProtectSystem=strict` made it read-only) and
+    `scripts/install.sh` creates `ssh-keys/` and `locks/` at 0700.
 - **High (#160): one unauthenticated remote client could make a host
   unloginnable.** The IPC rate limit was documented and named as per-UID, but the
   UID it was keyed on can only ever be 0 — `verifyPeerCredentials` rejects every

--- a/configs/systemd/oidc-auth-broker.service
+++ b/configs/systemd/oidc-auth-broker.service
@@ -21,7 +21,11 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth
+# /var/lib/oidc-pam holds the broker's own state: the SSH keys it issues
+# (ssh-keys/) and the per-user locks that serialize its authorized_keys writes
+# (locks/, see #161). ProtectSystem=strict makes /var read-only, so this has to be
+# listed or every key write fails.
+ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam
 CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
 
 # Logging

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -222,7 +222,7 @@ func NewBroker(cfg *config.Config) (*Broker, error) {
 		auditLogger:           auditLogger,
 		sessions:              make(map[string]*Session),
 		keyManager:            sshpkg.NewKeyManager("/var/lib/oidc-pam/ssh-keys"),
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager("/home"),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager("/home", sshpkg.DefaultLockDir),
 		stopChan:              make(chan struct{}),
 	}
 

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -293,7 +293,7 @@ func TestBrokerSSHKeyMethods(t *testing.T) {
 			},
 		},
 		keyManager:            sshpkg.NewKeyManager(keyDir),
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
 	}
 
 	// Use a short key size to keep the test fast.

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -119,7 +119,7 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 		auditLogger:           auditLogger,
 		sessions:              make(map[string]*Session),
 		keyManager:            keyManager,
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
 		stopChan:              make(chan struct{}),
 		pollIntervalUnit:      testPollUnit,
 		// A fixed passwd table, so the privileged-account guard (#159) behaves the

--- a/pkg/auth/key_sweep_test.go
+++ b/pkg/auth/key_sweep_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func newSweepTestBroker(t *testing.T) (*Broker, string) {
 		sessionMutex:          sync.RWMutex{},
 		providers:             map[string]*OIDCProvider{},
 		auditLogger:           auditLogger,
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir),
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
 	}
 
 	return broker, homeDir
@@ -193,6 +194,133 @@ func TestSweepToleratesMissingAuthorizedKeys(t *testing.T) {
 	}
 	if len(broker.ListSessions()) != 0 {
 		t.Errorf("%d sessions survived expiry", len(broker.ListSessions()))
+	}
+}
+
+// holdUsersLock takes the broker's authorized_keys lock for username and holds it
+// until the test ends, standing in for a competing writer.
+//
+// Before #161 this lock lived in the user's own ~/.ssh, so the "competing writer"
+// could be the user: `flock ~/.ssh/authorized_keys.lock -c 'sleep infinity'` and
+// the broker's single cleanup goroutine never ran again.
+func holdUsersLock(t *testing.T, broker *Broker, username string) {
+	t.Helper()
+
+	path := broker.authorizedKeysManager.LockPath(username)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	// flock is held per open file description, so this contends with the broker's
+	// own open of the same path even though both are in this process.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	})
+}
+
+// runExpiryWithin runs the expiry pass and fails the test if it has not finished
+// by limit, rather than letting the package hang until the go test timeout.
+func runExpiryWithin(t *testing.T, limit time.Duration, broker *Broker) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		broker.expireSessions(time.Now())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(limit):
+		t.Fatalf("expireSessions did not finish within %s; the cleanup goroutine is wedged (#161)", limit)
+	}
+}
+
+// The whole of #161: one account holding its own lock must not stop the expiry
+// pass, because there is exactly one cleanup goroutine for the host.
+func TestSweepSurvivesAnUncooperativeLockHolder(t *testing.T) {
+	broker, homeDir := newSweepTestBroker(t)
+	broker.authorizedKeysManager.SetLockTimeout(150 * time.Millisecond)
+
+	alicePath := writeAuthorizedKeys(t, homeDir, "alice",
+		oidcKeyLine(time.Now().Add(-48*time.Hour), "ALICEOLD"))
+	bobPath := writeAuthorizedKeys(t, homeDir, "bob",
+		oidcKeyLine(time.Now().Add(-48*time.Hour), "BOBOLD"))
+
+	holdUsersLock(t, broker, "alice")
+
+	for _, user := range []string{"alice", "bob"} {
+		broker.setSession(&Session{
+			ID:           "sess-" + user,
+			UserID:       user,
+			ExpiresAt:    time.Now().Add(-time.Minute),
+			LastAccessed: time.Now(),
+		})
+	}
+
+	runExpiryWithin(t, 5*time.Second, broker)
+
+	if strings.Contains(readAuthorizedKeys(t, bobPath), "BOBOLD") {
+		t.Error("bob's expired key survived because alice was holding her lock")
+	}
+	// alice's own key is left for a later pass: the sweep is best-effort, and
+	// writing without the lock would be worse than deferring.
+	if !strings.Contains(readAuthorizedKeys(t, alicePath), "ALICEOLD") {
+		t.Error("alice's authorized_keys was rewritten without holding the lock")
+	}
+	// Session expiry is the authoritative revocation and must not be held hostage
+	// to a file write.
+	if n := len(broker.ListSessions()); n != 0 {
+		t.Errorf("%d sessions survived expiry while a lock was held", n)
+	}
+}
+
+// Stop() waits on the cleanup goroutine, so a wedged sweep turned `systemctl
+// restart oidc-auth-broker` into a 90-second wait for SIGKILL.
+//
+// This drives the two statements of Stop() that can block — close(stopChan) then
+// wg.Wait() — around a sweep running under a held lock. It does not call Stop()
+// itself: the rest of Stop() shuts down the token manager and audit logger, which
+// have nothing to do with the lock and need a network-backed broker to construct.
+func TestStopIsNotBlockedByAHeldLock(t *testing.T) {
+	broker, homeDir := newSweepTestBroker(t)
+	broker.authorizedKeysManager.SetLockTimeout(150 * time.Millisecond)
+	broker.stopChan = make(chan struct{})
+
+	writeAuthorizedKeys(t, homeDir, "alice",
+		oidcKeyLine(time.Now().Add(-48*time.Hour), "ALICEOLD"))
+	holdUsersLock(t, broker, "alice")
+
+	broker.setSession(&Session{
+		ID:           "sess-alice",
+		UserID:       "alice",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+		LastAccessed: time.Now(),
+	})
+
+	broker.wg.Add(1)
+	go func() {
+		defer broker.wg.Done()
+		broker.expireSessions(time.Now())
+	}()
+
+	stopped := make(chan struct{})
+	go func() {
+		close(broker.stopChan)
+		broker.wg.Wait()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown did not complete while a user held their lock; Stop() would hang until SIGKILL (#161)")
 	}
 }
 

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,16 +14,59 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// withFileLock acquires an exclusive POSIX file lock on a lockfile adjacent to
-// the authorized_keys file, runs fn, then releases the lock. This serializes
-// concurrent read-then-write operations across processes.
+// DefaultLockDir is where the broker keeps the per-user lock files that serialize
+// its own authorized_keys writes.
 //
-// The lock file is opened with O_NOFOLLOW so a symlink planted at the lock path
-// (in a user-controlled .ssh directory) cannot redirect the open to another
-// file (see ensureSecureSSHDir for the surrounding symlink defenses).
-func withFileLock(lockPath string, fn func() error) error {
-	// #nosec G304 -- lockPath is under the validated .ssh dir; O_NOFOLLOW prevents
-	// following a planted symlink at the lock path.
+// (#161) The locks used to live in the user's own ~/.ssh, where the user could
+// take them: `flock ~/.ssh/authorized_keys.lock -c 'sleep infinity'` blocked the
+// broker's next write to that file forever, because the lock was acquired with a
+// blocking LOCK_EX. One unprivileged local user could therefore wedge the broker's
+// single session-expiry goroutine — after which no session expired, no key was
+// revoked for *any* user on the host, and `systemctl restart` hung on Stop() until
+// SIGKILL.
+//
+// A lock whose only job is to serialize the broker against itself has no business
+// being reachable by the account it is protecting, so it lives in the broker's own
+// state directory.
+const DefaultLockDir = "/var/lib/oidc-pam/locks"
+
+const (
+	// lockAcquireTimeout bounds how long a write waits for the per-user lock.
+	// Nothing outside the broker can hold it now, so reaching this means another
+	// broker instance, or a bug; either way the caller gets an error and the
+	// goroutine keeps running.
+	lockAcquireTimeout = 5 * time.Second
+
+	// lockRetryInterval is how often a blocked writer retries.
+	lockRetryInterval = 50 * time.Millisecond
+)
+
+// ErrLockUnavailable is returned when the per-user lock could not be taken within
+// lockAcquireTimeout. It is a distinct error so a caller can tell "someone else is
+// writing" from "the write failed".
+var ErrLockUnavailable = errors.New("authorized_keys lock unavailable")
+
+// withFileLock acquires an exclusive file lock, runs fn, then releases it. This
+// serializes concurrent read-then-write operations on one user's authorized_keys.
+//
+// The lock is taken non-blocking with a bounded retry, so no lock holder — however
+// it came to hold it — can park the calling goroutine indefinitely. That property
+// is deliberately independent of where the lock file lives: it is what makes a
+// future lock path, or a misconfigured state directory, unable to reintroduce
+// #161.
+//
+// It serializes writers within one host. Two brokers writing the same NFS home
+// from different hosts are not serialized by this, and never reliably were —
+// flock over NFS is advisory at best — which is why every write goes through
+// writeAuthorizedKeysAtomic rather than relying on the lock for integrity.
+func withFileLock(lockPath string, timeout time.Duration, fn func() error) error {
+	if err := ensureLockDir(filepath.Dir(lockPath)); err != nil {
+		return err
+	}
+
+	// #nosec G304 -- lockPath is <lockDir>/<validated username>.lock in a directory
+	// ensureLockDir has just checked is a real, broker-owned, non-group-writable
+	// directory; O_NOFOLLOW prevents following a symlink at the lock path itself.
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open lock file: %w", err)
@@ -32,11 +76,61 @@ func withFileLock(lockPath string, fn func() error) error {
 		_ = lockFile.Close()
 	}()
 
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		return fmt.Errorf("failed to acquire file lock: %w", err)
+	if err := acquireLock(lockFile, lockPath, timeout); err != nil {
+		return err
 	}
 
 	return fn()
+}
+
+// acquireLock takes an exclusive flock, retrying until timeout elapses.
+func acquireLock(lockFile *os.File, lockPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			return fmt.Errorf("failed to acquire file lock %q: %w", lockPath, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: %q was held by another writer for longer than %s",
+				ErrLockUnavailable, lockPath, timeout)
+		}
+		time.Sleep(lockRetryInterval)
+	}
+}
+
+// ensureLockDir creates the lock directory if it is absent and refuses to use one
+// that is not a directory the broker alone controls. A lock in a directory someone
+// else can write to is not a lock: they can plant the lock file, or hold it.
+func ensureLockDir(lockDir string) error {
+	info, err := os.Lstat(lockDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if mkErr := os.MkdirAll(lockDir, 0700); mkErr != nil {
+				return fmt.Errorf("failed to create lock directory %q: %w", lockDir, mkErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to stat lock directory %q: %w", lockDir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to use lock directory %q: it is a symlink", lockDir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("refusing to use lock directory %q: it is not a directory", lockDir)
+	}
+	if info.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("refusing to use lock directory %q: mode %#o is writable by group or other",
+			lockDir, info.Mode().Perm())
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("refusing to use lock directory %q: it is owned by uid %d, not by this process (uid %d)",
+			lockDir, stat.Uid, os.Geteuid())
+	}
+	return nil
 }
 
 // ensureSecureSSHDir verifies that the user's .ssh directory is safe for the
@@ -133,14 +227,42 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
 
 // AuthorizedKeysManager manages authorized_keys files for users
 type AuthorizedKeysManager struct {
-	baseDir string
+	baseDir     string
+	lockDir     string
+	lockTimeout time.Duration
 }
 
-// NewAuthorizedKeysManager creates a new authorized keys manager
-func NewAuthorizedKeysManager(baseDir string) *AuthorizedKeysManager {
+// NewAuthorizedKeysManager creates a new authorized keys manager.
+//
+// baseDir is the parent of the users' home directories (production: /home).
+// lockDir is where the per-user write locks live and must be a directory only the
+// broker can write to — production passes DefaultLockDir. It is a required
+// argument rather than a default with an override because a lock directory the
+// protected user can reach is the whole of #161, and that is not something to
+// arrive at by forgetting to pass an option.
+func NewAuthorizedKeysManager(baseDir, lockDir string) *AuthorizedKeysManager {
 	return &AuthorizedKeysManager{
-		baseDir: baseDir,
+		baseDir:     baseDir,
+		lockDir:     lockDir,
+		lockTimeout: lockAcquireTimeout,
 	}
+}
+
+// LockPath returns the lock file serializing writes to one user's
+// authorized_keys. The username is validated by every caller before use, so it
+// cannot contain a separator or traverse out of lockDir.
+func (akm *AuthorizedKeysManager) LockPath(username string) string {
+	return filepath.Join(akm.lockDir, username+".lock")
+}
+
+// SetLockTimeout overrides how long a write waits for the per-user lock before
+// giving up with ErrLockUnavailable.
+//
+// This exists so tests can exercise the contended path in milliseconds instead of
+// seconds. Call it before the manager is used; it is not safe to change
+// concurrently with a write.
+func (akm *AuthorizedKeysManager) SetLockTimeout(d time.Duration) {
+	akm.lockTimeout = d
 }
 
 // AddPublicKey adds a public key to a user's authorized_keys file
@@ -156,14 +278,14 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
+	lockPath := akm.LockPath(username)
 
 	// Create/verify .ssh directory, rejecting a symlinked .ssh (C-2).
 	if err := ensureSecureSSHDir(sshDir); err != nil {
 		return err
 	}
 
-	return withFileLock(lockPath, func() error {
+	return withFileLock(lockPath, akm.lockTimeout, func() error {
 		// Read existing authorized_keys file
 		var existingKeys []string
 		if data, err := os.ReadFile(authorizedKeysPath); err == nil {
@@ -217,14 +339,14 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
+	lockPath := akm.LockPath(username)
 
 	// Check if .ssh directory exists; if not, nothing to remove
 	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
 		return nil
 	}
 
-	return withFileLock(lockPath, func() error {
+	return withFileLock(lockPath, akm.lockTimeout, func() error {
 		// Read existing authorized_keys file
 		data, err := os.ReadFile(authorizedKeysPath)
 		if err != nil {
@@ -292,14 +414,14 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	lockPath := filepath.Join(sshDir, "authorized_keys.lock")
+	lockPath := akm.LockPath(username)
 
 	// Check if .ssh directory exists; if not, nothing to clean
 	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
 		return nil
 	}
 
-	return withFileLock(lockPath, func() error {
+	return withFileLock(lockPath, akm.lockTimeout, func() error {
 		// Read existing authorized_keys file (O_NOFOLLOW: never follow a symlink — C-2).
 		if err := rejectIfSymlink(authorizedKeysPath); err != nil {
 			return err

--- a/pkg/ssh/authorized_keys_test.go
+++ b/pkg/ssh/authorized_keys_test.go
@@ -10,15 +10,36 @@ import (
 	"time"
 )
 
+// newTestManager builds a manager whose home base is baseDir and whose lock
+// directory is a fresh temp dir.
+//
+// The lock directory is a separate argument in production too (#161): the locks
+// must not be reachable from the homes they protect. A test that pointed lockDir
+// at baseDir would still pass while reintroducing exactly the bug, so no test
+// shares the two.
+func newTestManager(t *testing.T, baseDir string) *AuthorizedKeysManager {
+	t.Helper()
+	return NewAuthorizedKeysManager(baseDir, t.TempDir())
+}
+
 func TestNewAuthorizedKeysManager(t *testing.T) {
 	baseDir := "/tmp/test-auth-keys"
-	akm := NewAuthorizedKeysManager(baseDir)
+	lockDir := "/tmp/test-auth-locks"
+	akm := NewAuthorizedKeysManager(baseDir, lockDir)
 
 	if akm == nil {
 		t.Fatal("Expected non-nil AuthorizedKeysManager")
 	}
 	if akm.baseDir != baseDir {
 		t.Errorf("Expected baseDir %s, got %s", baseDir, akm.baseDir)
+	}
+	if akm.lockDir != lockDir {
+		t.Errorf("Expected lockDir %s, got %s", lockDir, akm.lockDir)
+	}
+	// The lock must not live under the home directory it protects: a user who can
+	// write there can take the lock and wedge the broker (#161).
+	if got := akm.LockPath("alice"); strings.HasPrefix(got, filepath.Join(baseDir, "alice")) {
+		t.Errorf("lock path %s is inside the user's own home", got)
 	}
 }
 
@@ -30,7 +51,7 @@ func TestAddPublicKey(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	publicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... testuser@example.com")
 
@@ -81,7 +102,7 @@ func TestAddPublicKeyWithExistingFile(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
@@ -128,7 +149,7 @@ func TestRemovePublicKey(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	publicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... testuser@example.com")
 
@@ -165,7 +186,7 @@ func TestRemovePublicKeyNonExistentFile(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	publicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... testuser@example.com")
 
@@ -184,7 +205,7 @@ func TestRemovePublicKeyNotFound(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	existingKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... existing@example.com")
 	nonExistentKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... nonexistent@example.com")
@@ -222,7 +243,7 @@ func TestListOIDCKeys(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
@@ -273,7 +294,7 @@ func TestListOIDCKeysNonExistentFile(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 
 	// List OIDC keys from non-existent file
@@ -295,7 +316,7 @@ func TestBackupAuthorizedKeys(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
@@ -338,7 +359,7 @@ func TestBackupAuthorizedKeysNonExistentFile(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 
 	// Try to backup non-existent file
@@ -356,7 +377,7 @@ func TestRestoreAuthorizedKeys(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
@@ -406,7 +427,7 @@ func TestRestoreAuthorizedKeysNoBackup(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 
 	// Try to restore when no backup exists
@@ -420,7 +441,7 @@ func TestRestoreAuthorizedKeysNoBackup(t *testing.T) {
 }
 
 func TestValidateKeyFormat(t *testing.T) {
-	akm := NewAuthorizedKeysManager("/tmp")
+	akm := newTestManager(t, "/tmp")
 
 	// Test valid keys
 	validKeys := [][]byte{
@@ -462,7 +483,7 @@ func TestRemoveExpiredKeys(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
@@ -529,7 +550,7 @@ func TestAddPublicKeyConcurrent(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 
 	const goroutines = 20
@@ -574,7 +595,7 @@ func TestRemoveExpiredKeysNonExistentFile(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	akm := NewAuthorizedKeysManager(tmpDir)
+	akm := newTestManager(t, tmpDir)
 	username := "testuser"
 
 	// Try to remove expired keys from non-existent file

--- a/pkg/ssh/lock_test.go
+++ b/pkg/ssh/lock_test.go
@@ -1,0 +1,230 @@
+package ssh
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// holdLock takes the manager's lock for username the way a competing writer
+// would, and holds it until the test ends.
+//
+// flock ownership belongs to the open file description, not the process, so a
+// second os.OpenFile here contends with withFileLock exactly as a separate
+// process would — no subprocess needed. Before #161 the equivalent of this in a
+// user's shell (`flock ~/.ssh/authorized_keys.lock -c 'sleep infinity'`) was
+// enough to stop the broker's cleanup goroutine forever.
+func holdLock(t *testing.T, akm *AuthorizedKeysManager, username string) {
+	t.Helper()
+
+	if err := ensureLockDir(akm.lockDir); err != nil {
+		t.Fatalf("ensureLockDir: %v", err)
+	}
+	path := akm.LockPath(username)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("open lock file %s: %v", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock %s: %v", path, err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	})
+}
+
+// seedStaleKey writes a user's authorized_keys with one broker-issued key old
+// enough for RemoveExpiredKeys to want to remove it.
+func seedStaleKey(t *testing.T, baseDir, username string) string {
+	t.Helper()
+
+	sshDir := filepath.Join(baseDir, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(sshDir, "authorized_keys")
+	line := "ssh-rsa AAAAB3NzaC1yc2ESTALE " + username + "@oidc-pam-" +
+		strconv.FormatInt(time.Now().Add(-48*time.Hour).Unix(), 10)
+	if err := os.WriteFile(path, []byte(line+"\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+// runWithin runs fn and returns its error, failing the test if fn has not
+// returned by limit. Without the guard a regression would hang the whole package
+// until `go test` times out ten minutes later with no indication of which call
+// blocked.
+func runWithin(t *testing.T, limit time.Duration, fn func() error) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(limit):
+		t.Fatalf("call did not return within %s while the lock was held; it is blocking on the lock (#161)", limit)
+		return nil
+	}
+}
+
+// The wedge from #161: the cleanup goroutine's write must give up rather than
+// wait forever on a lock someone else holds.
+func TestRemoveExpiredKeysGivesUpWhenTheLockIsHeld(t *testing.T) {
+	base := t.TempDir()
+	akm := NewAuthorizedKeysManager(base, t.TempDir())
+	akm.SetLockTimeout(150 * time.Millisecond)
+
+	path := seedStaleKey(t, base, "alice")
+	holdLock(t, akm, "alice")
+
+	err := runWithin(t, 5*time.Second, func() error { return akm.RemoveExpiredKeys("alice") })
+	if !errors.Is(err, ErrLockUnavailable) {
+		t.Fatalf("expected ErrLockUnavailable, got %v", err)
+	}
+
+	// Failing to take the lock must not mean writing without it: the stale key is
+	// still there, to be removed on the next pass.
+	data, readErr := os.ReadFile(path) // #nosec G304 -- test temp dir
+	if readErr != nil {
+		t.Fatalf("ReadFile: %v", readErr)
+	}
+	if !strings.Contains(string(data), "STALE") {
+		t.Error("authorized_keys was rewritten without holding the lock")
+	}
+}
+
+// The login path has the same property, for a different reason: a hung
+// AddPublicKey holds up the authentication it belongs to, and sshd's
+// LoginGraceTime would kill the connection with no explanation logged.
+func TestAddPublicKeyGivesUpWhenTheLockIsHeld(t *testing.T) {
+	base := t.TempDir()
+	akm := NewAuthorizedKeysManager(base, t.TempDir())
+	akm.SetLockTimeout(150 * time.Millisecond)
+
+	holdLock(t, akm, "alice")
+
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ alice@oidc-pam")
+	err := runWithin(t, 5*time.Second, func() error { return akm.AddPublicKey("alice", key) })
+	if !errors.Is(err, ErrLockUnavailable) {
+		t.Fatalf("expected ErrLockUnavailable, got %v", err)
+	}
+}
+
+// One user's held lock must not affect another user's writes: the locks are
+// per-user precisely so that a single uncooperative account cannot stop cleanup
+// for the whole host.
+func TestOneUsersLockDoesNotBlockAnother(t *testing.T) {
+	base := t.TempDir()
+	akm := NewAuthorizedKeysManager(base, t.TempDir())
+	akm.SetLockTimeout(150 * time.Millisecond)
+
+	bobPath := seedStaleKey(t, base, "bob")
+	seedStaleKey(t, base, "alice")
+	holdLock(t, akm, "alice")
+
+	if err := runWithin(t, 5*time.Second, func() error { return akm.RemoveExpiredKeys("bob") }); err != nil {
+		t.Fatalf("RemoveExpiredKeys(bob): %v", err)
+	}
+
+	data, err := os.ReadFile(bobPath) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "STALE") {
+		t.Error("bob's expired key survived because alice was holding her lock")
+	}
+}
+
+// The other half of the #161 fix: the lock the user could take is gone, because
+// the lock is no longer anywhere the user can write.
+func TestTheLockIsNotInTheUsersHome(t *testing.T) {
+	base := t.TempDir()
+	lockDir := t.TempDir()
+	akm := NewAuthorizedKeysManager(base, lockDir)
+
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ alice@oidc-pam")
+	if err := akm.AddPublicKey("alice", key); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	sshDir := filepath.Join(base, "alice", ".ssh")
+	entries, err := os.ReadDir(sshDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".lock") {
+			t.Errorf("lock file %s is in the user's own .ssh, where the user can hold it", e.Name())
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(lockDir, "alice.lock")); err != nil {
+		t.Errorf("expected the lock in the broker's lock directory: %v", err)
+	}
+}
+
+func TestEnsureLockDirRejectsUnsafeDirectories(t *testing.T) {
+	t.Run("group or world writable", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "locks")
+		if err := os.Mkdir(dir, 0777); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		// Mkdir applies the umask, so set the mode explicitly.
+		if err := os.Chmod(dir, 0777); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		err := ensureLockDir(dir)
+		if err == nil || !strings.Contains(err.Error(), "writable by group or other") {
+			t.Fatalf("expected a refusal for a world-writable lock dir, got %v", err)
+		}
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		tmp := t.TempDir()
+		target := filepath.Join(tmp, "real")
+		if err := os.Mkdir(target, 0700); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		link := filepath.Join(tmp, "locks")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		err := ensureLockDir(link)
+		if err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("expected a refusal for a symlinked lock dir, got %v", err)
+		}
+	})
+
+	t.Run("not a directory", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "locks")
+		if err := os.WriteFile(path, nil, 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		err := ensureLockDir(path)
+		if err == nil || !strings.Contains(err.Error(), "not a directory") {
+			t.Fatalf("expected a refusal for a lock dir that is a file, got %v", err)
+		}
+	})
+
+	t.Run("created when absent", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "nested", "locks")
+		if err := ensureLockDir(dir); err != nil {
+			t.Fatalf("ensureLockDir: %v", err)
+		}
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0700 {
+			t.Errorf("lock dir created with mode %#o, want 0700", perm)
+		}
+	})
+}

--- a/pkg/ssh/security_hardening_test.go
+++ b/pkg/ssh/security_hardening_test.go
@@ -30,7 +30,7 @@ func TestAddPublicKeyRejectsSymlinkedAuthorizedKeys(t *testing.T) {
 		t.Fatalf("setup symlink: %v", err)
 	}
 
-	akm := NewAuthorizedKeysManager(base)
+	akm := newTestManager(t, base)
 	err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key"))
 	if err == nil {
 		t.Fatal("expected AddPublicKey to reject symlinked authorized_keys, got nil error")
@@ -63,7 +63,7 @@ func TestAddPublicKeyRejectsSymlinkedSSHDir(t *testing.T) {
 		t.Fatalf("setup symlink: %v", err)
 	}
 
-	akm := NewAuthorizedKeysManager(base)
+	akm := newTestManager(t, base)
 	if err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key")); err == nil {
 		t.Fatal("expected AddPublicKey to reject symlinked .ssh dir, got nil error")
 	}
@@ -74,7 +74,7 @@ func TestAddPublicKeyRejectsSymlinkedSSHDir(t *testing.T) {
 // options) is rejected.
 func TestAddPublicKeyRejectsEmbeddedNewline(t *testing.T) {
 	base := t.TempDir()
-	akm := NewAuthorizedKeysManager(base)
+	akm := newTestManager(t, base)
 	injected := []byte("ssh-ed25519 AAAAreal key\ncommand=\"evil\" ssh-ed25519 AAAAevil key2")
 	if err := akm.AddPublicKey("testuser", injected); err == nil {
 		t.Fatal("expected AddPublicKey to reject embedded newline, got nil error")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,10 @@ PAM_DIR="/lib/security"
 CONFIG_DIR="/etc/oidc-auth"
 RUN_DIR="/var/run/oidc-auth"
 LOG_DIR="/var/log/oidc-auth"
+# The broker's own state: SSH keys it issues, and the per-user locks that
+# serialize its authorized_keys writes. 0700 and root-owned, because a lock a
+# user can take is a lock a user can hold (#161).
+STATE_DIR="/var/lib/oidc-pam"
 SYSTEMD_DIR="/etc/systemd/system"
 
 # Colors for output
@@ -110,7 +114,10 @@ create_directories() {
     
     mkdir -p "$LOG_DIR"
     chmod 755 "$LOG_DIR"
-    
+
+    mkdir -p "$STATE_DIR/ssh-keys" "$STATE_DIR/locks"
+    chmod 700 "$STATE_DIR" "$STATE_DIR/ssh-keys" "$STATE_DIR/locks"
+
     print_info "Directories created"
 }
 

--- a/test/e2e/Dockerfile.broker
+++ b/test/e2e/Dockerfile.broker
@@ -42,9 +42,11 @@ RUN mkdir -p /etc/fakeoidc /etc/oidc-auth \
 COPY --from=builder /out/oidc-auth-broker /out/oidc-admin /out/fakeoidc /usr/local/bin/
 COPY test/e2e/broker.yaml /etc/oidc-auth/broker.yaml
 
-# The broker writes SSH keys here and audit records to /harness/audit, which
-# docker-compose.yml mounts as a volume shared with the client container.
-RUN mkdir -p /var/lib/oidc-pam/ssh-keys /var/log/oidc-auth /harness/audit
+# The broker writes SSH keys and its authorized_keys write locks here (locks/ is
+# root-owned and unreachable from the client container, which is the point of
+# #161), and audit records to /harness/audit, which docker-compose.yml mounts as a
+# volume shared with the client container.
+RUN mkdir -p /var/lib/oidc-pam/ssh-keys /var/lib/oidc-pam/locks /var/log/oidc-auth /harness/audit
 
 # The same local accounts the client image has, at the same uids, without home
 # directories (the shared /home volume owns those).

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -544,6 +544,77 @@ case_rate_limit_is_per_account() {
     expect_oidc_key_for alice
 }
 
+# #161: a user holding a lock in their own home must not affect the broker.
+#
+# The broker used to serialize its authorized_keys writes on
+# ~/.ssh/authorized_keys.lock — a path inside the home of the account it was
+# protecting — with a blocking flock. So `flock ~/.ssh/authorized_keys.lock -c
+# 'sleep infinity'`, which any user can run, blocked the broker's next write to
+# that file forever: the login below never finished, and worse, the broker's single
+# cleanup goroutine stopped expiring sessions and revoking keys for every account
+# on the host.
+#
+# The lock now lives in /var/lib/oidc-pam/locks inside the broker, which the user
+# cannot reach, and every acquisition is bounded. So the file alice holds here is
+# just a file, and her login is ordinary.
+#
+# The client and broker containers share /home, so alice's flock here really does
+# contend with anything the broker takes on the same path — which is what makes
+# this a regression test rather than a demonstration.
+case_home_lock_does_not_block_login() {
+    reset_state alice || return 1
+
+    if ! command -v flock >/dev/null; then
+        fail "flock is not installed in the client image; this case cannot hold a lock"
+        return 1
+    fi
+
+    # On a real host a user owns their own ~/.ssh, and that ownership is exactly
+    # what made the old lock path reachable. Assert it here rather than assume it:
+    # if an earlier case already logged alice in, the broker created ~/.ssh as root
+    # (a separate problem, #171), alice could not create the lock file at all, and
+    # this case would quietly hold nothing.
+    install -d -o alice -g alice -m 700 /home/alice/.ssh || {
+        fail "could not give alice ownership of her own .ssh"
+        return 1
+    }
+
+    # `exec sleep` so the process that ends up holding fd 9 — and therefore the
+    # lock — is the one whose pid lands in the file, which is what makes the
+    # cleanup below able to release it. A flock started as `flock -c "sleep ..."`
+    # passes the fd to a child, so killing flock would not release anything.
+    local pidfile=/tmp/home-lock-holder.pid
+    rm -f "${pidfile}"
+    su alice -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh \
+        && exec 9>~/.ssh/authorized_keys.lock && flock -x 9 \
+        && echo \$\$ >${pidfile} && exec sleep 120" &
+    # shellcheck disable=SC2064
+    trap "[[ -f ${pidfile} ]] && kill \$(cat ${pidfile}) 2>/dev/null; rm -f ${pidfile}" RETURN
+
+    local deadline=$((SECONDS + 15))
+    while [[ ! -s "${pidfile}" && "${SECONDS}" -lt "${deadline}" ]]; do sleep 1; done
+
+    # Confirm the lock is really held: a case that silently failed to take it would
+    # pass while proving nothing, which is the failure mode this harness keeps
+    # finding.
+    if flock -n -x /home/alice/.ssh/authorized_keys.lock -c true 2>/dev/null; then
+        fail "alice's lock is not held; this case would pass without testing anything"
+        return 1
+    fi
+    log "alice is holding /home/alice/.ssh/authorized_keys.lock (pid $(cat "${pidfile}"))"
+
+    control approve >/dev/null
+    attempt_login alice
+
+    # A successful login is the whole assertion. Against the old code the broker
+    # blocked inside AddPublicKey before it could mark the session active, so the
+    # module polled until its own timeout and the login was refused — a lock in
+    # alice's home denied alice her own login, and everyone else's cleanup.
+    expect_login_ok || return 1
+    expect_audit authentication_successful
+    expect_oidc_key_for alice
+}
+
 # With no broker there is no opinion to be had: the module must report that it
 # could not reach one (PAM_AUTHINFO_UNAVAIL) and the login must be refused, at
 # once rather than after the device-flow budget.
@@ -579,6 +650,7 @@ CASES=(
     account_stack_denies
     nonroot_ipc_rejected
     rate_limit_is_per_account
+    home_lock_does_not_block_login
     broker_down
 )
 


### PR DESCRIPTION
Fixes #161.

## The defect

`withFileLock` took a **blocking** `flock(LOCK_EX)` on `~/.ssh/authorized_keys.lock` — a path inside the home directory of the account it was protecting. So `flock ~/.ssh/authorized_keys.lock -c 'sleep infinity'`, which needs no privileges, parked the broker's only cleanup goroutine forever:

- no session expired and no key was revoked, **for any user on the host**;
- `Broker.Stop()` waits on that goroutine, so `systemctl restart` waited out `TimeoutStopSec` and ended in SIGKILL;
- a login's `AddPublicKey` blocked the same way, holding the authentication open until sshd's `LoginGraceTime` killed it.

## The fix

- Locks move to `/var/lib/oidc-pam/locks/<user>.lock` (`ssh.DefaultLockDir`), root-owned 0700. A lock whose only job is to serialize the broker against itself has no business being reachable by the account it protects.
- `ensureLockDir` refuses a lock directory that is a symlink, is not a directory, is group- or world-writable, or is owned by another uid.
- Acquisition is `LOCK_EX|LOCK_NB` with a bounded retry (5 s, 50 ms apart), returning `ssh.ErrLockUnavailable`. This is the part that makes the fix durable — no future lock location and no misconfigured state directory can park the daemon again. A failed acquisition skips that one user's write (the sweep is best-effort and retries) rather than writing without the lock.
- `NewAuthorizedKeysManager(baseDir, lockDir)` — the lock directory is required, not defaulted, so no caller can end up with a lock inside a user's home by omission.
- `configs/systemd/oidc-auth-broker.service` adds `/var/lib/oidc-pam` to `ReadWritePaths` (`ProtectSystem=strict` had made it read-only, which would have failed every key write), and `scripts/install.sh` creates `ssh-keys/` and `locks/` at 0700.

## Verification

Every test below was run against the restored defect first and fails there:

| test | against the defect |
| --- | --- |
| `TestRemoveExpiredKeysGivesUpWhenTheLockIsHeld` | hangs → fails at the 5 s guard |
| `TestAddPublicKeyGivesUpWhenTheLockIsHeld` | hangs → fails at the 5 s guard |
| `TestTheLockIsNotInTheUsersHome` | finds `authorized_keys.lock` in `~/.ssh` |
| `TestSweepSurvivesAnUncooperativeLockHolder` | `expireSessions` never finishes |
| `TestStopIsNotBlockedByAHeldLock` | shutdown never completes |
| e2e `home_lock_does_not_block_login` | alice's login refused, `exit 255` |

Also: `ensureLockDir` rejection cases (symlink, non-directory, group/world-writable, created-when-absent), and `TestOneUsersLockDoesNotBlockAnother`.

`go build ./...`, `go vet`, `golangci-lint run` (0 issues), `go test -race ./pkg/... ./internal/...` all green; full e2e suite **13/13**.

The e2e case needed one fidelity fix worth noting: it must `install -d -o alice` her own `~/.ssh` first. If an earlier case has already logged alice in, the broker created that directory as root, alice could not have created the lock file at all, and the case would have held nothing while passing — which is how it behaved on the first full-suite run.