### PR TITLE
fix(auth): bind only the claim the operator configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **High (#164): if the identity provider stopped returning the configured
+  `username_claim`, the authorization decision moved silently to `sub`.** An absent
+  `preferred_username` or `sub` claim was substituted with `userInfo.Subject`, and an
+  absent `email` with `userInfo.Email`, so a scope change, a claim-mapper edit or a
+  tenant migration re-pointed identity binding at an identifier the operator never
+  chose and never audited — without an error, a warning or an audit record. The claim
+  it fell back to is the one shipped in every provider config
+  (`preferred_username` in `azure-ad.yaml`, `okta.yaml`, `keycloak.yaml` and
+  `test/e2e/broker.yaml`), and for the many IdPs whose `sub` is an email or a
+  username — LDAP/AD-backed and self-hosted ones especially — that substituted value
+  was then matched against local account names, so #159's local-part matching applied
+  to it too.
+
+  - The configured claim is now the only claim consulted. A token that does not carry
+    it is refused: no session, no login key, and no token stored.
+  - The refusal names the claim that was configured and missing, and points at the
+    provider's scopes and claim mapping. A `sub`-based deployment stays expressible,
+    deliberately, as `username_claim: sub`.
+  - Audited as `USERNAME_CLAIM_MISSING` rather than `IDENTITY_MISMATCH`: nothing was
+    wrong with the identity, every login through that provider is failing for the same
+    reason, and the fix is in the provider or the config.
+
+  Coverage: the existing "claim absent in token fails closed" case passed against the
+  defect because its fixture had an empty `Subject`, which is exactly the condition
+  that hides the fallback. The new cases give the identity a non-empty `Subject` and
+  `Email`, cover all three deleted branches, and run through the full device flow —
+  proven to fail with the fallback restored (an active session, a provisioned key and
+  an `authentication_successful` record).
 - **High (#161): any local user could stop session expiry and key revocation for
   the whole host.** The broker serialized its `authorized_keys` writes on
   `~/.ssh/authorized_keys.lock` — a path inside the home directory of the very

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -437,6 +437,12 @@ pin exists to close: a subdomain under which an attacker can get a verified
 address. Every domain you list is a domain whose local parts choose local
 accounts on this host, so list only domains whose addresses you control.
 
+The claim you name is the only claim consulted. If the token does not carry it,
+the login is refused and audited as `USERNAME_CLAIM_MISSING` naming the claim —
+there is no fallback to `sub` or to any other claim, because an identifier you
+did not choose is not one you have audited. If your provider puts the login name
+in `sub`, say so with `username_claim: "sub"`.
+
 ### Privileged accounts
 
 No OIDC identity may log in as uid 0, or as any account with uid below 1000,

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -923,9 +923,17 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 				// claim problem that is not there.
 				errCode := "IDENTITY_MISMATCH"
 				message := "Rejected authentication: OIDC identity does not match requested local user"
-				if errors.Is(err, ErrPrivilegedAccount) {
+				switch {
+				case errors.Is(err, ErrPrivilegedAccount):
 					errCode = "PRIVILEGED_ACCOUNT_DENIED"
 					message = "Rejected authentication: refusing to bind an OIDC identity to a privileged local account"
+				case errors.Is(err, ErrUsernameClaimMissing):
+					// (#164) Also not a mismatch: there was nothing to compare. The claim the
+					// operator configured never arrived, so every login through this provider
+					// is failing for the same reason and the fix is in the provider or the
+					// config, not in this user's identity.
+					errCode = "USERNAME_CLAIM_MISSING"
+					message = "Rejected authentication: the configured username_claim is absent from the token, so the identity could not be bound"
 				}
 				log.Warn().
 					Err(err).
@@ -1351,9 +1359,9 @@ func sanitizeErrorForClient(err error) string {
 // arbitrary local account. It fails closed — any misconfiguration or mismatch
 // returns an error rather than allowing the login.
 //
-// The expected local username is resolved from the configured username_claim
-// (falling back to the standard "preferred_username" claim). Comparison is
-// case-insensitive on the local-part, matching typical POSIX/login behavior.
+// The expected local username is resolved from the configured username_claim, and
+// from no other claim (#164). Comparison is case-insensitive, and on the local-part
+// only where the provider has opted in (#159).
 func (b *Broker) verifyIdentityBinding(provider *OIDCProvider, userInfo *UserInfo, requestedUser string) error {
 	if userInfo == nil {
 		return fmt.Errorf("no user info available")
@@ -1372,7 +1380,7 @@ func (b *Broker) verifyIdentityBinding(provider *OIDCProvider, userInfo *UserInf
 
 	mapped, err := claimToUsername(userInfo, claimName)
 	if err != nil {
-		return err
+		return fmt.Errorf("provider %q: %w", provider.Config.Name, err)
 	}
 	mapped = strings.TrimSpace(strings.ToLower(mapped))
 	if mapped == "" {
@@ -1531,29 +1539,35 @@ func lookupLocalUID(name string) (int, bool, error) {
 	return uid, true, nil
 }
 
-// claimToUsername extracts a string username from the resolved claims using the
-// configured claim name, with sensible fallbacks to well-known UserInfo fields.
+// ErrUsernameClaimMissing is returned when the configured username_claim is not
+// in the token's claims at all. Distinguished from a mismatch because nothing about
+// the identity was wrong: the claim the operator named was never delivered, which is
+// a configuration or provider problem and is audited as one.
+var ErrUsernameClaimMissing = errors.New("configured username_claim is absent from the token claims")
+
+// claimToUsername extracts the string value of the configured claim. The claim the
+// operator named is the only claim consulted.
+//
+// (#164) There used to be a fallback here: an absent "preferred_username" or "sub"
+// substituted userInfo.Subject, and an absent "email" substituted userInfo.Email. So
+// if an IdP stopped returning preferred_username — a scope change, a claim-mapper
+// edit, a tenant migration — the authorization decision moved silently to `sub`, an
+// identifier the operator never chose and never audited, and for the many IdPs whose
+// `sub` is an email or a username it was then matched against local account names. A
+// `sub`-based deployment is expressible as username_claim: sub, which reaches
+// Claims["sub"] directly (extractUserInfoFromClaims always populates it).
 func claimToUsername(userInfo *UserInfo, claimName string) (string, error) {
-	if userInfo.Claims != nil {
-		if v, ok := userInfo.Claims[claimName]; ok {
-			if s, ok := v.(string); ok {
-				return s, nil
-			}
-			return "", fmt.Errorf("username_claim %q is not a string", claimName)
-		}
+	v, ok := userInfo.Claims[claimName]
+	if !ok {
+		return "", fmt.Errorf("username_claim %q is absent from the token claims for this identity; "+
+			"check the provider's scopes and claim mapping, or set username_claim to a claim it does "+
+			"return: %w", claimName, ErrUsernameClaimMissing)
 	}
-	// Fallbacks for the common standard claims even if not present in the raw map.
-	switch claimName {
-	case "preferred_username", "sub":
-		if userInfo.Subject != "" {
-			return userInfo.Subject, nil
-		}
-	case "email":
-		if userInfo.Email != "" {
-			return userInfo.Email, nil
-		}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("username_claim %q is not a string", claimName)
 	}
-	return "", fmt.Errorf("username_claim %q not present in token claims", claimName)
+	return s, nil
 }
 
 // classifyPollError maps a device-authorization polling error to a small, fixed

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -740,6 +740,76 @@ authentication:
 	}
 }
 
+// TestAbsentUsernameClaimRefusedOnTheRealPath drives #164 through the whole device
+// flow: an approved authorization whose token does not carry the configured
+// username_claim must leave no session and no SSH key, and be audited as
+// USERNAME_CLAIM_MISSING naming the claim that was configured and missing.
+//
+// The scenario is an IdP that stopped returning preferred_username — a scope change,
+// a claim-mapper edit, a tenant migration — while `sub` is a login name, as it is on
+// LDAP/AD-backed and self-hosted IdPs. Here `sub` happens to equal the local account
+// being logged into, so the deleted fallback bound it and the login was approved on a
+// claim the operator never chose. The end-to-end path is what shows the consequence:
+// on the broken code this run produces an active session and an installed key.
+func TestAbsentUsernameClaimRefusedOnTheRealPath(t *testing.T) {
+	// The provider is configured for preferred_username, as newPollTestEnv and every
+	// shipped provider config are. testuser is uid 1500, so the privileged-account
+	// guard is not what refuses this.
+	claimsWithoutPreferredUsername := map[string]any{
+		"sub":    "testuser",
+		"email":  "testuser@example.org",
+		"groups": []string{"researchers"},
+	}
+
+	env := newPollTestEnv(t)
+	env.idp.SetClaims(claimsWithoutPreferredUsername)
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("a login was activated with no preferred_username claim in the token, "+
+			"on the value of sub instead (#164): %+v", session)
+	}
+
+	event := env.auditEvent(t, "authentication_denied")
+	if event.ErrorCode != "USERNAME_CLAIM_MISSING" {
+		t.Errorf("denial recorded with error_code %q, want USERNAME_CLAIM_MISSING "+
+			"(nothing was wrong with the identity; the configured claim never arrived)", event.ErrorCode)
+	}
+	if !strings.Contains(event.ErrorMessage, "preferred_username") {
+		t.Errorf("the audited denial does not name the claim that was configured and missing: %q",
+			event.ErrorMessage)
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("a login with no configured username_claim in the token was recorded as successful (#164)")
+		}
+	}
+
+	// No credential of either kind: nothing in the key store, nothing authorized.
+	if _, err := env.broker.keyManager.LoadKey(env.session.ID); err == nil {
+		t.Error("a refused login left a key pair in the key store")
+	}
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a refused login installed a login key:\n%s", data)
+	}
+
+	// And the deployment the fix does not break: an operator whose IdP puts the login
+	// name in `sub` configures that, and the very same token is bound.
+	explicit := newPollTestEnv(t)
+	explicit.provider.Config.UserMapping.UsernameClaim = "sub"
+	explicit.idp.SetClaims(claimsWithoutPreferredUsername)
+	explicit.idp.Script(testoidc.Grant)
+
+	explicit.run(t)
+
+	if session := explicit.activeSession(); session == nil || !session.IsActive {
+		t.Error("username_claim: sub did not bind an identity whose sub is the local account")
+	}
+}
+
 // TestPrivilegedAccountRefusedOnTheRealPath drives #159 through the whole device
 // flow, not just the binding function: a completed, approved authorization whose
 // identity exactly matches a privileged local account must still be refused, leave

--- a/pkg/auth/identity_binding_test.go
+++ b/pkg/auth/identity_binding_test.go
@@ -223,6 +223,93 @@ func TestRootIsNotBindableViaEmailLocalPart(t *testing.T) {
 	}
 }
 
+// TestAbsentUsernameClaimBindsNothing is the gate for #164: when the configured
+// claim is not in the token, binding must fail, not quietly authorize on whichever
+// other claim the token happens to carry.
+//
+// claimToUsername substituted userInfo.Subject for an absent "preferred_username" or
+// "sub", and userInfo.Email for an absent "email". Every case here has a *non-empty*
+// Subject and Email, which is what the pre-existing coverage lacked: with an empty
+// Subject the fallback yielded "" and the empty-username check refused the login
+// anyway, so "claim absent in token fails closed" above passed against the defect.
+//
+// The local account is alice (uid 1001), so neither the privileged-account guard nor
+// a domain pin can be what refuses these — only the missing claim can.
+func TestAbsentUsernameClaimBindsNothing(t *testing.T) {
+	b := brokerForBinding()
+
+	cases := []struct {
+		name     string
+		claim    string
+		provider *OIDCProvider
+		userInfo *UserInfo
+	}{
+		{
+			// The headline case. preferred_username is what azure-ad.yaml, okta.yaml,
+			// keycloak.yaml and test/e2e/broker.yaml all configure, and a `sub` that is a
+			// login name is what LDAP/AD-backed and self-hosted IdPs commonly issue.
+			name:     "preferred_username absent while sub is a username",
+			claim:    "preferred_username",
+			provider: providerWithClaim("preferred_username"),
+			userInfo: &UserInfo{
+				Subject: "alice",
+				Email:   "alice@example.com",
+				Claims:  map[string]interface{}{"sub": "alice", "email": "alice@example.com"},
+			},
+		},
+		{
+			// With #159's opt-in in place the email fallback was live too: the domain is
+			// pinned and stripping is on, so the substituted address bound cleanly.
+			name:     "email absent under a pinned strip-domain mapping",
+			claim:    "email",
+			provider: providerWithMapping("email", true, "example.com"),
+			userInfo: &UserInfo{
+				Subject: "sub-alice",
+				Email:   "alice@example.com",
+				Claims:  map[string]interface{}{"sub": "sub-alice"},
+			},
+		},
+		{
+			// The third deleted branch. extractUserInfoFromClaims fills Subject from
+			// claims["sub"], so this shape needs a UserInfo assembled some other way —
+			// but the branch was reachable by claim name alone, so it is asserted by
+			// claim name too.
+			name:     "sub absent from the claim map",
+			claim:    "sub",
+			provider: providerWithClaim("sub"),
+			userInfo: &UserInfo{
+				Subject: "alice",
+				Email:   "alice@example.com",
+				Claims:  map[string]interface{}{"email": "alice@example.com"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := b.verifyIdentityBinding(tc.provider, tc.userInfo, "alice")
+			if err == nil {
+				t.Fatalf("an absent %q claim bound local user alice on another claim: this is #164", tc.claim)
+			}
+			if !errors.Is(err, ErrUsernameClaimMissing) {
+				t.Errorf("refused, but not as a missing claim, so the denial is audited as an "+
+					"identity mismatch and sends the operator after the wrong problem: %v", err)
+			}
+			// The operator's only lead is which claim they configured and did not get.
+			if !strings.Contains(err.Error(), tc.claim) {
+				t.Errorf("the error does not name the configured claim %q: %v", tc.claim, err)
+			}
+		})
+	}
+
+	// The deployment this does not break: `sub` is a perfectly good username_claim
+	// when the operator chooses it, which is the migration the error message points at.
+	userInfo := &UserInfo{Subject: "alice", Claims: map[string]interface{}{"sub": "alice"}}
+	if err := b.verifyIdentityBinding(providerWithClaim("sub"), userInfo, "alice"); err != nil {
+		t.Errorf("username_claim: sub did not bind an identity whose sub is the local account: %v", err)
+	}
+}
+
 // TestPrivilegedAccountGuardIsIndependentOfTheClaim covers the second acceptance
 // criterion of #159: the uid guard holds even when the claim is an exact match and
 // nothing about the mapping is misconfigured. It is the check that survives the


### PR DESCRIPTION
Fixes #164.

## The defect

`claimToUsername` did not fail when the configured `username_claim` was absent from
the token — it substituted a *different* claim: `userInfo.Subject` for
`preferred_username` and `sub`, `userInfo.Email` for `email`.

So if an IdP stopped returning the claim the operator named (a scope change, a
claim-mapper edit, a tenant migration), identity binding silently re-pointed at
`sub` — an identifier the operator never chose and never audited. `preferred_username`
is what `azure-ad.yaml`, `okta.yaml`, `keycloak.yaml` and `test/e2e/broker.yaml` all
configure, and for the many IdPs whose `sub` is an email or a username (LDAP/AD-backed
and self-hosted especially) the substituted value was then matched against local
account names, so #159's local-part matching applied to it as well. Nothing — no
error, no warning, no audit record — marked the change.

Everything else in `verifyIdentityBinding` already fails closed. This was the one
path that widened silently rather than failing.

## What changed

- `pkg/auth/broker.go`: the fallback is deleted. The configured claim is the only
  claim consulted; a token that does not carry it is refused with an error naming the
  claim and pointing at the provider's scopes and claim mapping. No session, no login
  key, no stored token. A `sub`-based deployment stays expressible as
  `username_claim: sub`, which reaches `Claims["sub"]` directly.
- New sentinel `ErrUsernameClaimMissing`, audited as `USERNAME_CLAIM_MISSING` rather
  than `IDENTITY_MISMATCH` — following the split #159 introduced for
  `PRIVILEGED_ACCOUNT_DENIED`. Nothing was wrong with the identity, every login
  through that provider is failing for the same reason, and the fix is in the provider
  or the config; recording it as a mismatch sends an operator after the wrong problem.
- The `verifyIdentityBinding` doc comment no longer describes a `preferred_username`
  fallback that does not exist, and errors from the claim lookup are wrapped with the
  provider name.
- `configs/CONFIGURATION-GUIDE.md`: one paragraph in the identity-binding section —
  the claim you name is the only claim consulted, refusals are audited as
  `USERNAME_CLAIM_MISSING`, use `username_claim: "sub"` if that is where your login
  name lives.
- `CHANGELOG.md`: first bullet under `## [Unreleased]` → `### Security`.

The fix composes with #159 rather than unpicking it: the strip-domain opt-in, the
domain pin and the privileged-account guard are untouched, and one of the new unit
cases is specifically the missing-`email` claim *under* a pinned strip-domain mapping,
which is the configuration in which the deleted fallback bound most cleanly.

## Tests

- `TestAbsentUsernameClaimBindsNothing` (`pkg/auth/identity_binding_test.go`): all
  three deleted branches, each with a **non-empty** `Subject` and `Email` — the
  acceptance criterion. Asserts refusal, `errors.Is(err, ErrUsernameClaimMissing)`,
  and that the message names the configured claim. Plus the positive control that
  `username_claim: sub` still binds.
- `TestAbsentUsernameClaimRefusedOnTheRealPath` (`pkg/auth/device_poll_test.go`): the
  full device-flow poll path against the in-process issuer, following the #158/#159
  pattern. Token grants, `preferred_username` is absent, `sub` is the local account
  name. Asserts no active session, `authentication_denied` with
  `USERNAME_CLAIM_MISSING` and the claim named in the audited message, no
  `authentication_successful` event, nothing in the key store, nothing in
  `authorized_keys` — and then that the same token succeeds with
  `username_claim: sub`.

### Regression gate

With the `switch claimName` fallback temporarily restored, both new tests fail and
name the real problem:

- the poll-path test reports an activated session (`IsActive:true`, a `TokenID`, an
  `SSHKeyID` and an installed public key) and `audit log has 0
  "authentication_denied" event(s) ... it recorded [authentication_successful]`;
- all three unit sub-cases report `an absent "<claim>" claim bound local user alice on
  another claim: this is #164`.

The fallback was then removed again and the suite re-run clean. Note that the
pre-existing "claim absent in token fails closed" table case passes either way — its
fixture has an empty `Subject`, which is exactly the condition that hid this branch.

## Verified

- `go build ./...`
- `gofmt -l pkg internal cmd` — no output
- `go test ./pkg/... ./internal/...` — all pass

## Deliberately left out

- No e2e case in `test/e2e/cases.sh`. `fakeoidc` always emits `preferred_username`
  (`/control/identity` sets it unconditionally), so covering this would mean adding a
  control endpoint that drops a claim — new harness surface for a case the in-process
  device-flow test already covers end to end. Nothing in e2e breaks.
- No cgo/C files touched, so no container run was needed.
- The shipped provider configs are unchanged: all of them name a claim their IdP does
  return, and the fix only removes what happened when one did not.