### PR TITLE
fix(auth): make allowed_groups deny the login instead of trimming the claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Low (#166): `allowed_groups` and `allowed_roles` denied nothing.** Both were
+  applied while claims were being read, where the only thing they could do was drop
+  the group and role names that were not in the list. A user in **none** of the
+  `allowed_groups` therefore reached the login decision with an empty group list and
+  was authenticated normally — the option that reads as an authorization gate was a
+  projection. The only thing that would have caught it is the global
+  `authentication.require_groups`, which is empty in every shipped config and, until
+  #158, was the only group key enforced at all. The severity is Low only because the
+  keys appear in no shipped YAML and in no document, so no deployment relies on
+  them; the exposure was to the first operator who found the struct field and
+  assumed the obvious meaning.
+
+  - Both are now login gates, enforced on the device-flow poll path in
+    `Broker.verifyGroupAuthorization`: a non-empty list the identity satisfies
+    nothing in refuses the authentication, leaving no session and no SSH key. An
+    empty list still means no restriction, which is what every existing deployment
+    depends on.
+  - They no longer touch the group or role list. `extractUserInfoFromClaims`
+    reports the identity as the IdP asserted it (`group_prefix` and
+    `group_mappings` are still projections), so the session, the audit record and
+    `require_groups` all see the same groups. Under the old code an identity that
+    *did* satisfy `require_groups` could be refused by it, because the allowlist had
+    already removed the group it was being required to have.
+  - `require_groups` and the allowlists meet in one function rather than becoming
+    two competing checks, because they ask different questions and cannot be one
+    list: `require_groups` demands *every* group it names, an allowlist demands *at
+    least one*. Refusals are audited apart — `GROUP_NOT_ALLOWED` against
+    `GROUP_DENIED` — since they send an operator to different config keys.
+    Case-insensitive matching for the allowlists is kept as it was, so this changes
+    what a non-match does and not what matches.
+
+  Coverage: five cases in `device_poll_test.go`, all through the real poll loop as
+  #158's are — refusal with no session, no key and no success record; a member
+  admitted with *all* of its groups; an empty list restricting nothing;
+  `allowed_roles` on its own; and the three-way composition with `require_groups`.
+  Re-applying the filter makes four of them fail, one of them (`required but not
+  allowed`) by demonstrating the interaction above.
 - **High (#164): if the identity provider stopped returning the configured
   `username_claim`, the authorization decision moved silently to `sub`.** An absent
   `preferred_username` or `sub` claim was substituted with `userInfo.Subject`, and an

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -968,14 +968,28 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 			// the form QUICK-START.md and DEPLOYMENT.md both tell operators to use —
 			// was collected into PolicyResult.RequiredGroups and then never read by
 			// anything, so the documented config enforced no groups at all.
-			if err := b.verifyRequiredGroups(requiredGroups, userInfo.Groups); err != nil {
+			//
+			// (#166) The provider's allowed_groups/allowed_roles are decided here too,
+			// so there is one group-authorization decision on the login path rather
+			// than a second, weaker one buried in claim extraction.
+			if err := b.verifyGroupAuthorization(provider.Config.UserMapping, requiredGroups, userInfo); err != nil {
+				// The two refusals point at different config keys and at opposite
+				// mistakes — "missing a mandatory group" against "in none of the
+				// permitted ones" — so they are audited apart (#166).
+				errCode := "GROUP_DENIED"
+				message := "Rejected authentication: required group membership not satisfied"
+				if errors.Is(err, ErrGroupNotAllowed) {
+					errCode = "GROUP_NOT_ALLOWED"
+					message = "Rejected authentication: identity is in none of the allowed groups or roles"
+				}
 				log.Warn().
 					Err(err).
 					Str("session_id", session.ID).
 					Str("requested_user", session.UserID).
-					Msg("Rejected authentication: required group membership not satisfied")
+					Str("error_code", errCode).
+					Msg(message)
 				if b.metrics != nil {
-					b.metrics.RecordAuth(provider.Name, "failure", "GROUP_DENIED")
+					b.metrics.RecordAuth(provider.Name, "failure", errCode)
 				}
 				b.auditLogger.LogAuthEvent(security.AuditEvent{
 					EventType:    "authentication_denied",
@@ -984,7 +998,7 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 					Groups:       userInfo.Groups,
 					SessionID:    session.ID,
 					Success:      false,
-					ErrorCode:    "GROUP_DENIED",
+					ErrorCode:    errCode,
 					ErrorMessage: err.Error(),
 					Timestamp:    time.Now(),
 				})
@@ -1596,6 +1610,69 @@ func classifyPollError(err error) string {
 	default:
 		return "POLL_FAILED"
 	}
+}
+
+// ErrGroupNotAllowed marks a refusal by a provider's allowed_groups or
+// allowed_roles, as opposed to one by require_groups. The caller audits the two
+// with different error codes because they send an operator to different config
+// keys (#166).
+var ErrGroupNotAllowed = errors.New("identity is in none of the allowed groups or roles")
+
+// verifyGroupAuthorization is the single point at which a login is accepted or
+// refused on group membership. Two independently configured lists meet here, and
+// they are not the same gate:
+//
+//   - required — authentication.require_groups plus the require_groups of every
+//     matching per-resource policy, as resolved by the policy engine — is a
+//     conjunction: the user must be in all of them.
+//   - mapping.AllowedGroups / AllowedRoles, set per provider under user_mapping,
+//     is a disjunction: the user must be in at least one.
+//
+// In both cases an empty list means no restriction, and a non-empty list the
+// identity satisfies nothing in means the login is refused. They cannot be folded
+// into one list — "all of these" and "at least one of these" are different
+// questions, and an operator who writes both means both — so they are enforced
+// side by side rather than in two places. #166 was exactly the cost of the second
+// arrangement: allowed_groups was applied during claim extraction, where the only
+// thing it could do was shrink the group list, so a user in none of the allowed
+// groups logged in with no groups at all.
+//
+// The one asymmetry left is case: require_groups compares exactly, the allowlists
+// case-insensitively. Each keeps the comparison it already had, so this fix changes
+// no operator's matching, only what a non-match does.
+func (b *Broker) verifyGroupAuthorization(mapping config.UserMapping, required []string, userInfo *UserInfo) error {
+	if err := b.verifyRequiredGroups(required, userInfo.Groups); err != nil {
+		return err
+	}
+	if err := verifyGroupAllowlist("group", mapping.AllowedGroups, userInfo.Groups); err != nil {
+		return err
+	}
+	return verifyGroupAllowlist("role", mapping.AllowedRoles, userInfo.Roles)
+}
+
+// verifyGroupAllowlist refuses an identity that holds none of the allowed names.
+// An empty allowlist permits everything: that is the shipped default, and every
+// deployment that has never heard of the key depends on it.
+//
+// Matching is case-insensitive, which is what the old projection did. Only the
+// consequence of a non-match changes here; changing the comparison rule at the
+// same time would be a second, silent behaviour change for anyone who did set the
+// key.
+func verifyGroupAllowlist(kind string, allowed, have []string) error {
+	if len(allowed) == 0 {
+		return nil
+	}
+	permitted := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		permitted[strings.ToLower(a)] = struct{}{}
+	}
+	for _, h := range have {
+		if _, ok := permitted[strings.ToLower(h)]; ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: user is in none of the allowed %ss: %s",
+		ErrGroupNotAllowed, kind, strings.Join(allowed, ", "))
 }
 
 // verifyRequiredGroups enforces that the authenticated user is a member of every

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -838,17 +838,12 @@ func (p *OIDCProvider) extractUserInfoFromClaims(claims map[string]interface{}) 
 						}
 					}
 
-					// Enforce allowlist if configured — drop groups not in the set.
-					if len(mapping.AllowedGroups) > 0 {
-						allowed := make(map[string]bool, len(mapping.AllowedGroups))
-						for _, g := range mapping.AllowedGroups {
-							allowed[strings.ToLower(g)] = true
-						}
-						if !allowed[strings.ToLower(groupStr)] {
-							continue
-						}
-					}
-
+					// allowed_groups is deliberately *not* applied here. It used to drop
+					// every group outside the set, which left a user who was in none of
+					// them holding an empty group list and authenticating normally — an
+					// option named allowed_* that denied nothing (#166). It is a login
+					// gate now, enforced once in Broker.verifyGroupAuthorization, and
+					// this function's job is only to report the identity as it is.
 					userInfo.Groups = append(userInfo.Groups, groupStr)
 				}
 			}
@@ -860,16 +855,8 @@ func (p *OIDCProvider) extractUserInfoFromClaims(claims map[string]interface{}) 
 		if roles, ok := claims[mapping.RolesClaim].([]interface{}); ok {
 			for _, role := range roles {
 				if roleStr, ok := role.(string); ok {
-					// Enforce allowlist if configured — drop roles not in the set.
-					if len(mapping.AllowedRoles) > 0 {
-						allowed := make(map[string]bool, len(mapping.AllowedRoles))
-						for _, r := range mapping.AllowedRoles {
-							allowed[strings.ToLower(r)] = true
-						}
-						if !allowed[strings.ToLower(roleStr)] {
-							continue
-						}
-					}
+					// As with allowed_groups above: allowed_roles denies the login in
+					// the broker rather than trimming this list (#166).
 					userInfo.Roles = append(userInfo.Roles, roleStr)
 				}
 			}

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -810,6 +810,191 @@ func TestAbsentUsernameClaimRefusedOnTheRealPath(t *testing.T) {
 	}
 }
 
+// TestAllowedGroupsDenyTheLogin is the acceptance gate for #166: a user in none of
+// a provider's allowed_groups must be refused, not admitted with a trimmed group
+// list.
+//
+// The old code applied the allowlist inside claim extraction, where the only thing
+// it could do was drop groups. An identity in none of the allowed groups therefore
+// arrived at the enforcement point with Groups == nil — which
+// verifyRequiredGroups happily accepts when require_groups is empty, as it is in
+// every shipped config — and got a session and a login key. This has to run through
+// the poll loop for the same reason #158 did: the check was never the problem, its
+// position on the login path was.
+func TestAllowedGroupsDenyTheLogin(t *testing.T) {
+	env := newPollTestEnv(t)
+
+	// The issuer's identity is in "researchers" and nothing else, and
+	// require_groups is deliberately left empty: allowed_groups alone has to
+	// refuse this login.
+	env.provider.Config.UserMapping.AllowedGroups = []string{"hpc-admins"}
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("a user in none of the allowed_groups was authenticated: %+v", session)
+	}
+
+	event := env.auditEvent(t, "authentication_denied")
+	if event.ErrorCode != "GROUP_NOT_ALLOWED" {
+		t.Errorf("denial recorded with error_code %q, want GROUP_NOT_ALLOWED "+
+			"(nothing was missing from a required set; the identity is outside the permitted one)",
+			event.ErrorCode)
+	}
+	if event.Success {
+		t.Error("the denial event is recorded with success=true")
+	}
+	// The record has to name what the identity actually held, or an operator cannot
+	// tell which group to add. The old projection would have emptied this.
+	if len(event.Groups) != 1 || event.Groups[0] != "researchers" {
+		t.Errorf("audited groups = %v, want [researchers] — the groups the identity has, "+
+			"not the ones that survived a filter", event.Groups)
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("a user in none of the allowed_groups was recorded as a successful login (#166)")
+		}
+	}
+
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a refused login installed a login key:\n%s", data)
+	}
+}
+
+// The other half of #166's semantics: allowed_groups is a gate, so a user who is in
+// one of the allowed groups gets in — and keeps every group the IdP gave them.
+// Trimming the list here would leave the session, the audit trail and any
+// require_groups check downstream reasoning about an identity the IdP never
+// asserted.
+func TestAllowedGroupsAdmitAMemberWithAllItsGroups(t *testing.T) {
+	env := newPollTestEnv(t)
+
+	env.idp.SetClaims(map[string]any{
+		"sub":                "test-subject",
+		"preferred_username": "testuser",
+		"email":              "testuser@example.org",
+		"groups":             []string{"researchers", "hpc-users"},
+	})
+	// Case-insensitively matching one of the two is enough; the allowlist is a
+	// disjunction, and it does not have to name "hpc-users" for that group to
+	// survive.
+	env.provider.Config.UserMapping.AllowedGroups = []string{"Researchers"}
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	session := env.activeSession()
+	if session == nil || !session.IsActive {
+		t.Fatal("a member of an allowed group was refused")
+	}
+	if len(session.Groups) != 2 || session.Groups[0] != "researchers" || session.Groups[1] != "hpc-users" {
+		t.Errorf("session groups = %v, want [researchers hpc-users]: allowed_groups gates the login, "+
+			"it does not filter the claim (#166)", session.Groups)
+	}
+}
+
+// An unset allowlist restricts nothing. This is the shipped default and what every
+// deployment that has never set the key relies on, so it is worth an explicit gate
+// rather than an inference from the other tests passing.
+func TestEmptyAllowedGroupsRestrictNothing(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.provider.Config.UserMapping.AllowedGroups = nil
+	env.provider.Config.UserMapping.AllowedRoles = nil
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session == nil || !session.IsActive {
+		t.Error("an empty allowed_groups refused a login; empty means unrestricted")
+	}
+}
+
+// allowed_roles is the same gate over a different claim, and it was the same defect.
+func TestAllowedRolesDenyTheLogin(t *testing.T) {
+	env := newPollTestEnv(t)
+
+	env.provider.Config.UserMapping.RolesClaim = "roles"
+	env.provider.Config.UserMapping.AllowedRoles = []string{"cluster-admin"}
+	env.idp.SetClaims(map[string]any{
+		"sub":                "test-subject",
+		"preferred_username": "testuser",
+		"email":              "testuser@example.org",
+		"groups":             []string{"researchers"},
+		"roles":              []string{"guest"},
+	})
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("a user holding none of the allowed_roles was authenticated: %+v", session)
+	}
+	if event := env.auditEvent(t, "authentication_denied"); event.ErrorCode != "GROUP_NOT_ALLOWED" {
+		t.Errorf("denial recorded with error_code %q, want GROUP_NOT_ALLOWED", event.ErrorCode)
+	}
+}
+
+// require_groups and allowed_groups now meet in one function, so the composition of
+// the two has to be pinned: each refuses on its own, each refusal keeps its own
+// error code, and satisfying one does not excuse the other.
+func TestRequireGroupsAndAllowedGroupsCompose(t *testing.T) {
+	tests := []struct {
+		name          string
+		required      []string
+		allowed       []string
+		wantSession   bool
+		wantErrorCode string
+	}{
+		{
+			name:        "satisfies both",
+			required:    []string{"researchers"},
+			allowed:     []string{"researchers"},
+			wantSession: true,
+		},
+		{
+			// In an allowed group, but missing a group the policy demands.
+			name:          "allowed but not required",
+			required:      []string{"hpc-admins"},
+			allowed:       []string{"researchers"},
+			wantErrorCode: "GROUP_DENIED",
+		},
+		{
+			// Holds everything require_groups asks for and is still outside the
+			// permitted set. This is the case the old code could not express at all.
+			name:          "required but not allowed",
+			required:      []string{"researchers"},
+			allowed:       []string{"hpc-admins"},
+			wantErrorCode: "GROUP_NOT_ALLOWED",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newPollTestEnv(t)
+			env.requiredGroups = tc.required
+			env.provider.Config.UserMapping.AllowedGroups = tc.allowed
+			env.idp.Script(testoidc.Grant)
+
+			env.run(t)
+
+			session := env.activeSession()
+			if tc.wantSession {
+				if session == nil || !session.IsActive {
+					t.Fatal("the login was refused although it satisfies both group settings")
+				}
+				return
+			}
+			if session != nil {
+				t.Errorf("the session survived a refused login: %+v", session)
+			}
+			if event := env.auditEvent(t, "authentication_denied"); event.ErrorCode != tc.wantErrorCode {
+				t.Errorf("denial recorded with error_code %q, want %q", event.ErrorCode, tc.wantErrorCode)
+			}
+		})
+	}
+}
+
 // TestPrivilegedAccountRefusedOnTheRealPath drives #159 through the whole device
 // flow, not just the binding function: a completed, approved authorization whose
 // identity exactly matches a privileged local account must still be refused, leave

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,8 +92,19 @@ type UserMapping struct {
 	DisplayNameTemplate string            `mapstructure:"display_name_template"`
 	GroupPrefix         string            `mapstructure:"group_prefix"`
 	GroupMappings       map[string]string `mapstructure:"group_mappings"`
-	AllowedGroups       []string          `mapstructure:"allowed_groups"`
-	AllowedRoles        []string          `mapstructure:"allowed_roles"`
+
+	// AllowedGroups and AllowedRoles gate the login: when either is non-empty the
+	// identity must hold at least one of the names in it, or the authentication is
+	// refused with GROUP_NOT_ALLOWED. Empty means no restriction. Matching is
+	// case-insensitive, and both are enforced in addition to — not instead of —
+	// authentication.require_groups, which demands *every* group it names.
+	//
+	// Until #166 these filtered the group and role lists instead of deciding the
+	// login, so an identity in none of the allowed groups authenticated with an
+	// empty group list. They no longer alter what the session or the audit trail
+	// records the identity as holding; see Broker.verifyGroupAuthorization.
+	AllowedGroups []string `mapstructure:"allowed_groups"`
+	AllowedRoles  []string `mapstructure:"allowed_roles"`
 }
 
 // ResearchPolicies contains research computing specific policies


### PR DESCRIPTION
Fixes #166.

## The defect

`allowed_groups` and `allowed_roles` were applied inside
`extractUserInfoFromClaims` (`pkg/auth/device_flow.go`), one claim value at a time,
where the only thing an allowlist can do is `continue` — drop the name from the list
being built. So a user in **none** of the `allowed_groups` did not get refused; they
got `userInfo.Groups == nil` and authenticated normally, with a session and an SSH
key. The only thing that would have caught it is the global
`authentication.require_groups`, which is empty in every shipped config and, until
#158, was not enforced from the per-policy form operators are actually told to write.

Severity is Low because the keys appear in no shipped YAML and no document, so no
deployment relies on them. The exposure was to the first operator who found the
struct field and assumed the meaning the name states.

There was a second, quieter consequence: because the allowlist trimmed the list
*before* `require_groups` read it, an identity that genuinely satisfied
`require_groups` could be refused by it — the group it was required to have had
already been filtered out.

## What changed

- **`allowed_groups` / `allowed_roles` are gates, not projections.** A non-empty list
  the identity satisfies nothing in refuses the authentication; an empty list means no
  restriction (the shipped default, and what every existing deployment depends on).
  Refusal happens on the device-flow poll path, so it produces no session and no SSH
  key, and is audited as `GROUP_NOT_ALLOWED` — distinguishable from the
  `GROUP_DENIED` that `require_groups` produces, because the two send an operator to
  different config keys.
- **They no longer touch the group or role list.** `extractUserInfoFromClaims` now
  reports the identity as the IdP asserted it; `group_prefix` and `group_mappings`
  remain projections, as they should be. This is what makes the session, the audit
  record and `require_groups` agree on one group list.
- **`require_groups` and the allowlists meet in one place**, `Broker.verifyGroupAuthorization`,
  called from `pollDeviceAuthorization` where #158 put the `require_groups` check.
  They deliberately are *not* collapsed into one list: `require_groups` is a
  conjunction (every group it names) and an allowlist is a disjunction (at least one),
  so an operator who writes both means both. Enforcing them side by side in one
  function is what keeps them from becoming two competing checks in two places, which
  is what #166 was.
- The allowlists keep their **case-insensitive** comparison, which is what the old
  filter used; `require_groups` keeps its exact one. Only the consequence of a
  non-match changes, so nobody's matching behaviour moves under them. The asymmetry is
  documented on `verifyGroupAuthorization`.
- `pkg/config/config.go` documents both fields: what empty means, what non-empty
  means, and that they are additional to `require_groups`.

## Verification

- `go build ./...`, `gofmt -l pkg internal cmd` (no output), `go test ./pkg/... ./internal/...`
  — all clean. `golangci-lint run pkg/auth/... pkg/config/...`: 0 issues.
- Five new cases in `pkg/auth/device_poll_test.go`, driven through the real
  `pollDeviceAuthorization` loop against the in-process issuer, following #158's
  pattern: refusal (no session, no key, no `authentication_successful` record,
  `GROUP_NOT_ALLOWED`, and the audited groups still naming what the identity holds);
  a member admitted with *all* of its groups; an empty allowlist restricting nothing;
  `allowed_roles` on its own; and the three-way composition with `require_groups`.
- **Regression gate.** With the filtering restored in `extractUserInfoFromClaims` and
  the allowlist call removed from `verifyGroupAuthorization`, four of the five fail,
  naming the real problem:
  - `TestAllowedGroupsDenyTheLogin`: "a user in none of the allowed_groups was
    authenticated" with `Groups:[] ... IsActive:true` and an `SSHKeyID`, plus
    "audit log has 0 "authentication_denied" event(s) ... it recorded
    [authentication_successful]".
  - `TestAllowedRolesDenyTheLogin`: the same for roles.
  - `TestAllowedGroupsAdmitAMemberWithAllItsGroups`: "session groups = [researchers],
    want [researchers hpc-users]" — the projection at work.
  - `TestRequireGroupsAndAllowedGroupsCompose/required_but_not_allowed`: recorded
    `GROUP_DENIED` instead of `GROUP_NOT_ALLOWED`, which is the bad interaction
    described above showing up on its own: the user *is* in `researchers`, the
    allowlist removed it, and `require_groups` then refused them for lacking a group
    they have.
  - `TestEmptyAllowedGroupsRestrictNothing` passes either way, as it must — an unset
    allowlist behaved correctly before and still does.

## Judgement calls, and what is left out

- The issue offered a rename to `group_filter` as the alternative; I took the deny, as
  it preferred.
- **Dropping the projection was my call**, and it goes slightly beyond the issue's
  literal fix ("deny when the intersection is empty"). Keeping both would mean a
  user who passes the gate still gets a truncated group list, which is what makes
  `require_groups` misfire; a gate that also rewrites the identity is the trap in a
  smaller form.
- No config or doc wording to fix: `grep -rni 'allowed_group|allowed_role|group_filter'`
  hits only `pkg/config/config.go`, exactly as the issue says. I did not add the keys
  to any shipped YAML — enforcing something no config mentions is the fix; advertising
  it is a separate decision.
- No C files touched, so no container run was needed.
- `verifyRequiredGroups`'s own case-sensitivity is untouched. Harmonising it would
  change behaviour for the deployments that *do* set `require_groups`, which is not
  this issue.
