### PR TITLE
fix(ssh): keep authorized_keys newline-terminated and stop auditing no-op revocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `allowed_roles` on its own; and the three-way composition with `require_groups`.
   Re-applying the filter makes four of them fail, one of them (`required but not
   allowed`) by demonstrating the interaction above.
+- **High (#165): after any expiry sweep, the next login's SSH key became
+  permanently unrevocable while the audit log reported it as revoked.** The sweep
+  rewrote `authorized_keys` from a `bufio.Scanner`, which strips newlines, and
+  joined the survivors without restoring the final one — so the file was left
+  unterminated. `AddPublicKey` appends with `O_APPEND`, so the user's next login
+  fused its `# Added by OIDC PAM on …` comment onto the last surviving key line.
+  sshd still honours the key on such a line, but nothing can remove it again: the
+  sweep can no longer parse the timestamp out of `…@oidc-pam-1770000000# Added by…`
+  and so retains the key (fail-safe by design), and targeted revocation compares
+  the whole line and no longer matches. `RemovePublicKey` returned `nil` for "no
+  such line" exactly as it did for a real removal, so the broker went on to log
+  `SSH key revoked` at Info and record a revoke-success metric for a removal that
+  changed nothing. No attacker is needed: one expired key plus one later login.
+
+  - Both rewrite paths now go through one writer, `writeAuthorizedKeysLines`, which
+    guarantees the file ends in exactly one newline. The two paths previously
+    derived the file's tail independently — `RemovePublicKey` split on `"\n"` and
+    happened to be correct, the sweep did not — and sharing the writer is what
+    stops them disagreeing again.
+  - `AddPublicKey` terminates an unterminated last line before appending, so a file
+    left that way by anything else (a user's editor, a broker from before this fix)
+    cannot fuse the next key either.
+  - `RemovePublicKey` now returns `(removed bool, err error)`. A caller cannot
+    silently mistake "there was no such line" for "the line is gone"; `removed=false`
+    with a nil error means the entry is still there.
+  - `revokeSSHKey` audits the two outcomes separately: `ssh_key_revoked`
+    (`success=true`) only when an `authorized_keys` line was actually removed, and
+    otherwise `ssh_key_revocation_incomplete` with
+    `ErrorCode=AUTHORIZED_KEYS_ENTRY_NOT_REMOVED` and a revoke-**failure** metric,
+    naming the user and session so an operator can find the file.
+  - Note for operators: entries already fused by this defect are not repaired by
+    the fix — they are indistinguishable from a legitimate key whose comment field
+    contains a `#`. Grep for `# Added by OIDC PAM` on a line that does not start
+    with `#` and delete those lines by hand.
 - **High (#164): if the identity provider stopped returning the configured
   `username_claim`, the authorization decision moved silently to `sub`.** An absent
   `preferred_username` or `sub` claim was substituted with `userInfo.Subject`, and an

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -1308,7 +1308,8 @@ func (b *Broker) revokeSSHKey(session *Session) error {
 	}
 
 	// Remove from authorized_keys (best effort — do not abort on failure)
-	if err := b.authorizedKeysManager.RemovePublicKey(session.UserID, sshKey.PublicKey); err != nil {
+	removed, err := b.authorizedKeysManager.RemovePublicKey(session.UserID, sshKey.PublicKey)
+	if err != nil {
 		log.Warn().
 			Err(err).
 			Str("session_id", session.ID).
@@ -1324,11 +1325,54 @@ func (b *Broker) revokeSSHKey(session *Session) error {
 		return fmt.Errorf("failed to delete SSH key files: %w", err)
 	}
 
+	// The authorized_keys line is what grants the access, so only its removal is a
+	// revocation. A no-match means the credential is still authorized, and #165 was
+	// exactly this outcome being reported as "SSH key revoked" with a success metric:
+	// the audit trail asserted a revocation that had not happened, for a line that
+	// (having been fused with a comment) could no longer be removed by anything.
+	// Still best effort — the session is gone either way — but audited as the failure
+	// it is, so an operator can find the host and the file.
+	if !removed {
+		log.Warn().
+			Str("session_id", session.ID).
+			Str("user_id", session.UserID).
+			Str("ssh_key_id", session.SSHKeyID).
+			Msg("SSH key files deleted but no matching authorized_keys entry was removed")
+
+		if b.auditLogger != nil {
+			b.auditLogger.LogAuthEvent(security.AuditEvent{
+				EventType:    "ssh_key_revocation_incomplete",
+				UserID:       session.UserID,
+				Email:        session.Email,
+				SessionID:    session.ID,
+				Success:      false,
+				ErrorCode:    "AUTHORIZED_KEYS_ENTRY_NOT_REMOVED",
+				ErrorMessage: "no authorized_keys line matched the revoked key; it may still authorize access",
+				Timestamp:    time.Now(),
+			})
+		}
+		if b.metrics != nil {
+			b.metrics.RecordSSHKeyOp("revoke", "failure")
+		}
+
+		return nil
+	}
+
 	log.Info().
 		Str("session_id", session.ID).
 		Str("ssh_key_id", session.SSHKeyID).
 		Msg("SSH key revoked")
 
+	if b.auditLogger != nil {
+		b.auditLogger.LogAuthEvent(security.AuditEvent{
+			EventType: "ssh_key_revoked",
+			UserID:    session.UserID,
+			Email:     session.Email,
+			SessionID: session.ID,
+			Success:   true,
+			Timestamp: time.Now(),
+		})
+	}
 	if b.metrics != nil {
 		b.metrics.RecordSSHKeyOp("revoke", "success")
 	}

--- a/pkg/auth/key_revocation_test.go
+++ b/pkg/auth/key_revocation_test.go
@@ -1,0 +1,257 @@
+package auth
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	oidcmetrics "github.com/scttfrdmn/oidc-pam/pkg/metrics"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
+)
+
+// revokeTestEnv is a broker wired up for revocation only: real key storage, a real
+// authorized_keys tree, and — the point of the fixture — a file-backed audit logger
+// and a metrics registry, because #165 was a *reporting* defect. A disabled logger
+// cannot show a revocation being claimed for a key that is still authorized.
+type revokeTestEnv struct {
+	broker    *Broker
+	homeDir   string
+	auditPath string
+	registry  *prometheus.Registry
+}
+
+func newRevokeTestEnv(t *testing.T) *revokeTestEnv {
+	t.Helper()
+
+	// "sync" writes on the calling goroutine, so nothing is left buffered when
+	// revokeSSHKey returns and the test never has to wait for a flush.
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{
+		Enabled:          true,
+		Outputs:          []config.AuditOutput{{Type: "file", Path: auditPath}},
+		OverflowStrategy: "sync",
+	})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = auditLogger.Stop() })
+
+	keyManager := sshpkg.NewKeyManager(t.TempDir())
+	keyManager.SetKeySize(2048) // this test is about bookkeeping, not RSA
+
+	registry := prometheus.NewRegistry()
+	homeDir := t.TempDir()
+
+	broker := &Broker{
+		config:                &config.Config{},
+		sessions:              make(map[string]*Session),
+		providers:             map[string]*OIDCProvider{},
+		auditLogger:           auditLogger,
+		keyManager:            keyManager,
+		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
+		metrics:               oidcmetrics.New(registry, nil),
+	}
+
+	return &revokeTestEnv{broker: broker, homeDir: homeDir, auditPath: auditPath, registry: registry}
+}
+
+// provision generates a key for a session and authorizes it, returning the session
+// ready to be revoked.
+func (e *revokeTestEnv) provision(t *testing.T, username string) *Session {
+	t.Helper()
+
+	session := &Session{
+		ID:           "a3f1c9d2e5b48706" + username,
+		UserID:       username,
+		Email:        username + "@example.com",
+		CreatedAt:    time.Now(),
+		ExpiresAt:    time.Now().Add(time.Hour),
+		LastAccessed: time.Now(),
+		IsActive:     true,
+	}
+	sshKey, err := e.broker.generateSSHKey(session)
+	if err != nil {
+		t.Fatalf("generateSSHKey: %v", err)
+	}
+	session.SSHKeyID = sshKey.ID
+	session.SSHPublicKey = sshKey.PublicKey
+	return session
+}
+
+func (e *revokeTestEnv) authorizedKeys(t *testing.T, username string) string {
+	t.Helper()
+
+	path := filepath.Join(e.homeDir, username, ".ssh", "authorized_keys")
+	data, err := os.ReadFile(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("ReadFile %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// auditEventTypes returns the event types recorded so far, in order. Nil when
+// nothing was recorded, so a test can assert on an absence.
+func (e *revokeTestEnv) auditEventTypes(t *testing.T) []string {
+	t.Helper()
+
+	var types []string
+	for _, event := range e.auditEvents(t) {
+		types = append(types, event.EventType)
+	}
+	return types
+}
+
+func (e *revokeTestEnv) auditEvents(t *testing.T) []security.AuditEvent {
+	t.Helper()
+
+	data, err := os.ReadFile(e.auditPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("reading the audit log: %v", err)
+	}
+
+	var events []security.AuditEvent
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var event security.AuditEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("audit line %q is not a valid event: %v", line, err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+// revokeMetric returns the oidc_ssh_key_operations_total counter for
+// operation="revoke" and the given result.
+func (e *revokeTestEnv) revokeMetric(t *testing.T, result string) float64 {
+	t.Helper()
+
+	families, err := e.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != "oidc_ssh_key_operations_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if labelsMatch(metric, map[string]string{"operation": "revoke", "result": result}) {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func labelsMatch(metric *dto.Metric, want map[string]string) bool {
+	got := make(map[string]string, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		got[label.GetName()] = label.GetValue()
+	}
+	for name, value := range want {
+		if got[name] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// The positive control: a revocation that really removes the authorized_keys line
+// is the only thing allowed to produce ssh_key_revoked.
+func TestRevocationThatRemovesTheKeyIsAuditedAsSuccess(t *testing.T) {
+	env := newRevokeTestEnv(t)
+	session := env.provision(t, "alice")
+
+	if err := env.broker.revokeSSHKey(session); err != nil {
+		t.Fatalf("revokeSSHKey: %v", err)
+	}
+
+	if remaining := env.authorizedKeys(t, "alice"); strings.Contains(remaining, strings.TrimSpace(session.SSHPublicKey)) {
+		t.Error("the revoked key is still in authorized_keys")
+	}
+	if got := env.auditEventTypes(t); !recorded(got, "ssh_key_revoked") {
+		t.Errorf("a successful revocation recorded %v, want an ssh_key_revoked event", got)
+	}
+	if got := env.revokeMetric(t, "success"); got != 1 {
+		t.Errorf("revoke success metric = %v, want 1", got)
+	}
+	if got := env.revokeMetric(t, "failure"); got != 0 {
+		t.Errorf("revoke failure metric = %v, want 0", got)
+	}
+}
+
+// #165: a removal that matched nothing must not be audited as a revocation. The
+// entry is still in the file (or, as in the #165 sequence, fused with a comment and
+// no longer matchable at all), so "SSH key revoked" would be a false statement in
+// the record an operator is meant to trust.
+func TestRevocationThatMatchesNothingIsNotAuditedAsSuccess(t *testing.T) {
+	env := newRevokeTestEnv(t)
+	session := env.provision(t, "bob")
+
+	// Stand in for the state #165 produces: the line the broker would look for is
+	// no longer there to be matched, but something is.
+	path := filepath.Join(env.homeDir, "bob", ".ssh", "authorized_keys")
+	survivor := strings.TrimSpace(session.SSHPublicKey) + "# Added by OIDC PAM on 2026-08-13 12:00:00\n"
+	if err := os.WriteFile(path, []byte(survivor), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := env.broker.revokeSSHKey(session); err != nil {
+		t.Fatalf("revokeSSHKey: %v", err)
+	}
+
+	types := env.auditEventTypes(t)
+	if recorded(types, "ssh_key_revoked") {
+		t.Errorf("the audit log claims ssh_key_revoked for a removal that matched nothing (#165); events: %v", types)
+	}
+	if !recorded(types, "ssh_key_revocation_incomplete") {
+		t.Errorf("a revocation that removed nothing recorded %v, want an ssh_key_revocation_incomplete event", types)
+	}
+	for _, event := range env.auditEvents(t) {
+		if event.EventType != "ssh_key_revocation_incomplete" {
+			continue
+		}
+		if event.Success {
+			t.Error("the incomplete-revocation event is marked successful")
+		}
+		if event.UserID != "bob" || event.SessionID != session.ID {
+			t.Errorf("event does not identify the affected user and session: user_id=%q session_id=%q",
+				event.UserID, event.SessionID)
+		}
+	}
+	if got := env.revokeMetric(t, "success"); got != 0 {
+		t.Errorf("revoke success metric = %v for a removal that matched nothing, want 0", got)
+	}
+	if got := env.revokeMetric(t, "failure"); got != 1 {
+		t.Errorf("revoke failure metric = %v, want 1", got)
+	}
+	// The line that could not be revoked is still there; the audit trail now says so.
+	if remaining := env.authorizedKeys(t, "bob"); !strings.Contains(remaining, "# Added by OIDC PAM") {
+		t.Errorf("the unmatched line was removed after all; file is %q", remaining)
+	}
+}
+
+func recorded(eventTypes []string, eventType string) bool {
+	for _, t := range eventTypes {
+		if t == eventType {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -225,6 +225,34 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
 	return nil
 }
 
+// writeAuthorizedKeysLines renders the surviving lines back to authorized_keys,
+// guaranteeing the file ends in exactly one newline.
+//
+// (#165) Both rewrite paths go through this because they used to disagree, and one
+// of them was wrong: RemovePublicKey split on "\n" — which keeps a trailing empty
+// element, so Join restored the final newline — while RemoveExpiredKeys used a
+// bufio.Scanner, which drops it. A file left without a final newline is not merely
+// untidy: AddPublicKey appends with O_APPEND, so the next login fused its
+// "# Added by OIDC PAM" comment onto the last surviving key line. The resulting
+// entry still authorizes its holder but can never be removed again — the expiry
+// sweep can no longer parse its timestamp and targeted revocation no longer matches
+// the line — while the broker audited the failed removal as a success.
+//
+// Sharing one write path is the point: two callers deriving the file's tail
+// independently is what allowed them to differ in the first place.
+func writeAuthorizedKeysLines(sshDir, path string, lines []string) error {
+	// Trailing blanks are dropped so that a caller's choice of line splitting
+	// cannot change the file's tail, then the last real line is terminated.
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	var content []byte
+	if len(lines) > 0 {
+		content = []byte(strings.Join(lines, "\n") + "\n")
+	}
+	return writeAuthorizedKeysAtomic(sshDir, path, content)
+}
+
 // AuthorizedKeysManager manages authorized_keys files for users
 type AuthorizedKeysManager struct {
 	baseDir     string
@@ -288,8 +316,15 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 	return withFileLock(lockPath, akm.lockTimeout, func() error {
 		// Read existing authorized_keys file
 		var existingKeys []string
+		// (#165) Whether the file needs a newline before this append. The rewrite
+		// paths now always leave one, but the file belongs to the user and can be
+		// edited by anything: appending to a file whose last line is unterminated
+		// fuses the comment below onto that line, producing an entry no remover can
+		// ever match again. Cheap to check here, and it is the last chance to.
+		needsSeparator := false
 		if data, err := os.ReadFile(authorizedKeysPath); err == nil {
 			existingKeys = strings.Split(string(data), "\n")
+			needsSeparator = len(data) > 0 && data[len(data)-1] != '\n'
 		}
 
 		// Check if key already exists
@@ -309,6 +344,12 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 			return fmt.Errorf("failed to open authorized_keys file: %w", err)
 		}
 		defer func() { _ = file.Close() }()
+
+		if needsSeparator {
+			if _, err := file.WriteString("\n"); err != nil {
+				return fmt.Errorf("failed to terminate the last authorized_keys line: %w", err)
+			}
+		}
 
 		// Add timestamp comment
 		timestamp := time.Now().Format("2006-01-02 15:04:05")
@@ -331,10 +372,18 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 	})
 }
 
-// RemovePublicKey removes a public key from a user's authorized_keys file
-func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []byte) error {
+// RemovePublicKey removes a public key from a user's authorized_keys file. It
+// reports whether a matching line was actually found and removed.
+//
+// (#165) The removed flag is not decoration. This used to return only an error, and
+// nil for both "the line is gone" and "there was no such line", so the broker logged
+// "SSH key revoked" and recorded a revoke-success metric for a removal that changed
+// nothing — the audit trail asserted a revocation that had not happened while the
+// credential stayed usable. Callers must distinguish the two: removed=false, err=nil
+// means the entry is still there, if it was ever there at all.
+func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []byte) (bool, error) {
 	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
+		return false, fmt.Errorf("invalid username: %w", err)
 	}
 	userHomeDir := filepath.Join(akm.baseDir, username)
 	sshDir := filepath.Join(userHomeDir, ".ssh")
@@ -343,10 +392,11 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 
 	// Check if .ssh directory exists; if not, nothing to remove
 	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
-		return nil
+		return false, nil
 	}
 
-	return withFileLock(lockPath, akm.lockTimeout, func() error {
+	removed := false
+	err := withFileLock(lockPath, akm.lockTimeout, func() error {
 		// Read existing authorized_keys file
 		data, err := os.ReadFile(authorizedKeysPath)
 		if err != nil {
@@ -361,7 +411,6 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 		keyToRemove := strings.TrimSpace(string(publicKey))
 
 		var filteredLines []string
-		removed := false
 
 		for _, line := range lines {
 			trimmedLine := strings.TrimSpace(line)
@@ -380,8 +429,7 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 		}
 
 		// Write filtered content back atomically, refusing to follow symlinks (C-2).
-		newContent := strings.Join(filteredLines, "\n")
-		if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, []byte(newContent)); err != nil {
+		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath, filteredLines); err != nil {
 			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
 
@@ -392,6 +440,10 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 
 		return nil
 	})
+	if err != nil {
+		return false, err
+	}
+	return removed, nil
 }
 
 // RemoveExpiredKeys removes broker-issued keys older than 24 hours from a user's
@@ -479,8 +531,9 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 
 		if removedCount > 0 {
 			// Write filtered content back atomically, refusing to follow symlinks (C-2).
-			newContent := strings.Join(filteredLines, "\n")
-			if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, []byte(newContent)); err != nil {
+			// The scanner has stripped every line's newline, so the shared writer is
+			// what puts the file's final one back (#165).
+			if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath, filteredLines); err != nil {
 				return fmt.Errorf("failed to write authorized_keys file: %w", err)
 			}
 

--- a/pkg/ssh/authorized_keys_test.go
+++ b/pkg/ssh/authorized_keys_test.go
@@ -160,9 +160,12 @@ func TestRemovePublicKey(t *testing.T) {
 	}
 
 	// Remove the public key
-	err = akm.RemovePublicKey(username, publicKey)
+	removed, err := akm.RemovePublicKey(username, publicKey)
 	if err != nil {
 		t.Errorf("Failed to remove public key: %v", err)
+	}
+	if !removed {
+		t.Error("RemovePublicKey reported no match for a key it had just added")
 	}
 
 	// Verify the key was removed
@@ -191,9 +194,12 @@ func TestRemovePublicKeyNonExistentFile(t *testing.T) {
 	publicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... testuser@example.com")
 
 	// Try to remove a key when file doesn't exist
-	err = akm.RemovePublicKey(username, publicKey)
+	removed, err := akm.RemovePublicKey(username, publicKey)
 	if err != nil {
 		t.Errorf("Expected no error when removing key from non-existent file, got: %v", err)
+	}
+	if removed {
+		t.Error("RemovePublicKey claimed a removal from a file that does not exist")
 	}
 }
 
@@ -217,9 +223,14 @@ func TestRemovePublicKeyNotFound(t *testing.T) {
 	}
 
 	// Try to remove a different key
-	err = akm.RemovePublicKey(username, nonExistentKey)
+	removed, err := akm.RemovePublicKey(username, nonExistentKey)
 	if err != nil {
 		t.Errorf("Expected no error when removing non-existent key, got: %v", err)
+	}
+	// The caller has to be able to tell this from a real removal, or it audits a
+	// revocation that did not happen (#165).
+	if removed {
+		t.Error("RemovePublicKey reported a removal for a key that was never present")
 	}
 
 	// Verify the existing key is still there

--- a/pkg/ssh/trailing_newline_test.go
+++ b/pkg/ssh/trailing_newline_test.go
@@ -1,0 +1,208 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// brokerKeyLine builds an authorized_keys entry of the shape the broker issues:
+// the `@oidc-pam-<unix>` comment is what RemoveExpiredKeys reads to decide whether
+// the key is stale.
+func brokerKeyLine(issuedAt time.Time, distinguisher string) []byte {
+	return []byte(fmt.Sprintf("ssh-rsa AAAAB3NzaC1yc2E%s testuser@oidc-pam-%d",
+		distinguisher, issuedAt.Unix()))
+}
+
+// readKeys returns a user's authorized_keys contents verbatim — trailing newline
+// included, which is the whole subject of these tests.
+func readKeys(t *testing.T, baseDir, username string) string {
+	t.Helper()
+
+	path := filepath.Join(baseDir, username, ".ssh", "authorized_keys")
+	data, err := os.ReadFile(path) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// fusedLines returns the lines that hold a key and a broker comment at once. Such
+// a line is the #165 defect made visible: sshd would still honour the key part,
+// and neither remover can ever match the line again.
+func fusedLines(content string) []string {
+	var fused []string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "# Added by OIDC PAM") && !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			fused = append(fused, line)
+		}
+	}
+	return fused
+}
+
+// The rewritten file must end in a newline. authorized_keys is append-only for
+// every writer that touches it, so an unterminated last line is not cosmetic: the
+// next append lands on it (#165).
+func TestExpirySweepLeavesATrailingNewline(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	for _, key := range [][]byte{
+		brokerKeyLine(time.Now().Add(-48*time.Hour), "STALE"),
+		brokerKeyLine(time.Now().Add(-time.Hour), "FRESH"),
+	} {
+		if err := akm.AddPublicKey("testuser", key); err != nil {
+			t.Fatalf("AddPublicKey: %v", err)
+		}
+	}
+
+	if err := akm.RemoveExpiredKeys("testuser"); err != nil {
+		t.Fatalf("RemoveExpiredKeys: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if content == "" {
+		t.Fatal("the sweep emptied a file that still had a fresh key in it")
+	}
+	if !strings.HasSuffix(content, "\n") {
+		t.Errorf("the swept file does not end in a newline, so the next AddPublicKey will "+
+			"append onto its last key line (#165); tail is %q", tail(content))
+	}
+	if strings.HasSuffix(content, "\n\n") {
+		t.Errorf("the swept file gained a blank line at the end; tail is %q", tail(content))
+	}
+}
+
+// Same requirement for the targeted-removal path. It happened to be correct
+// (strings.Split keeps the trailing empty element), and now that both paths share
+// one writer this is what stops that from regressing.
+func TestTargetedRemovalLeavesATrailingNewline(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	doomed := brokerKeyLine(time.Now(), "DOOMED")
+	keeper := brokerKeyLine(time.Now(), "KEEPER")
+	for _, key := range [][]byte{doomed, keeper} {
+		if err := akm.AddPublicKey("testuser", key); err != nil {
+			t.Fatalf("AddPublicKey: %v", err)
+		}
+	}
+
+	removed, err := akm.RemovePublicKey("testuser", doomed)
+	if err != nil {
+		t.Fatalf("RemovePublicKey: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemovePublicKey reported no match for a key it had just added")
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if !strings.HasSuffix(content, "\n") {
+		t.Errorf("the rewritten file does not end in a newline (#165); tail is %q", tail(content))
+	}
+}
+
+// The sequence from #165, with no attacker in it: a sweep removes an expired key,
+// the user logs in again, and the login's comment lands on the last surviving key
+// line — making that entry both permanently authorized and permanently
+// irremovable. This drives the whole cycle and insists the last step really
+// revokes.
+func TestAddSweepAddRevokeRoundTrip(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	stale := brokerKeyLine(time.Now().Add(-48*time.Hour), "STALE")
+	surviving := brokerKeyLine(time.Now().Add(-time.Hour), "SURVIVING")
+	for _, key := range [][]byte{stale, surviving} {
+		if err := akm.AddPublicKey("testuser", key); err != nil {
+			t.Fatalf("AddPublicKey: %v", err)
+		}
+	}
+
+	if err := akm.RemoveExpiredKeys("testuser"); err != nil {
+		t.Fatalf("RemoveExpiredKeys: %v", err)
+	}
+
+	// The next login, appending to whatever the sweep left behind.
+	nextLogin := brokerKeyLine(time.Now(), "NEXTLOGIN")
+	if err := akm.AddPublicKey("testuser", nextLogin); err != nil {
+		t.Fatalf("AddPublicKey after the sweep: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if fused := fusedLines(content); len(fused) > 0 {
+		t.Errorf("a key line was fused with the login comment appended after the sweep, "+
+			"so that key can never be revoked again (#165): %q", fused)
+	}
+	for _, want := range []string{"SURVIVING", "NEXTLOGIN"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("%s key is missing from authorized_keys after the round trip", want)
+		}
+	}
+	if strings.Contains(content, "STALE") {
+		t.Error("the expired key survived the sweep")
+	}
+
+	// Both keys must still be revocable — the point of the whole exercise.
+	for _, key := range [][]byte{surviving, nextLogin} {
+		removed, err := akm.RemovePublicKey("testuser", key)
+		if err != nil {
+			t.Fatalf("RemovePublicKey: %v", err)
+		}
+		if !removed {
+			t.Errorf("no authorized_keys line matched %q, so revoking it is a no-op", key)
+		}
+		if got := readKeys(t, baseDir, "testuser"); strings.Contains(got, string(key)) {
+			t.Errorf("key %q still authorizes access after revocation", key)
+		}
+	}
+}
+
+// A file some other writer left unterminated — the user's own editor, or a broker
+// from before this fix — must not turn the next login into a fused line either.
+func TestAddPublicKeyTerminatesAnUnterminatedFile(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	sshDir := filepath.Join(baseDir, "testuser", ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	existing := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 personal-laptop"
+	if err := os.WriteFile(filepath.Join(sshDir, "authorized_keys"), []byte(existing), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	newKey := brokerKeyLine(time.Now(), "NEWKEY")
+	if err := akm.AddPublicKey("testuser", newKey); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if fused := fusedLines(content); len(fused) > 0 {
+		t.Errorf("appending to an unterminated file fused a comment onto a key line (#165): %q", fused)
+	}
+	// The user's own key is not the broker's to rewrite, only to terminate.
+	if !strings.Contains(content, existing) {
+		t.Errorf("the user's own key was mangled; file is %q", content)
+	}
+	removed, err := akm.RemovePublicKey("testuser", newKey)
+	if err != nil {
+		t.Fatalf("RemovePublicKey: %v", err)
+	}
+	if !removed {
+		t.Error("the key added to an unterminated file cannot be revoked")
+	}
+}
+
+// tail returns the last few bytes of s, for failure messages about a file's end.
+func tail(s string) string {
+	const n = 40
+	if len(s) <= n {
+		return s
+	}
+	return "..." + s[len(s)-n:]
+}


### PR DESCRIPTION
Fixes #165.

## The defect

`RemoveExpiredKeys` rewrote `authorized_keys` from a `bufio.Scanner` — which
strips newlines — and joined the survivors without restoring the final one, so
every sweep that removed a key left the file unterminated. `AddPublicKey` appends
with `O_APPEND`, so the user's **next login fused its `# Added by OIDC PAM on …`
comment onto the last surviving key line**:

```
ssh-rsa AAAA… alice@oidc-pam-1770000000# Added by OIDC PAM on 2026-08-13 12:00:00
```

sshd still honours the key on that line, but nothing can remove it again:

- the sweep cannot `ParseInt` a timestamp out of `1770000000# Added by …`, so it
  retains the key (deliberately fail-safe), and
- `RemovePublicKey` compares the whole trimmed line, so targeted revocation no
  longer matches either.

And the failed removal was reported as a success: `RemovePublicKey` returned
`nil` for "no such line" exactly as for a real removal, so `revokeSSHKey` logged
`SSH key revoked` at Info and recorded a revoke-**success** metric. The audit
trail asserted a revocation that had not happened, for a credential that stays
usable indefinitely. No attacker is involved — one expired key plus one later
login.

The asymmetry the issue calls out is real: `RemovePublicKey` split on `"\n"`,
which keeps a trailing empty element, so its `Join` restored the newline. Only
the `Scanner` path was wrong.

## What changed

- **One write path, `writeAuthorizedKeysLines`** (`pkg/ssh/authorized_keys.go`),
  used by both `RemovePublicKey` and `RemoveExpiredKeys`. It drops trailing blanks
  and terminates the last real line, so the file ends in exactly one `\n`. The two
  callers deriving the tail independently is what let them disagree; sharing the
  writer is what stops it recurring.
- **`AddPublicKey` terminates an unterminated last line before appending**
  (defence in depth): the file belongs to the user and can be left that way by
  anything — their editor, a broker from before this fix.
- **`RemovePublicKey` now returns `(removed bool, err error)`.** I changed the
  signature rather than adding a sibling function: a sibling would leave the
  ambiguous version exported, so the two could drift — which is the same class of
  bug as the two write paths disagreeing — and a caller can no longer mistake "no
  such line" for "the line is gone" by ignoring a return it does not know about.
  All callers are in-repo (one in `revokeSSHKey`, four in `pkg/ssh` tests, all
  updated) and the module is pre-1.0.
- **`revokeSSHKey` audits the two outcomes separately** (`pkg/auth/broker.go`):
  `ssh_key_revoked` (`success=true`) only when a line was actually removed;
  otherwise `ssh_key_revocation_incomplete` with
  `ErrorCode=AUTHORIZED_KEYS_ENTRY_NOT_REMOVED`, naming user and session, plus a
  revoke-**failure** metric. It still returns `nil` — revocation is best effort and
  the session is torn down either way — so no control flow changed. A
  `RemovePublicKey` error now also lands in this branch, where it previously still
  logged "SSH key revoked".

## Tests

`pkg/ssh/trailing_newline_test.go`:
- `TestExpirySweepLeavesATrailingNewline` — the acceptance criterion's final-byte
  assertion (and that no blank line is gained).
- `TestTargetedRemovalLeavesATrailingNewline` — pins the path that was already
  correct.
- `TestAddSweepAddRevokeRoundTrip` — add → expire sweep → add → revoke: no line
  holds a key and a comment at once, and both surviving keys are still actually
  removable.
- `TestAddPublicKeyTerminatesAnUnterminatedFile` — the defensive append, including
  that the user's own key is terminated, not rewritten.

`pkg/auth/key_revocation_test.go` — a broker with a real file-backed audit logger
(`OverflowStrategy: "sync"`, so nothing is left buffered and no test waits) and a
Prometheus registry:
- `TestRevocationThatRemovesTheKeyIsAuditedAsSuccess` — positive control.
- `TestRevocationThatMatchesNothingIsNotAuditedAsSuccess` — the criterion: no
  `ssh_key_revoked`, an `ssh_key_revocation_incomplete` that is not marked
  successful, success metric 0 / failure metric 1.

Existing `RemovePublicKey` tests now assert the `removed` flag, including that a
no-match reports `false`.

## Verification

- **Regression gate.** With only the write path reverted to
  `strings.Join(lines, "\n")`, both newline tests fail naming the cause: *"the
  swept file does not end in a newline, so the next AddPublicKey will append onto
  its last key line (#165); tail is …FRESH testuser@oidc-pam-1786673833"*. With the
  `AddPublicKey` defence also removed, the round trip fails on the real thing: *"a
  key line was fused with the login comment appended after the sweep, so that key
  can never be revoked again (#165)"*, followed by *"no authorized_keys line
  matched …, so revoking it is a no-op"* and *"still authorizes access after
  revocation"*. Separately, with `revokeSSHKey` ignoring `removed`, the audit test
  fails with *"the audit log claims ssh_key_revoked for a removal that matched
  nothing (#165)"*. All restored afterwards.
- `go build ./...`, `gofmt -l pkg internal cmd` (clean), `go test ./pkg/...
  ./internal/...`, `go test -race ./pkg/ssh/ ./pkg/auth/`, `golangci-lint run
  ./pkg/ssh/... ./pkg/auth/...` (0 issues). No C files touched, so the container
  cgo run was not needed.

## Deliberately not done

- **No repair of already-fused lines.** A line whose comment field contains a `#`
  is legitimate, so an in-place repair would be guesswork against a file the broker
  does not own. The CHANGELOG entry tells operators how to find and delete them
  (`# Added by OIDC PAM` appearing on a line that does not start with `#`).
- Locking untouched — `withFileLock`/`LockPath`/the lock directory from #161 are
  as they were.
- The wider key-provisioning problems of #171 are left alone, as is the
  `parts[2]`-based timestamp parsing in the sweep (`TODO(L-3)`).