### PR TITLE
fix(pam): bound the broker response to the module's buffer (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without testing anything), and `alice@example.org` refused for local `alice`.
 
 ### Fixed
+- **High (#162): a verification URL longer than about 100 characters made every
+  login on the host fail, with nothing to go on but "Failed to parse broker
+  response".** The module read a broker response into an 8 KiB buffer, and the
+  verification URI reached it three times over: as `device_url`, as text inside
+  `instructions`, and as QR art whose size grows with the URI — art the broker
+  serialized *twice*, once as its own `qr_code` field and again embedded in the
+  instructions. An ordinary device response therefore sat about 20 bytes from the
+  limit. Past it, what arrived was a truncated prefix, `json_tokener_parse` refused
+  it, and the login was refused with `PAM_AUTHINFO_UNAVAIL` — the same result as a
+  broker that is not running, so the shipped stack's `auth requisite pam_deny.so`
+  left the operator with no password fallback and no diagnosis. Every provider in
+  the wild hands out a short URI, which is why nothing caught this.
+
+  - The QR art is serialized once, inside `instructions`. The redundant `qr_code`
+    field is gone from the IPC response (and from `internal/brokerclient`, which
+    declared it and never read it).
+  - The broker now owns the size of what it sends. A device response that would not
+    fit the module's buffer is re-rendered **without the QR art** — a login the user
+    completes by typing the URL beats a response that cannot be parsed — and at the
+    write site a response that still does not fit is replaced by a small, parseable
+    `RESPONSE_TOO_LARGE` failure rather than a truncated prefix of the real one.
+    Admin payloads are deliberately exempt: `oidc-admin` decodes a stream, and
+    `sessions_list` on a busy host is legitimately larger than the module's buffer.
+  - The buffer is 16 KiB, the bound the **oauth2-pam wire protocol (version 1)**
+    sets on a response. That project owns the broker↔module contract and this one
+    consumes it (#179), so the size is taken from there rather than chosen here.
+    `MAX_RESPONSE_SIZE` and `internal/ipc`'s `maxResponseSize` are held equal by a
+    test that reads the C header, so the two cannot drift; the second, unused
+    `MAX_BUFFER_SIZE` macro that had the same value is gone.
+  - `receive_auth_response` no longer reports success on a full buffer with no end
+    of message. That case is now distinguished from a transport failure and reported
+    as `PAM_SERVICE_ERR` ("error in service module"), not `PAM_AUTHINFO_UNAVAIL`
+    ("could not reach an opinion"), with the size in syslog. Both fail closed, but
+    they no longer look alike to whoever is reading the log.
+  - The broker bounds what a provider can hand it: `verification_uri` and
+    `verification_uri_complete` at 512 bytes, `user_code` at 64, rejected with an
+    error naming the provider's field — the input side of the same problem, where
+    the error can still say where the value came from.
+  - Tests in three places, since this defect lived between them: a Go test that
+    marshals the worst-case response the broker's own validation permits and asserts
+    it fits (with the art, and without); a cgo test that an oversized response is
+    reported distinctly rather than as an unreachable broker; and an e2e case that
+    logs in against an issuer handing out a 400-byte verification URI, asserting the
+    URL still reaches the user and the module never falls back on a parse failure.
+    `fakeoidc` grew a `/control/verification-uri?pad=N` route for it, because a
+    harness that only ever sees a 29-byte URI cannot tell that this is broken.
 - **High (#158): `require_groups` written the way every document tells operators
   to write it enforced nothing.** Group membership was checked against the global
   `authentication.require_groups`, but the configuration in QUICK-START.md,

--- a/cmd/pam-module/bridge_linux.go
+++ b/cmd/pam-module/bridge_linux.go
@@ -36,6 +36,7 @@ import "github.com/scttfrdmn/oidc-pam/pkg/pam"
 // It lives in a normal .go file because cgo is not permitted in _test.go files.
 var pamCodesFromHeaders = map[string]pam.PAMResultCode{
 	"PAM_SUCCESS":          C.PAM_SUCCESS,
+	"PAM_SERVICE_ERR":      C.PAM_SERVICE_ERR,
 	"PAM_SYSTEM_ERR":       C.PAM_SYSTEM_ERR,
 	"PAM_PERM_DENIED":      C.PAM_PERM_DENIED,
 	"PAM_AUTH_ERR":         C.PAM_AUTH_ERR,

--- a/cmd/pam-module/cgo_bridge.h
+++ b/cmd/pam-module/cgo_bridge.h
@@ -16,9 +16,31 @@
 #define PAM_MODULE_NAME "pam_oidc"
 #define PAM_MODULE_VERSION "0.1.0"
 
-// Maximum buffer sizes
-#define MAX_BUFFER_SIZE 8192
-#define MAX_RESPONSE_SIZE 8192
+// Size of the buffer a broker response is read into, NUL included.
+//
+// 16 KiB is the bound the oauth2-pam wire protocol (version 1) sets on a response:
+// that project owns the broker<->module contract and this one consumes it (#179),
+// so the number is taken from there rather than chosen here.
+//
+// This is one half of a contract with the broker: maxResponseSize in
+// internal/ipc/response.go is the other, and TestResponseSizeMatchesTheModulesBuffer
+// reads this file to hold the two equal. The broker never sends more than fits
+// here — it degrades the response, and reports an error rather than a prefix of one
+// — because a response that did not fit used to arrive truncated, fail to parse,
+// and refuse every login on the host with nothing in syslog but "Failed to parse
+// broker response". That was #162, with the buffer at 8 KiB and the QR art
+// serialized into the response twice.
+//
+// There used to be a second, unused MAX_BUFFER_SIZE macro with the same value.
+// Two names for one size is how a size ends up changed in one place only.
+#define MAX_RESPONSE_SIZE 16384
+
+// receive_auth_response results. A response that does not fit MAX_RESPONSE_SIZE is
+// distinguished from a transport failure so the caller can say so: the two mean
+// very different things to whoever is reading the log.
+#define RECV_OK 0
+#define RECV_ERROR (-1)
+#define RECV_RESPONSE_TOO_LARGE (-2)
 // Longest usable Unix socket path, taken from the platform's sockaddr_un
 // (108 bytes on Linux, 104 on Darwin/BSD) so it can never disagree with it.
 #define MAX_SOCKET_PATH (sizeof(((struct sockaddr_un *)0)->sun_path))

--- a/cmd/pam-module/cgo_bridge_linux.c
+++ b/cmd/pam-module/cgo_bridge_linux.c
@@ -219,7 +219,7 @@ int send_check_session_request(int sock, const char *session_id, const char *use
 // PAM stack.
 int receive_auth_response(int sock, char *response, size_t response_size) {
     if (response_size == 0) {
-        return -1;
+        return RECV_ERROR;
     }
 
     size_t total = 0;
@@ -233,14 +233,14 @@ int receive_auth_response(int sock, char *response, size_t response_size) {
         int pr = poll(&pfd, 1, RESPONSE_READ_TIMEOUT_MS);
         if (pr == 0) {
             log_pam_message(LOG_ERR, "Timed out waiting for broker response");
-            return -1;
+            return RECV_ERROR;
         }
         if (pr < 0) {
             if (errno == EINTR) {
                 continue;
             }
             log_pam_message(LOG_ERR, "poll() failed waiting for response: %s", strerror(errno));
-            return -1;
+            return RECV_ERROR;
         }
 
         ssize_t received = recv(sock, response + total, cap - total, 0);
@@ -249,7 +249,7 @@ int receive_auth_response(int sock, char *response, size_t response_size) {
                 continue;
             }
             log_pam_message(LOG_ERR, "Failed to receive response: %s", strerror(errno));
-            return -1;
+            return RECV_ERROR;
         }
         if (received == 0) {
             // Connection closed by broker. Accept whatever we have if it forms a
@@ -268,13 +268,28 @@ int receive_auth_response(int sock, char *response, size_t response_size) {
 
     if (total == 0) {
         log_pam_message(LOG_ERR, "Connection closed by broker before any response");
-        return -1;
+        return RECV_ERROR;
     }
 
     response[total] = '\0';
+
+    // A full buffer with no end of message in it is the beginning of a response,
+    // not a response. Returning success here is what made #162 silent: the caller
+    // handed the truncated JSON to json_tokener_parse, which failed, and every
+    // login on the host was refused with nothing to go on but "Failed to parse
+    // broker response". The broker is responsible for not sending more than
+    // MAX_RESPONSE_SIZE; this is what happens when it does anyway.
+    if (total >= cap && memchr(response, '\n', total) == NULL) {
+        log_pam_message(LOG_ERR,
+                        "Broker response does not fit this module's %zu-byte buffer "
+                        "(%zu bytes read with no end of message)",
+                        response_size, total);
+        return RECV_RESPONSE_TOO_LARGE;
+    }
+
     log_pam_message(LOG_DEBUG, "Received response: %s", response);
 
-    return 0;
+    return RECV_OK;
 }
 
 // Display message to user
@@ -576,17 +591,33 @@ static int broker_recv_and_close(int sock, char *response, size_t response_size)
     return rc;
 }
 
+// Map a failed read of a broker response onto a PAM result.
+//
+// PAM_AUTHINFO_UNAVAIL means "I could not reach an opinion": no broker, no reply,
+// a reply that is not JSON. A response too large for this module's buffer is a
+// different statement — the broker answered, and what is wrong is the contract
+// between the two halves of this project, not the transport and not the user. It
+// gets PAM_SERVICE_ERR ("error in service module") so that an operator reading
+// auth.log can tell the two apart, and so the fix they look for is the response
+// size rather than the broker's health. Both fail closed (#162).
+static int recv_failure_result(int rc) {
+    if (rc == RECV_RESPONSE_TOO_LARGE) {
+        return PAM_SERVICE_ERR;
+    }
+    return PAM_AUTHINFO_UNAVAIL;
+}
+
 static int broker_authenticate_once(const char *socket_path, const char *username, const char *service,
                                     const char *rhost, const char *tty,
                                     char *response, size_t response_size) {
     int sock = connect_to_broker(socket_path);
     if (sock == -1) {
         log_pam_message(LOG_ERR, "Failed to connect to authentication broker");
-        return -1;
+        return RECV_ERROR;
     }
     if (send_auth_request(sock, username, service, rhost, tty) != 0) {
         close(sock);
-        return -1;
+        return RECV_ERROR;
     }
     return broker_recv_and_close(sock, response, response_size);
 }
@@ -596,11 +627,11 @@ static int broker_check_session_once(const char *socket_path, const char *sessio
     int sock = connect_to_broker(socket_path);
     if (sock == -1) {
         log_pam_message(LOG_ERR, "Failed to reconnect to authentication broker while polling");
-        return -1;
+        return RECV_ERROR;
     }
     if (send_check_session_request(sock, session_id, username) != 0) {
         close(sock);
-        return -1;
+        return RECV_ERROR;
     }
     return broker_recv_and_close(sock, response, response_size);
 }
@@ -617,21 +648,24 @@ static int broker_check_session_once(const char *socket_path, const char *sessio
 // "poll once, then give up".
 //
 // Only a transport or parse failure returns PAM_AUTHINFO_UNAVAIL ("I could not
-// reach an opinion"). Everything else — a refusal, a vanished session, an
+// reach an opinion"), and only a response too large for this module's buffer
+// returns PAM_SERVICE_ERR. Everything else — a refusal, a vanished session, an
 // exhausted budget — is a denial, so the auth stack fails closed.
 int perform_authentication(pam_handle_t *pamh, const char *socket_path, const char *username,
                            const char *service, const char *rhost, const char *tty, int timeout_s) {
-    char response[MAX_BUFFER_SIZE];
+    char response[MAX_RESPONSE_SIZE];
     char session_id[MAX_SESSION_ID_SIZE];
     json_object *response_obj;
     const char *session;
     int poll_interval;
     long deadline;
     int result;
+    int rc;
 
-    if (broker_authenticate_once(socket_path, username, service, rhost, tty,
-                                 response, sizeof(response)) != 0) {
-        return PAM_AUTHINFO_UNAVAIL;
+    rc = broker_authenticate_once(socket_path, username, service, rhost, tty,
+                                  response, sizeof(response));
+    if (rc != RECV_OK) {
+        return recv_failure_result(rc);
     }
 
     response_obj = json_tokener_parse(response);
@@ -681,9 +715,10 @@ int perform_authentication(pam_handle_t *pamh, const char *socket_path, const ch
         // code, so an immediate poll can only ever report "pending".
         sleep_seconds(remaining < poll_interval ? remaining : poll_interval);
 
-        if (broker_check_session_once(socket_path, session_id, username,
-                                      response, sizeof(response)) != 0) {
-            return PAM_AUTHINFO_UNAVAIL;
+        rc = broker_check_session_once(socket_path, session_id, username,
+                                       response, sizeof(response));
+        if (rc != RECV_OK) {
+            return recv_failure_result(rc);
         }
 
         response_obj = json_tokener_parse(response);

--- a/cmd/pam-module/device_flow_linux_test.go
+++ b/cmd/pam-module/device_flow_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -434,4 +435,64 @@ func TestAcctMgmtHasNoOpinion(t *testing.T) {
 	if got != pam.PAMIgnore {
 		t.Errorf("pam_sm_acct_mgmt returned %d, want PAM_IGNORE (%d)", got, pam.PAMIgnore)
 	}
+}
+
+// oversizedResponse is a syntactically valid response too large for the module's
+// buffer. It is written verbatim, so what the module sees is a prefix of it with no
+// end of message in it — which is what the broker used to send whenever the QR art
+// pushed a device response past 8 KiB (#162).
+//
+// The size here is far above the module's buffer rather than exactly one byte over
+// it: the exact number is pinned from the other side, by
+// TestResponseSizeMatchesTheModulesBuffer in internal/ipc.
+func oversizedResponse() string {
+	return `{"success":true,"session_id":"sess-big","requires_device":true,"instructions":"` +
+		strings.Repeat("Q", 32<<10) + `"}` + "\n"
+}
+
+// A response the module cannot fit in its buffer must be reported as its own
+// failure, not as "the broker is unavailable".
+//
+// Before this, receive_auth_response returned success on a full buffer with no
+// newline, so the caller parsed a truncated prefix, json_tokener_parse failed, and
+// the only trace was "Failed to parse broker response" — with a PAM result
+// indistinguishable from a broker that is not running. An operator debugging
+// "nobody can log in" was told to look at the wrong thing.
+func TestPerformAuthenticationReportsAnOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("on the initial authenticate", func(t *testing.T) {
+		t.Parallel()
+
+		broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+			return oversizedResponse()
+		})
+
+		got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+		if got == pam.PAMAuthInfoUnavail {
+			t.Fatal("an oversized response is reported as PAM_AUTHINFO_UNAVAIL, the same result as a " +
+				"broker that is not running")
+		}
+		if got != pam.PAMServiceError {
+			t.Fatalf("got PAM result %d, want pam.PAMServiceError (%d)", got, pam.PAMServiceError)
+		}
+	})
+
+	// The poll path reads responses with the same buffer, so it must classify them
+	// the same way.
+	t.Run("on a poll", func(t *testing.T) {
+		t.Parallel()
+
+		broker := newFakeBroker(t, func(n int, _ map[string]interface{}) interface{} {
+			if n == 1 {
+				return deviceStarted("sess-big")
+			}
+			return oversizedResponse()
+		})
+
+		got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+		if got != pam.PAMServiceError {
+			t.Fatalf("got PAM result %d, want pam.PAMServiceError (%d)", got, pam.PAMServiceError)
+		}
+	})
 }

--- a/cmd/pam-module/pam_codes_linux_test.go
+++ b/cmd/pam-module/pam_codes_linux_test.go
@@ -24,6 +24,7 @@ import (
 func TestPAMResultCodesMatchHeaders(t *testing.T) {
 	declared := map[string]pam.PAMResultCode{
 		"PAM_SUCCESS":          pam.PAMSuccess,
+		"PAM_SERVICE_ERR":      pam.PAMServiceError,
 		"PAM_SYSTEM_ERR":       pam.PAMSystemError,
 		"PAM_PERM_DENIED":      pam.PAMPermDenied,
 		"PAM_AUTH_ERR":         pam.PAMAuthError,

--- a/internal/brokerclient/client.go
+++ b/internal/brokerclient/client.go
@@ -62,7 +62,6 @@ type Response struct {
 	SessionID        string                 `json:"session_id,omitempty"`
 	DeviceCode       string                 `json:"device_code,omitempty"`
 	DeviceURL        string                 `json:"device_url,omitempty"`
-	QRCode           string                 `json:"qr_code,omitempty"`
 	ExpiresAt        time.Time              `json:"expires_at,omitempty"`
 	SSHPublicKey     string                 `json:"ssh_public_key,omitempty"`
 	RequiresDevice   bool                   `json:"requires_device,omitempty"`

--- a/internal/ipc/errors.go
+++ b/internal/ipc/errors.go
@@ -39,6 +39,8 @@ func clientErrorMessage(code string) string {
 		return "Maximum concurrent sessions reached"
 	case "KEY_LIST_FAILED":
 		return "Failed to list managed SSH keys"
+	case "RESPONSE_TOO_LARGE":
+		return "Authentication response too large to send"
 	default:
 		return "An error occurred"
 	}

--- a/internal/ipc/response.go
+++ b/internal/ipc/response.go
@@ -1,0 +1,106 @@
+package ipc
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/rs/zerolog/log"
+)
+
+// maxResponseSize is the largest response the broker will send to the PAM module,
+// counting the newline that terminates it.
+//
+// The number comes from the oauth2-pam wire protocol (version 1), which bounds a
+// response at 16 KiB and permits a client to refuse a larger one. That project owns
+// the broker<->module contract and this one consumes it (#179), so this is not ours
+// to pick.
+//
+// The module reads a response into a buffer of exactly this size
+// (MAX_RESPONSE_SIZE in cmd/pam-module/cgo_bridge.h, held equal to this constant by
+// TestResponseSizeMatchesTheModulesBuffer). Nothing larger can reach it: what
+// arrived was a truncated prefix, json_tokener_parse failed on it, and every login
+// on the host was refused with nothing in syslog but "Failed to parse broker
+// response". That was #162 — at 8 KiB, with the QR art serialized twice (once as
+// qr_code and again inside instructions), an ordinary device-flow response came
+// within ~20 bytes of the limit.
+//
+// So the broker owns the size of what it sends: it degrades the response while it
+// still can, and reports a parseable error when it cannot. The module's buffer is
+// not something a client can be trusted to have.
+//
+// Admin payloads are deliberately exempt. oidc-admin is a Go client decoding a
+// stream, and `sessions_list` on a busy host is legitimately larger than the
+// module's buffer.
+const maxResponseSize = 16384
+
+// setDeviceInstructions renders the device-flow instructions into response,
+// dropping the QR art if the response would not otherwise fit the PAM module's
+// buffer.
+//
+// The art is by far the largest thing in a device response — several kilobytes,
+// growing with the length of the verification URI — and it is a convenience: the
+// instructions carry the same URL and user code as text. So a response that does
+// not fit loses the art, not the login (#162). What is left is a login the user
+// completes by typing the URL, instead of one that fails to parse.
+func (s *Server) setDeviceInstructions(response *Response, loginType, qrCode string) {
+	response.Instructions = s.formatInstructions(loginType, response.DeviceURL, response.DeviceCode, qrCode)
+
+	if qrCode == "" || fitsModuleBuffer(response) {
+		return
+	}
+
+	log.Warn().
+		Str("user_id", response.UserID).
+		Int("device_url_len", len(response.DeviceURL)).
+		Msg("Device instructions do not fit the PAM module's buffer with the QR code; sending them without it")
+
+	response.Instructions = s.formatInstructions(loginType, response.DeviceURL, response.DeviceCode, "")
+}
+
+// fitsModuleBuffer reports whether response, once marshalled and newline
+// terminated, is small enough for the PAM module to read.
+func fitsModuleBuffer(response *Response) bool {
+	payload, err := json.Marshal(response)
+	if err != nil {
+		// Unmarshallable is not "fits": the caller's fallback is smaller, and
+		// writeResponse will report the encoding failure.
+		return false
+	}
+	return len(payload)+1 <= maxResponseSize
+}
+
+// writeResponse writes one newline-delimited JSON response.
+//
+// Responses to the PAM module (*Response) are additionally bounded by
+// maxResponseSize: rather than a truncated prefix the module cannot parse, an
+// oversized response is replaced by a small RESPONSE_TOO_LARGE failure, which the
+// module maps to a distinct PAM result and which says in the broker log how big
+// the response was.
+func (s *Server) writeResponse(conn net.Conn, response any) {
+	payload, err := json.Marshal(response)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to encode IPC response")
+		return
+	}
+
+	if _, forModule := response.(*Response); forModule && len(payload)+1 > maxResponseSize {
+		log.Error().
+			Int("response_size", len(payload)+1).
+			Int("max_response_size", maxResponseSize).
+			Msg("Response does not fit the PAM module's buffer; sending RESPONSE_TOO_LARGE instead of a truncated response")
+
+		payload, err = json.Marshal(&Response{
+			Success:      false,
+			ErrorCode:    "RESPONSE_TOO_LARGE",
+			ErrorMessage: clientErrorMessage("RESPONSE_TOO_LARGE"),
+		})
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to encode RESPONSE_TOO_LARGE response")
+			return
+		}
+	}
+
+	if _, err := conn.Write(append(payload, '\n')); err != nil {
+		log.Error().Err(err).Msg("Failed to write IPC response")
+	}
+}

--- a/internal/ipc/response_size_test.go
+++ b/internal/ipc/response_size_test.go
@@ -1,0 +1,268 @@
+package ipc
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/auth"
+)
+
+// The two constants that must not drift: the broker's own cap and the buffer the
+// PAM module reads a response into. If the module's buffer were the smaller of the
+// two, the broker would happily send responses that arrive truncated — which is
+// exactly #162, and it produced nothing in syslog but "Failed to parse broker
+// response" on every login.
+func TestResponseSizeMatchesTheModulesBuffer(t *testing.T) {
+	const header = "../../cmd/pam-module/cgo_bridge.h"
+
+	data, err := os.ReadFile(header)
+	if err != nil {
+		t.Fatalf("read %s: %v", header, err)
+	}
+
+	// Deliberately not cgo: this has to run on a developer's Mac, where the module
+	// itself cannot be compiled (#141).
+	match := regexp.MustCompile(`(?m)^#define\s+MAX_RESPONSE_SIZE\s+(\d+)`).FindSubmatch(data)
+	if match == nil {
+		t.Fatalf("no MAX_RESPONSE_SIZE definition in %s; if it was renamed, update this test — "+
+			"the two sizes must stay equal", header)
+	}
+
+	moduleBuffer, err := strconv.Atoi(string(match[1]))
+	if err != nil {
+		t.Fatalf("MAX_RESPONSE_SIZE is not a number: %v", err)
+	}
+
+	if moduleBuffer != maxResponseSize {
+		t.Errorf("MAX_RESPONSE_SIZE in %s is %d but maxResponseSize is %d; the broker must not send "+
+			"more than the module can read", header, moduleBuffer, maxResponseSize)
+	}
+}
+
+// worstCaseDeviceResponse is the largest device-flow response the broker's own
+// input validation permits: a verification URI at maxVerificationURILen, a user
+// code at maxUserCodeLen, and every other field filled to its limit.
+func worstCaseDeviceResponse(t *testing.T, withQR bool) *Response {
+	t.Helper()
+
+	// 512 and 64 are the caps validateDeviceAuthLengths enforces in
+	// pkg/auth/device_flow.go. They are not exported; a change there that this does
+	// not follow shows up as a failure here, which is the intent.
+	deviceURL := "https://idp.example.com/device?user_code=" +
+		strings.Repeat("u", 512-len("https://idp.example.com/device?user_code="))
+	deviceCode := strings.Repeat("C", 64)
+
+	qrCode := ""
+	if withQR {
+		var err error
+		qrCode, err = auth.GenerateQRCode(deviceURL)
+		if err != nil {
+			t.Fatalf("GenerateQRCode: %v", err)
+		}
+	}
+
+	return &Response{
+		Success:        true,
+		UserID:         strings.Repeat("u", maxUserIDLen),
+		Email:          strings.Repeat("e", 200) + "@example.com",
+		Groups:         []string{"platform-engineering", "hpc-users", "cluster-admins"},
+		SessionID:      strings.Repeat("s", maxSessionIDLen),
+		DeviceCode:     deviceCode,
+		DeviceURL:      deviceURL,
+		ExpiresAt:      time.Now().Add(15 * time.Minute),
+		SSHPublicKey:   "ssh-rsa " + strings.Repeat("A", 716) + " user@oidc-pam-1755000000",
+		RequiresDevice: true,
+		Instructions:   auth.FormatDeviceInstructions(deviceURL, deviceCode, qrCode),
+		RiskScore:      42,
+		Metadata: map[string]interface{}{
+			"provider":         "keycloak",
+			"polling_interval": 5,
+		},
+	}
+}
+
+// The acceptance test for #162: the response the module actually has to parse has
+// to fit in its buffer.
+//
+// Both rungs are asserted here. Without the art there must be room to spare, or
+// there is no degradation left and every such login fails; with the art it should
+// fit too, so that the ladder is a bound on the pathological case rather than
+// something an ordinary long-URI login trips.
+func TestWorstCaseDeviceResponseFits(t *testing.T) {
+	withoutQR := worstCaseDeviceResponse(t, false)
+	if !fitsModuleBuffer(withoutQR) {
+		payload, err := json.Marshal(withoutQR)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		t.Fatalf("the worst-case device response without the QR art is %d bytes, over the module's %d-byte "+
+			"buffer: there is no degradation left and every such login fails to parse",
+			len(payload)+1, maxResponseSize)
+	}
+
+	withQR := worstCaseDeviceResponse(t, true)
+	payload, err := json.Marshal(withQR)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	t.Logf("worst case with QR art: %d bytes (module buffer %d)", len(payload)+1, maxResponseSize)
+	if !fitsModuleBuffer(withQR) {
+		t.Errorf("the worst-case device response with the QR art is %d bytes, over the module's %d-byte "+
+			"buffer: the longest verification URI the broker accepts would lose its QR code",
+			len(payload)+1, maxResponseSize)
+	}
+}
+
+// The first rung of the ladder: a device response that does not fit with the QR
+// art keeps the URL and the code and loses the art, so the user can still finish
+// the login.
+func TestDeviceInstructionsDropTheQRArtWhenTheResponseWouldNotFit(t *testing.T) {
+	response := worstCaseDeviceResponse(t, false)
+	qrCode, err := auth.GenerateQRCode(response.DeviceURL)
+	if err != nil {
+		t.Fatalf("GenerateQRCode: %v", err)
+	}
+
+	// The worst case the broker's own validation permits fits with the art, so
+	// something else has to push this response over: group membership, which is the
+	// one field in a response nothing bounds — it is whatever the IdP put in the
+	// token. (A response that overflows even without the art is writeResponse's
+	// problem, and it sends a parseable RESPONSE_TOO_LARGE rather than a prefix.)
+	for {
+		probe := *response
+		probe.Instructions = auth.FormatDeviceInstructions(response.DeviceURL, response.DeviceCode, qrCode)
+		if !fitsModuleBuffer(&probe) {
+			break
+		}
+		response.Groups = append(response.Groups, fmt.Sprintf("research-computing-group-%03d", len(response.Groups)))
+	}
+	t.Logf("overflowed the module's %d-byte buffer at %d group memberships", maxResponseSize, len(response.Groups))
+
+	(&Server{}).setDeviceInstructions(response, "ssh", qrCode)
+
+	if !fitsModuleBuffer(response) {
+		payload, marshalErr := json.Marshal(response)
+		if marshalErr != nil {
+			t.Fatalf("Marshal: %v", marshalErr)
+		}
+		t.Fatalf("device response is %d bytes, over the module's %d-byte buffer", len(payload)+1, maxResponseSize)
+	}
+	if strings.Contains(response.Instructions, qrCode) {
+		t.Error("the QR art was kept in a response that does not fit the module's buffer")
+	}
+	// Dropping the art must not drop what the user needs to act on.
+	if !strings.Contains(response.Instructions, response.DeviceURL) {
+		t.Error("instructions no longer contain the verification URL")
+	}
+	if !strings.Contains(response.Instructions, response.DeviceCode) {
+		t.Error("instructions no longer contain the user code")
+	}
+}
+
+// A QR code that does fit is kept: the degradation is a response to size, not a
+// removal of the feature.
+func TestDeviceInstructionsKeepAQRCodeThatFits(t *testing.T) {
+	response := &Response{
+		Success:        true,
+		SessionID:      "sess-1",
+		DeviceCode:     "WDJB-MJHT",
+		DeviceURL:      "https://idp.example.com/device",
+		RequiresDevice: true,
+	}
+	qrCode, err := auth.GenerateQRCode(response.DeviceURL)
+	if err != nil {
+		t.Fatalf("GenerateQRCode: %v", err)
+	}
+
+	(&Server{}).setDeviceInstructions(response, "ssh", qrCode)
+
+	if !strings.Contains(response.Instructions, qrCode) {
+		t.Error("a QR code that fits the module's buffer was dropped")
+	}
+	if !fitsModuleBuffer(response) {
+		t.Error("an ordinary device response does not fit the module's buffer")
+	}
+}
+
+// A response too large for the module must arrive as a response, not as a
+// truncated prefix of one: the module can report a distinct failure for the first
+// and can only fail to parse the second.
+func TestWriteResponseReplacesAnOversizedResponse(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	oversized := &Response{
+		Success:      true,
+		SessionID:    "sess-1",
+		Instructions: strings.Repeat("Q", maxResponseSize*2),
+	}
+
+	go func() {
+		defer func() { _ = server.Close() }()
+		(&Server{}).writeResponse(server, oversized)
+	}()
+
+	payload, err := readOneResponse(client)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(payload) > maxResponseSize {
+		t.Fatalf("wrote %d bytes, over the module's %d-byte buffer", len(payload), maxResponseSize)
+	}
+
+	var got Response
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("the module would fail to parse what was sent: %v", err)
+	}
+	if got.Success {
+		t.Error("an oversized response was replaced by a success")
+	}
+	if got.ErrorCode != "RESPONSE_TOO_LARGE" {
+		t.Errorf("error_code = %q, want RESPONSE_TOO_LARGE", got.ErrorCode)
+	}
+}
+
+// Admin payloads are exempt: oidc-admin decodes a stream, and sessions_list on a
+// busy host is legitimately bigger than the PAM module's buffer. Capping them
+// would break the tool that operators use to see the sessions.
+func TestWriteResponseDoesNotCapAdminPayloads(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	big := map[string]string{"sessions": strings.Repeat("s", maxResponseSize*2)}
+
+	go func() {
+		defer func() { _ = server.Close() }()
+		(&Server{}).writeResponse(server, big)
+	}()
+
+	payload, err := readOneResponse(client)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(payload) < maxResponseSize {
+		t.Fatalf("an admin payload of %d bytes was truncated to %d", maxResponseSize*2, len(payload))
+	}
+	var got map[string]string
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("admin payload did not survive the round trip: %v", err)
+	}
+}
+
+// readOneResponse reads the newline-delimited response writeResponse sends,
+// without the newline.
+func readOneResponse(conn net.Conn) ([]byte, error) {
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil {
+		return line, err
+	}
+	return line[:len(line)-1], nil
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -50,7 +50,12 @@ type Request struct {
 	Metadata   map[string]interface{} `json:"metadata"`
 }
 
-// Response represents a response to PAM module
+// Response represents a response to PAM module.
+//
+// Every field here costs part of maxResponseSize, so nothing goes in twice. There
+// used to be a qr_code field alongside Instructions, which already embeds the same
+// ASCII art: no client ever read it, and the two copies together put an ordinary
+// device-flow response ~20 bytes under the module's 8 KiB buffer (#162).
 type Response struct {
 	Success          bool                   `json:"success"`
 	UserID           string                 `json:"user_id"`
@@ -59,7 +64,6 @@ type Response struct {
 	SessionID        string                 `json:"session_id"`
 	DeviceCode       string                 `json:"device_code"`
 	DeviceURL        string                 `json:"device_url"`
-	QRCode           string                 `json:"qr_code"`
 	ExpiresAt        time.Time              `json:"expires_at"`
 	SSHPublicKey     string                 `json:"ssh_public_key"`
 	RequiresDevice   bool                   `json:"requires_device"`
@@ -308,13 +312,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 	response := s.handleRequest(&request)
 
 	// Send response
-	encoder := json.NewEncoder(conn)
-	if err := encoder.Encode(response); err != nil {
-		log.Error().
-			Err(err).
-			Msg("Failed to encode IPC response")
-		return
-	}
+	s.writeResponse(conn, response)
 
 	log.Debug().
 		Str("request_type", request.Type).
@@ -453,7 +451,6 @@ func (s *Server) handleAuthenticate(request *Request) *Response {
 		SessionID:        authResponse.SessionID,
 		DeviceCode:       authResponse.DeviceCode,
 		DeviceURL:        authResponse.DeviceURL,
-		QRCode:           authResponse.QRCode,
 		ExpiresAt:        authResponse.ExpiresAt,
 		SSHPublicKey:     authResponse.SSHPublicKey,
 		RequiresDevice:   authResponse.RequiresDevice,
@@ -466,7 +463,7 @@ func (s *Server) handleAuthenticate(request *Request) *Response {
 
 	// Add formatted instructions based on login type
 	if authResponse.RequiresDevice {
-		response.Instructions = s.formatInstructions(request.LoginType, authResponse.DeviceURL, authResponse.DeviceCode, authResponse.QRCode)
+		s.setDeviceInstructions(response, request.LoginType, authResponse.QRCode)
 	}
 
 	return response
@@ -571,16 +568,9 @@ func (s *Server) formatInstructions(loginType, deviceURL, deviceCode, qrCode str
 
 // sendErrorResponse sends an error response
 func (s *Server) sendErrorResponse(conn net.Conn, errorCode, errorMessage string) {
-	response := &Response{
+	s.writeResponse(conn, &Response{
 		Success:      false,
 		ErrorCode:    errorCode,
 		ErrorMessage: errorMessage,
-	}
-
-	encoder := json.NewEncoder(conn)
-	if err := encoder.Encode(response); err != nil {
-		log.Error().
-			Err(err).
-			Msg("Failed to send error response")
-	}
+	})
 }

--- a/internal/testoidc/issuer.go
+++ b/internal/testoidc/issuer.go
@@ -46,12 +46,13 @@ type Issuer struct {
 	kid      string
 	clientID string
 
-	mu        sync.Mutex
-	issuerURL string
-	script    []Outcome
-	polls     int
-	claims    map[string]any
-	devices   map[string]string // device_code -> nonce received at the device endpoint
+	mu          sync.Mutex
+	issuerURL   string
+	script      []Outcome
+	polls       int
+	claims      map[string]any
+	devices     map[string]string // device_code -> nonce received at the device endpoint
+	uriPadBytes int               // extra bytes in verification_uri, see SetVerificationURIPadding
 }
 
 // DefaultClaims is the claim set a fresh Issuer puts in ID tokens and returns
@@ -155,15 +156,38 @@ func (i *Issuer) NextOutcome() Outcome {
 	return i.script[min(i.polls, len(i.script)-1)]
 }
 
+// SetVerificationURIPadding makes the device endpoint return a verification_uri
+// padded with n extra bytes of query string.
+//
+// Real providers hand out short URIs, which is why nothing caught #162: the
+// verification URI reaches the PAM module three times over — as device_url, as
+// text in the instructions, and as QR art that grows with it — and a URI of a few
+// hundred bytes was enough to push the response past the module's response buffer.
+// A harness that only ever sees a 29-byte URI cannot tell that this is broken.
+func (i *Issuer) SetVerificationURIPadding(n int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.uriPadBytes = n
+}
+
+// VerificationURIPadding is the padding currently in effect, so a harness can
+// report it as part of the issuer's state.
+func (i *Issuer) VerificationURIPadding() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.uriPadBytes
+}
+
 // Reset returns the issuer to its initial state: default claims, no polls
-// recorded, and no device codes outstanding. The script is left alone, since a
-// harness sets it per case.
+// recorded, no device codes outstanding, and an unpadded verification URI. The
+// script is left alone, since a harness sets it per case.
 func (i *Issuer) Reset() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.polls = 0
 	i.claims = DefaultClaims()
 	i.devices = make(map[string]string)
+	i.uriPadBytes = 0
 }
 
 // Handler serves the OIDC endpoints. The paths are also what the discovery
@@ -227,12 +251,18 @@ func (i *Issuer) handleDevice(w http.ResponseWriter, r *http.Request) {
 	// it echoed in the ID token; remember it per device code.
 	i.devices[deviceCode] = r.Form.Get("nonce")
 	base := i.issuerURL
+	pad := i.uriPadBytes
 	i.mu.Unlock()
+
+	verificationURI := base + "/activate"
+	if pad > 0 {
+		verificationURI += "?p=" + strings.Repeat("p", pad)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"device_code":      deviceCode,
 		"user_code":        "WDJB-MJHT",
-		"verification_uri": base + "/activate",
+		"verification_uri": verificationURI,
 		"expires_in":       600,
 		"interval":         5,
 	})

--- a/pkg/auth/device_auth_limits_test.go
+++ b/pkg/auth/device_auth_limits_test.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// startDeviceFlowAgainst runs StartDeviceFlow against a provider that answers the
+// device authorization request with resp.
+func startDeviceFlowAgainst(t *testing.T, resp DeviceAuthResponse) (*DeviceFlow, error) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+
+	provider := &OIDCProvider{
+		Name: "test-provider",
+		Config: config.OIDCProvider{
+			Name:           "test-provider",
+			Issuer:         server.URL,
+			ClientID:       "test-client",
+			Scopes:         []string{"openid"},
+			DeviceEndpoint: server.URL + "/device",
+		},
+		httpClient: server.Client(),
+	}
+
+	return provider.StartDeviceFlow(&AuthRequest{UserID: "testuser", LoginType: "ssh"})
+}
+
+// #162: the verification URI reaches the PAM module three times over — as
+// device_url, as text in the instructions, and as QR art whose size grows with it
+// — and the module reads the whole response into a fixed 8 KiB buffer. A provider
+// that answers with a kilobyte-long URI would make every login on the host fail to
+// parse the response, so it is refused here, where the error can name the field.
+func TestStartDeviceFlowRejectsOverlongProviderStrings(t *testing.T) {
+	valid := DeviceAuthResponse{
+		DeviceCode:      "device-code",
+		UserCode:        "WDJB-MJHT",
+		VerificationURI: "https://idp.example.com/device",
+		ExpiresIn:       600,
+		Interval:        5,
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(*DeviceAuthResponse)
+		wantText string
+	}{
+		{
+			name: "verification_uri over the limit",
+			mutate: func(r *DeviceAuthResponse) {
+				r.VerificationURI = "https://idp.example.com/device?x=" + strings.Repeat("A", 513)
+			},
+			wantText: "verification_uri",
+		},
+		{
+			name: "verification_uri_complete over the limit",
+			mutate: func(r *DeviceAuthResponse) {
+				r.VerificationURIComplete = "https://idp.example.com/device?code=" + strings.Repeat("A", 513)
+			},
+			wantText: "verification_uri_complete",
+		},
+		{
+			name: "user_code over the limit",
+			mutate: func(r *DeviceAuthResponse) {
+				r.UserCode = strings.Repeat("C", maxUserCodeLen+1)
+			},
+			wantText: "user_code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := valid
+			tt.mutate(&resp)
+
+			flow, err := startDeviceFlowAgainst(t, resp)
+			if err == nil {
+				t.Fatalf("StartDeviceFlow accepted an over-long %s; the response it produces cannot be "+
+					"parsed by the PAM module (device_url is %d bytes)", tt.wantText, len(flow.DeviceURL))
+			}
+			if !strings.Contains(err.Error(), tt.wantText) {
+				t.Errorf("error does not name the offending field %q: %v", tt.wantText, err)
+			}
+		})
+	}
+}
+
+// The limits are bounds on the absurd, not on the real: values at the limit, and
+// every URI an actual provider issues, are accepted unchanged.
+func TestStartDeviceFlowAcceptsStringsAtTheLimit(t *testing.T) {
+	prefix := "https://idp.example.com/device?user_code="
+	atLimit := prefix + strings.Repeat("u", maxVerificationURILen-len(prefix))
+
+	flow, err := startDeviceFlowAgainst(t, DeviceAuthResponse{
+		DeviceCode:              "device-code",
+		UserCode:                strings.Repeat("C", maxUserCodeLen),
+		VerificationURI:         "https://idp.example.com/device",
+		VerificationURIComplete: atLimit,
+		ExpiresIn:               600,
+		Interval:                5,
+	})
+	if err != nil {
+		t.Fatalf("StartDeviceFlow rejected values at the limit: %v", err)
+	}
+	if flow.DeviceURL != atLimit {
+		t.Errorf("device URL = %q, want the complete verification URI unchanged", flow.DeviceURL)
+	}
+}

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -46,6 +46,26 @@ const (
 	slowDownIncrement  = 5
 )
 
+// Bounds on the provider-supplied strings that end up in the response the PAM
+// module reads.
+//
+// The module reads a response into a fixed-size buffer (MAX_RESPONSE_SIZE, 16 KiB),
+// and the verification URI is in there twice over: as device_url, and inside the
+// formatted instructions as both text and QR art whose size grows with the URI. A
+// provider (or anything that can answer as one) returning a kilobyte-long
+// verification_uri therefore pushes an ordinary login response past what the module
+// can parse, and every login on the host fails with nothing in syslog but "Failed
+// to parse broker response" (#162). internal/ipc bounds the response it sends as
+// well; this bounds the input, where the error can still name the provider and the
+// field.
+//
+// 512 bytes is far above anything real: the longest verification URIs in the wild
+// are around 100 characters, and the user code is meant to be typed by a human.
+const (
+	maxVerificationURILen = 512
+	maxUserCodeLen        = 64
+)
+
 // DeviceFlow represents an OAuth2 device authorization flow
 type DeviceFlow struct {
 	DeviceCode      string
@@ -324,6 +344,10 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 		return nil, fmt.Errorf("provider returned invalid expires_in value: %d (must be 1–%d seconds)", deviceResp.ExpiresIn, maxDeviceCodeExpiry)
 	}
 
+	if err := validateDeviceAuthLengths(&deviceResp); err != nil {
+		return nil, err
+	}
+
 	// Clamp the provider's interval to [minPollingInterval, maxPollingInterval].
 	if deviceResp.Interval < minPollingInterval {
 		deviceResp.Interval = minPollingInterval
@@ -356,6 +380,32 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 		Msg("Device flow initiated")
 
 	return deviceFlow, nil
+}
+
+// validateDeviceAuthLengths rejects a device authorization response whose
+// user-facing strings are too long to fit in the response the PAM module reads
+// (#162). Refusing here fails the login for the one user whose provider misbehaves,
+// with the provider and field named in the error; letting it through fails every
+// login on the host with an unparseable response.
+func validateDeviceAuthLengths(resp *DeviceAuthResponse) error {
+	fields := []struct {
+		name  string
+		value string
+		max   int
+	}{
+		{"verification_uri", resp.VerificationURI, maxVerificationURILen},
+		{"verification_uri_complete", resp.VerificationURIComplete, maxVerificationURILen},
+		{"user_code", resp.UserCode, maxUserCodeLen},
+	}
+
+	for _, field := range fields {
+		if len(field.value) > field.max {
+			return fmt.Errorf("provider returned a %s of %d bytes, over the %d-byte limit",
+				field.name, len(field.value), field.max)
+		}
+	}
+
+	return nil
 }
 
 // PollDeviceAuthorization polls for device authorization completion.

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -30,7 +30,15 @@ import (
 type PAMResultCode int
 
 const (
-	PAMSuccess         PAMResultCode = 0  // PAM_SUCCESS
+	PAMSuccess PAMResultCode = 0 // PAM_SUCCESS
+
+	// PAMServiceError is "error in service module": the module and the broker
+	// disagree about something, as opposed to the broker being unreachable
+	// (PAMAuthInfoUnavail) or the user being refused (PAMAuthError). The module
+	// returns it when a broker response does not fit its response buffer, so that
+	// an operator can tell those three apart in auth.log (#162).
+	PAMServiceError PAMResultCode = 3 // PAM_SERVICE_ERR
+
 	PAMSystemError     PAMResultCode = 4  // PAM_SYSTEM_ERR
 	PAMPermDenied      PAMResultCode = 6  // PAM_PERM_DENIED
 	PAMAuthError       PAMResultCode = 7  // PAM_AUTH_ERR

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -615,6 +615,62 @@ case_home_lock_does_not_block_login() {
     expect_oidc_key_for alice
 }
 
+# #162: a long verification URI must not break the login.
+#
+# The URI reaches the module three times over — as device_url, as text in the
+# instructions, and as QR art whose size grows with it — and the module reads the
+# whole response into a fixed buffer. At 8 KiB, with the art also serialized into a
+# separate qr_code field, a URI of a few hundred bytes pushed an ordinary device
+# response past the buffer; what arrived was a truncated prefix, json-c refused it,
+# and *every* login on the host was refused with nothing in syslog but "Failed to
+# parse broker response" and a PAM result indistinguishable from a broker that was
+# not running.
+#
+# Every provider in the wild hands out a URI of around 30 bytes, which is why
+# neither the unit tests nor this harness caught it. So the issuer is asked for a
+# long one here, and the assertion is simply that the login works — plus the two
+# things that say *why* it worked: the URL still reached the user, and the module
+# never had to fall back on a parse failure.
+case_long_verification_uri() {
+    reset_state alice || return 1
+
+    # 400 bytes of padding: comfortably over the old 8 KiB buffer once rendered as
+    # QR art, and within the 512-byte cap the broker now enforces on what a provider
+    # may return (validateDeviceAuthLengths, pkg/auth/device_flow.go) — so this is a
+    # login the broker must complete, not one it should reject.
+    control 'verification-uri?pad=400' >/dev/null
+    if [[ "$(state_field uri_padding)" != "400" ]]; then
+        fail "the issuer did not take the verification-uri padding; this case would prove nothing"
+        return 1
+    fi
+
+    start_login alice
+    wait_for_polls 1 30 || { kill "${LOGIN_PID}" 2>/dev/null; return 1; }
+
+    control approve >/dev/null
+    reap_login
+
+    expect_login_ok || return 1
+    expect_oidc_key_for alice
+    expect_audit authentication_successful
+
+    # The padded URL itself has to have reached the client: a response that quietly
+    # dropped the instructions would pass everything above while leaving a real user
+    # with nowhere to go.
+    if grep -q 'fakeoidc:8443/activate?p=pppp' <<<"${LOGIN_OUTPUT}"; then
+        log "the padded verification URL reached the client"
+    else
+        fail "the client was never shown the padded verification URL"
+        printf '%s\n' "${LOGIN_OUTPUT}" | sed 's/^/      ssh: /'
+    fi
+
+    # The #162 symptoms. The first is what a truncated response looks like from the
+    # module; the second is the module refusing a response too big for its buffer,
+    # which the broker must have prevented by degrading the response instead.
+    expect_no_module_log 'Failed to parse broker response'
+    expect_no_module_log 'does not fit this module'
+}
+
 # With no broker there is no opinion to be had: the module must report that it
 # could not reach one (PAM_AUTHINFO_UNAVAIL) and the login must be refused, at
 # once rather than after the device-flow budget.
@@ -641,6 +697,7 @@ case_broker_down() {
 CASES=(
     waits_while_pending
     approved_login
+    long_verification_uri
     never_approved
     denied_by_provider
     identity_mismatch

--- a/test/e2e/fakeoidc/main.go
+++ b/test/e2e/fakeoidc/main.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -130,8 +131,29 @@ func controlHandler(iss *testoidc.Issuer) http.Handler {
 		writeState(w, iss, "identity set")
 	})
 
-	// Reset: default identity, no polls counted. Cases call this first so the
-	// poll count they assert on is their own.
+	// Verification URI: how long a verification_uri the provider hands out.
+	//
+	//   /control/verification-uri?pad=400
+	//   /control/verification-uri?pad=0
+	//
+	// A real provider's URI is short, which is why nothing in this harness caught
+	// #162 — the URI reaches the PAM module three times over (as device_url, as text
+	// in the instructions, and as QR art that grows with it), so a few hundred bytes
+	// of it used to overflow the module's response buffer and refuse every login on
+	// the host. Padding is how a case asks for a URI long enough to prove that the
+	// login still works.
+	mux.HandleFunc("/control/verification-uri", func(w http.ResponseWriter, r *http.Request) {
+		pad, err := strconv.Atoi(r.URL.Query().Get("pad"))
+		if err != nil || pad < 0 {
+			http.Error(w, "pad must be a non-negative number of bytes\n", http.StatusBadRequest)
+			return
+		}
+		iss.SetVerificationURIPadding(pad)
+		writeState(w, iss, "verification uri padded")
+	})
+
+	// Reset: default identity, no polls counted, unpadded verification URI. Cases
+	// call this first so the poll count they assert on is their own.
 	mux.HandleFunc("/control/reset", func(w http.ResponseWriter, r *http.Request) {
 		iss.Reset()
 		iss.Script(testoidc.Pending)
@@ -151,10 +173,11 @@ func controlHandler(iss *testoidc.Issuer) http.Handler {
 func writeState(w http.ResponseWriter, iss *testoidc.Issuer, action string) {
 	claims := iss.Claims()
 	body := map[string]any{
-		"outcome":  string(iss.NextOutcome()),
-		"polls":    iss.Polls(),
-		"username": claims["preferred_username"],
-		"groups":   claims["groups"],
+		"outcome":     string(iss.NextOutcome()),
+		"polls":       iss.Polls(),
+		"username":    claims["preferred_username"],
+		"groups":      claims["groups"],
+		"uri_padding": iss.VerificationURIPadding(),
 	}
 	if action != "" {
 		body["action"] = action


### PR DESCRIPTION
Fixes #162.

A verification URL longer than about 100 characters made **every login on the host fail**, with nothing in syslog but `Failed to parse broker response`.

The module read a response into an 8 KiB buffer, and the verification URI reached it three times over: as `device_url`, as text inside `instructions`, and as QR art whose size grows with the URI — art the broker serialized *twice*, once as its own `qr_code` field and again embedded in the instructions. An ordinary device response sat ~20 bytes from the limit. Past it the response arrived truncated, `json_tokener_parse` refused it, and the login was refused with `PAM_AUTHINFO_UNAVAIL` — the same result as a broker that is not running, so the shipped stack's `auth requisite pam_deny.so` left the operator with no fallback and no diagnosis. Every provider in the wild hands out a short URI, which is why nothing caught it.

## What changed

The broker now owns the size of what it sends.

- **One copy of the QR art**, inside `instructions`. The redundant `qr_code` field is gone from the IPC response and from `internal/brokerclient`, which declared it and never read it.
- **A degradation ladder** (`internal/ipc/response.go`): a device response that would not fit the module's buffer is re-rendered *without the art* — a login the user completes by typing the URL beats a response that cannot be parsed — and at the write site a response that still does not fit is replaced by a small, parseable `RESPONSE_TOO_LARGE` failure rather than a truncated prefix of the real one. Admin payloads are deliberately exempt: `oidc-admin` decodes a stream, and `sessions_list` on a busy host is legitimately larger than the module's buffer.
- **16 KiB, from the oauth2-pam wire protocol (version 1)**, not chosen here. That project owns the broker↔module contract and this one consumes it (#179). `MAX_RESPONSE_SIZE` and `internal/ipc`'s `maxResponseSize` are held equal by a test that reads the C header, so they cannot drift; the unused `MAX_BUFFER_SIZE` duplicate is gone.
- **Distinct failure semantics**: `receive_auth_response` no longer reports success on a full buffer with no end of message. That case is `PAM_SERVICE_ERR` ("error in service module"), not `PAM_AUTHINFO_UNAVAIL` ("could not reach an opinion"), with the size logged. Both fail closed; they no longer look alike in `auth.log`.
- **Provider input bounded** where the error can still name the field: `verification_uri` and `verification_uri_complete` at 512 bytes, `user_code` at 64.

## Verification

Tested in the three places this defect lived between, and each gate was proven to fail against the restored defect:

- `internal/ipc`: marshals the worst-case response the broker's own validation permits and asserts it fits, both with the art and without; the drop-the-art rung and the `RESPONSE_TOO_LARGE` replacement; and that admin payloads are not capped.
- `cmd/pam-module` (cgo, in a container — this host cannot compile the module): an oversized response is reported as `PAM_SERVICE_ERR`, explicitly *not* `PAM_AUTHINFO_UNAVAIL`, on both the initial authenticate and a poll. Restoring either half of the defect (recv returning success on a full buffer; `RECV_RESPONSE_TOO_LARGE` mapped back to `PAM_AUTHINFO_UNAVAIL`) makes it fail with the right message.
- `test/e2e`: a new `long_verification_uri` case logs in against an issuer handing out a 400-byte verification URI, asserting the URL still reaches the user and that the module never falls back on a parse failure. `fakeoidc` grew `/control/verification-uri?pad=N` for it. Against a copy of the tree with the broker and module halves reverted, that same case refuses an approved login after 6 s — so it is a regression test, not a passing formality.

## Note

`RESPONSE_TOO_LARGE` is not in wire protocol version 1's error vocabulary. An unknown `error_code` maps to `PAM_AUTH_ERR` and fails closed, so this is safe for any conformant client, but it should be raised as a vocabulary question on oauth2-pam when #179 is taken up rather than left as a silent local extension.