### PR TITLE
fix(pam): stop crashing on a missing PAM conversation and logging broker responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **High (#168): the shipped PAM stacks logged every login's broker response to
+  syslog, and a service with no PAM conversation crashed the login outright.** Five
+  defects in the C module, grouped because they are one PR's worth of work.
+
+  - `display_message` called through `conv->conv` on the strength of
+    `pam_get_item(PAM_CONV, …)` answering `PAM_SUCCESS`, which it does even for a
+    service that set no conversation function. Showing the device-flow instructions
+    then jumped to address zero and killed the auth child — under sshd that child
+    *is* the login. Both the item and the function pointer are checked now, and a
+    message that cannot be shown is logged and skipped instead.
+  - `get_user_info` applied its `"unknown"`/`"localhost"` substitutes only when
+    `pam_get_item` *failed*. An item a service never set comes back as
+    `PAM_SUCCESS` with a NULL pointer, and the next thing that happens to it is
+    `json_object_new_string()`, i.e. `strlen(NULL)`. `PAM_RHOST` is not set by
+    services that are not remote and `PAM_TTY` not by services with no terminal, so
+    this was reachable from any non-sshd stack — `su`, `sudo`, `login`, cron — and
+    not from something exotic. Found while writing the test for the defect above,
+    which crashed on this one first; fixed with it.
+  - `debug_enabled` was a process global that was set and never cleared, so a single
+    `debug` anywhere turned on debug logging for every *later* authentication in the
+    process — and `pam_sm_authenticate` runs inside sshd, which serves many logins
+    from one process and may run more than one service's stack there. What that
+    logged included the **entire broker response**: the live device code, the user's
+    email and groups, and whatever the broker↔module contract grows next. The flag
+    is now taken from each invocation's own arguments (`pam_oidc_options.debug`), a
+    response is logged by size and never by body, and the shipped `ssh` and `login`
+    stacks no longer pass `debug` — they used to, next to a note telling the reader
+    to remove it, which is not a default.
+  - `classify_response` read the grant condition with `json_object_get_boolean`,
+    which answers true for any non-empty JSON *string*: `"success":"false"` was a
+    success, and under `auth sufficient pam_oidc.so` a success is a login. The field
+    must be a JSON boolean now. The broker emits one, which is why insisting on it
+    costs nothing in the one function whose whole job is to be strict about the
+    grant.
+  - The unused `prompt_user`, which copied a conversation reply into a buffer whose
+    size only its caller knew, is deleted rather than left to be wired up. This
+    module never prompts: the device flow happens in the user's browser.
+
+  Coverage: three cgo tests against a fake broker, two of them driving
+  `pam_sm_authenticate` itself so that argument parsing is part of what is
+  exercised — an authentication whose PAM handle carries no conversation function
+  (a segfault before the fix), a second authentication in the same process not
+  inheriting the first's `debug`, and `success` as the string `"false"`, the string
+  `"true"`, `1` and `null` each refused rather than granted. A fourth test reads
+  `configs/pam` and fails if a shipped stack passes `debug`.
 - **Low (#166): `allowed_groups` and `allowed_roles` denied nothing.** Both were
   applied while claims were being read, where the only thing they could do was drop
   the group and role names that were not in the list. A user in **none** of the

--- a/cmd/pam-module/auth_linux.go
+++ b/cmd/pam-module/auth_linux.go
@@ -43,6 +43,73 @@ func performAuthentication(socketPath, username, service, rhost, tty string, tim
 		C.int(timeoutSeconds)))
 }
 
+// pamHandle is a real pam_handle_t from pam_start. perform_authentication
+// tolerates a NULL handle and then shows the user nothing, so a NULL one cannot
+// exercise anything the PAM conversation touches; these tests need a handle whose
+// items the module actually reads.
+type pamHandle struct {
+	h *C.pam_handle_t
+}
+
+// startPAMHandleWithoutConversation returns a handle whose PAM_CONV item holds no
+// conversation function — what a service that never set one presents to the module
+// (#168).
+//
+// libpam will not store a NULL conv *pointer* (pam_set_item refuses it), so a conv
+// struct with a NULL function is the reachable shape of "no conversation", and it
+// is the one that used to be called through. display_message guards both.
+func startPAMHandleWithoutConversation(service, user string) (*pamHandle, pam.PAMResultCode) {
+	cService := C.CString(service)
+	cUser := C.CString(user)
+	defer func() {
+		C.free(unsafe.Pointer(cService))
+		C.free(unsafe.Pointer(cUser))
+	}()
+
+	var conv C.struct_pam_conv // zero value: no conversation function, no appdata
+	var handle *C.pam_handle_t
+
+	rc := pam.PAMResultCode(C.pam_start(cService, cUser, &conv, &handle))
+	if rc != pam.PAMSuccess {
+		return nil, rc
+	}
+	return &pamHandle{h: handle}, rc
+}
+
+func (p *pamHandle) close() {
+	C.pam_end(p.h, C.PAM_SUCCESS)
+}
+
+// smAuthenticate drives pam_sm_authenticate itself, so the module's argument
+// parsing is part of what is exercised rather than being bypassed the way
+// performAuthentication bypasses it.
+func smAuthenticate(p *pamHandle, args []string) pam.PAMResultCode {
+	argv := make([]*C.char, len(args))
+	for i, a := range args {
+		argv[i] = C.CString(a)
+	}
+	defer func() {
+		for _, arg := range argv {
+			C.free(unsafe.Pointer(arg))
+		}
+	}()
+
+	var argvPtr **C.char
+	if len(argv) > 0 {
+		argvPtr = (**C.char)(unsafe.Pointer(&argv[0]))
+	}
+
+	return pam.PAMResultCode(C.pam_sm_authenticate(p.h, 0, C.int(len(args)), argvPtr))
+}
+
+// debugLoggingEnabled reports whether the module is currently logging at
+// LOG_DEBUG. The module writes to syslog, which a test cannot read, so this is how
+// a test observes that the `debug` argument of one invocation does not carry into
+// the next (#168).
+func debugLoggingEnabled() bool {
+	return C.debug_logging_enabled() != 0
+}
+
 // classifyLoginTypeC exposes the C module's login-type classification so a Go
 // test can assert it agrees with GetLoginType. The two must match: the broker
 // applies per-login-type policy, and the C module and the Go client would

--- a/cmd/pam-module/cgo_bridge.h
+++ b/cmd/pam-module/cgo_bridge.h
@@ -71,14 +71,20 @@
 #define MAX_POLL_INTERVAL 60
 
 // Options parsed from the module arguments in /etc/pam.d/<service>.
+//
+// debug belongs here, per invocation, rather than only in the module's global:
+// the flag used to be set once and never cleared, so one service's `debug` turned
+// on debug logging for every later authentication in the same process (#168).
 typedef struct {
     char socket_path[MAX_SOCKET_PATH];
     int timeout_s;
+    int debug;
 } pam_oidc_options;
 
 // Function prototypes
 void parse_arguments(int argc, const char **argv, pam_oidc_options *opts);
 void log_pam_message(int priority, const char *format, ...);
+int debug_logging_enabled(void);
 int connect_to_broker(const char *socket_path);
 int get_user_info(pam_handle_t *pamh, const char **username, const char **service, const char **rhost, const char **tty);
 const char *classify_login_type(const char *service, const char *tty);
@@ -89,6 +95,5 @@ int receive_auth_response(int sock, char *response, size_t response_size);
 int perform_authentication(pam_handle_t *pamh, const char *socket_path, const char *username,
                            const char *service, const char *rhost, const char *tty, int timeout_s);
 int display_message(pam_handle_t *pamh, const char *message);
-int prompt_user(pam_handle_t *pamh, const char *prompt, char *response, size_t response_size);
 
 #endif // CGO_BRIDGE_H

--- a/cmd/pam-module/cgo_bridge_linux.c
+++ b/cmd/pam-module/cgo_bridge_linux.c
@@ -8,7 +8,17 @@
 // Total time budget for reading a complete broker response, in milliseconds.
 #define RESPONSE_READ_TIMEOUT_MS 30000
 
-// Global variables
+// Whether this invocation logs at LOG_DEBUG, taken from the module arguments by
+// parse_arguments.
+//
+// It has to be a global because log_pam_message is one, but it must not carry
+// state from one invocation to the next: pam_sm_authenticate runs inside sshd,
+// which serves many logins from one process and may run more than one service's
+// stack there. Setting the flag and never clearing it meant a single `debug` on
+// any stack turned on debug logging for every later authentication in that
+// process, including those of services that did not ask for it (#168).
+// parse_arguments now assigns this on every entry into the module, so an
+// invocation gets exactly what its own arguments asked for.
 static int debug_enabled = 0;
 
 // The compiled-in default must fit in pam_oidc_options.socket_path, which is
@@ -30,6 +40,13 @@ void log_pam_message(int priority, const char *format, ...) {
     closelog();
     
     va_end(args);
+}
+
+// Whether debug logging is in force right now. This is a separate function so a
+// Go test can watch the flag across two invocations — the module writes to syslog,
+// which a test cannot read. See TestDebugFlagDoesNotOutliveItsInvocation.
+int debug_logging_enabled(void) {
+    return debug_enabled;
 }
 
 // Connect to the OIDC authentication broker
@@ -68,36 +85,50 @@ int connect_to_broker(const char *socket_path) {
     return sock;
 }
 
-// Get user information from PAM handle
+// Get user information from PAM handle.
+//
+// An item the service never set comes back as PAM_SUCCESS with a NULL pointer, so
+// every one of these needs the substitute applied on NULL as well as on failure.
+// Testing only the return value left *rhost or *tty NULL, and the next thing that
+// happens to them is json_object_new_string(), i.e. strlen(NULL) — a crash of the
+// auth child, which under sshd is the login. PAM_RHOST is unset for every local
+// service (su, sudo, login, cron), and PAM_TTY for anything that is not on a
+// terminal (#168).
 int get_user_info(pam_handle_t *pamh, const char **username, const char **service, const char **rhost, const char **tty) {
     int retval;
-    
+
     // Get username
     retval = pam_get_user(pamh, username, NULL);
     if (retval != PAM_SUCCESS) {
         log_pam_message(LOG_ERR, "Failed to get username: %s", pam_strerror(pamh, retval));
         return retval;
     }
-    
+    if (*username == NULL) {
+        log_pam_message(LOG_ERR, "PAM returned no username");
+        return PAM_USER_UNKNOWN;
+    }
+
     // Get service name
     retval = pam_get_item(pamh, PAM_SERVICE, (const void**)service);
     if (retval != PAM_SUCCESS) {
         log_pam_message(LOG_WARNING, "Failed to get service name: %s", pam_strerror(pamh, retval));
+    }
+    if (retval != PAM_SUCCESS || *service == NULL) {
         *service = "unknown";
     }
-    
+
     // Get remote host
     retval = pam_get_item(pamh, PAM_RHOST, (const void**)rhost);
-    if (retval != PAM_SUCCESS) {
+    if (retval != PAM_SUCCESS || *rhost == NULL) {
         *rhost = "localhost";
     }
-    
+
     // Get TTY
     retval = pam_get_item(pamh, PAM_TTY, (const void**)tty);
-    if (retval != PAM_SUCCESS) {
+    if (retval != PAM_SUCCESS || *tty == NULL) {
         *tty = "unknown";
     }
-    
+
     log_pam_message(LOG_DEBUG, "User info - username: %s, service: %s, rhost: %s, tty: %s",
                     *username, *service, *rhost, *tty);
     
@@ -287,7 +318,13 @@ int receive_auth_response(int sock, char *response, size_t response_size) {
         return RECV_RESPONSE_TOO_LARGE;
     }
 
-    log_pam_message(LOG_DEBUG, "Received response: %s", response);
+    // The size, never the body. A response carries the live device code, the
+    // user's email and groups, and whatever else the broker<->module contract
+    // grows next; this module cannot know what is in one. syslog is not the place
+    // for it — LOG_AUTHPRIV is retained, shipped off the host and readable by
+    // everyone who can read auth.log, and `debug` is turned on by an operator
+    // debugging a login, not by the user whose response it is (#168).
+    log_pam_message(LOG_DEBUG, "Received %zu-byte broker response", total);
 
     return RECV_OK;
 }
@@ -305,10 +342,21 @@ int display_message(pam_handle_t *pamh, const char *message) {
         log_pam_message(LOG_ERR, "Failed to get conversation function: %s", pam_strerror(pamh, retval));
         return retval;
     }
-    
+
+    // PAM_SUCCESS does not promise a usable conversation. A service that set none,
+    // or set one with a NULL function, hands back exactly this — and calling
+    // through it killed the auth child mid-login, which under sshd is the login
+    // itself (#168). Nothing can be shown to this user, which is not a reason to
+    // crash: the caller carries on and the login can still be completed from the
+    // device code the user already has, or it times out and is refused.
+    if (conv == NULL || conv->conv == NULL) {
+        log_pam_message(LOG_WARNING, "No PAM conversation function available; not showing message to user");
+        return PAM_CONV_ERR;
+    }
+
     msg.msg_style = PAM_TEXT_INFO;
     msg.msg = message;
-    
+
     retval = conv->conv(1, &msgp, &resp, conv->appdata_ptr);
     if (retval != PAM_SUCCESS) {
         log_pam_message(LOG_ERR, "Failed to display message: %s", pam_strerror(pamh, retval));
@@ -325,42 +373,11 @@ int display_message(pam_handle_t *pamh, const char *message) {
     return PAM_SUCCESS;
 }
 
-// Prompt user for input
-int prompt_user(pam_handle_t *pamh, const char *prompt, char *response, size_t response_size) {
-    struct pam_message msg;
-    const struct pam_message *msgp = &msg;
-    struct pam_response *resp = NULL;
-    struct pam_conv *conv;
-    int retval;
-    
-    retval = pam_get_item(pamh, PAM_CONV, (const void**)&conv);
-    if (retval != PAM_SUCCESS) {
-        log_pam_message(LOG_ERR, "Failed to get conversation function: %s", pam_strerror(pamh, retval));
-        return retval;
-    }
-    
-    msg.msg_style = PAM_PROMPT_ECHO_ON;
-    msg.msg = prompt;
-    
-    retval = conv->conv(1, &msgp, &resp, conv->appdata_ptr);
-    if (retval != PAM_SUCCESS) {
-        log_pam_message(LOG_ERR, "Failed to prompt user: %s", pam_strerror(pamh, retval));
-        return retval;
-    }
-    
-    if (resp && resp->resp) {
-        strncpy(response, resp->resp, response_size - 1);
-        response[response_size - 1] = '\0';
-        
-        // Clean up
-        free(resp->resp);
-        free(resp);
-    } else {
-        response[0] = '\0';
-    }
-    
-    return PAM_SUCCESS;
-}
+// There was a prompt_user() here. It had no caller — this module never asks the
+// user for input, since the device flow happens in the user's browser — and it
+// copied a conversation reply into a buffer whose size only its caller knew
+// (#168). Deleted rather than left for someone to wire up. The device flow needs
+// display_message and nothing else.
 
 // Parse module arguments
 // Parse the module arguments from /etc/pam.d/<service> into opts, which is
@@ -370,7 +387,7 @@ int prompt_user(pam_handle_t *pamh, const char *prompt, char *response, size_t r
 // therefore trusted, unlike oidc-pam-helper's argv, which may come from an
 // unprivileged caller (see L-6). Recognized arguments:
 //
-//   debug             Log at LOG_DEBUG to syslog.
+//   debug             Log at LOG_DEBUG to syslog, for this invocation only.
 //   socket=<path>     Absolute path to the broker's Unix socket. Defaults to
 //                     SOCKET_PATH, which matches the broker's own default for
 //                     server.socket_path.
@@ -391,10 +408,23 @@ void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
     memcpy(opts->socket_path, SOCKET_PATH, sizeof(SOCKET_PATH));
     opts->timeout_s = DEFAULT_AUTH_TIMEOUT;
 
+    // Debug is settled before anything else is parsed: this assignment is what
+    // stops a previous invocation's `debug` from still being in force (#168), and
+    // doing it in its own pass means the messages logged below obey this
+    // invocation's arguments whatever order they arrive in.
     for (i = 0; i < argc; i++) {
         if (strcmp(argv[i], "debug") == 0) {
-            debug_enabled = 1;
-            log_pam_message(LOG_DEBUG, "Debug mode enabled");
+            opts->debug = 1;
+        }
+    }
+    debug_enabled = opts->debug;
+    if (opts->debug) {
+        log_pam_message(LOG_DEBUG, "Debug mode enabled");
+    }
+
+    for (i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "debug") == 0) {
+            continue; // handled above
         } else if (strncmp(argv[i], "socket=", 7) == 0) {
             const char *path = argv[i] + 7;
             size_t len = strlen(path);
@@ -518,8 +548,14 @@ static int classify_response(json_object *obj) {
     json_object *success_obj = NULL;
 
     // A response we cannot interpret is not a grant.
-    if (!json_object_object_get_ex(obj, "success", &success_obj)) {
-        log_pam_message(LOG_ERR, "Broker response has no success field");
+    //
+    // The type is checked, not just the presence: json_object_get_boolean answers
+    // true for any non-empty JSON *string*, so `"success":"false"` used to be read
+    // as a success (#168). The real broker emits a JSON bool, which is exactly why
+    // nothing is given up by insisting on one here.
+    if (!json_object_object_get_ex(obj, "success", &success_obj) ||
+        !json_object_is_type(success_obj, json_type_boolean)) {
+        log_pam_message(LOG_ERR, "Broker response has no boolean success field");
         return PAM_AUTHINFO_UNAVAIL;
     }
 

--- a/cmd/pam-module/configs_test.go
+++ b/cmd/pam-module/configs_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The PAM stacks in configs/pam must not pass `debug`.
+//
+// `debug` makes the module log the details of every authentication that service
+// handles to LOG_AUTHPRIV — before #168, that included the broker's entire
+// response, device code and instructions and all. The shipped ssh and login stacks
+// passed it, so every host built by copying them into /etc/pam.d logged that on
+// every login; the ssh config even carried a note telling the reader to take it
+// out again. It is a diagnostic an operator turns on while watching a login, not a
+// default.
+//
+// This test has no build tag on purpose: it reads files, needs no cgo, and the
+// stacks are worth pinning on a developer's Mac too.
+func TestShippedPAMStacksDoNotEnableDebug(t *testing.T) {
+	dir := filepath.Join("..", "..", "configs", "pam")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	moduleLines := 0
+	for _, entry := range entries {
+		// README.md documents the `debug` argument deliberately; it is not a stack.
+		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		for i, line := range strings.Split(string(content), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 0 || strings.HasPrefix(fields[0], "#") {
+				continue
+			}
+			if !strings.Contains(line, "pam_oidc.so") {
+				continue
+			}
+			moduleLines++
+
+			for _, field := range fields {
+				if field == "debug" {
+					t.Errorf("%s:%d ships `debug`, so every login this stack handles logs its "+
+						"details to LOG_AUTHPRIV: %s", path, i+1, strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+
+	if moduleLines == 0 {
+		t.Fatalf("found no pam_oidc.so lines under %s; this test is checking nothing", dir)
+	}
+}

--- a/cmd/pam-module/device_flow_linux_test.go
+++ b/cmd/pam-module/device_flow_linux_test.go
@@ -377,6 +377,119 @@ func TestPerformAuthenticationRejectsOverlongSessionID(t *testing.T) {
 	}
 }
 
+// The module used to read the success field with json_object_get_boolean, which
+// answers true for any non-empty JSON *string*: `"success":"false"` was a grant, and
+// with `auth sufficient pam_oidc.so` a grant is a login (#168). The real broker
+// emits a JSON bool, so nothing is given up by insisting on one.
+func TestPerformAuthenticationRequiresABooleanSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Written verbatim by the fake broker: the point is the JSON type of the field,
+	// which a Go map could not express.
+	replies := []struct {
+		name  string
+		reply string
+	}{
+		{"the string false", `{"success":"false","error_code":"AUTHENTICATION_FAILED"}` + "\n"},
+		{"the string true", `{"success":"true","user_id":"testuser","session_id":"sess-str"}` + "\n"},
+		{"the number 1", `{"success":1,"user_id":"testuser","session_id":"sess-int"}` + "\n"},
+		{"null", `{"success":null,"session_id":"sess-null"}` + "\n"},
+	}
+
+	for _, tt := range replies {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return tt.reply
+			})
+
+			got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+			if got == pam.PAMSuccess {
+				t.Fatalf("success=%s was classified as a grant: PAM_SUCCESS from `auth sufficient "+
+					"pam_oidc.so` is a login", tt.name)
+			}
+			if got != pam.PAMAuthInfoUnavail {
+				t.Fatalf("success=%s: got PAM result %d, want pam.PAMAuthInfoUnavail (%d)",
+					tt.name, got, pam.PAMAuthInfoUnavail)
+			}
+		})
+	}
+}
+
+// A service can hand the module a PAM_CONV item with no conversation function in
+// it. display_message called through it without looking, so showing the device-flow
+// instructions dereferenced NULL and killed the process — and under sshd that
+// process is the login's auth child (#168).
+//
+// This drives pam_sm_authenticate rather than perform_authentication so the handle
+// and the module arguments both travel the path PAM uses.
+func TestAuthenticateSurvivesAMissingConversationFunction(t *testing.T) {
+	// Not parallel: pam_sm_authenticate parses module arguments, which sets the
+	// module's process-wide debug flag.
+	broker := newFakeBroker(t, func(n int, _ map[string]interface{}) interface{} {
+		if n == 1 {
+			// Carries instructions, so the module tries to show them.
+			return deviceStarted("sess-noconv")
+		}
+		return denied("SESSION_NOT_FOUND")
+	})
+
+	handle, rc := startPAMHandleWithoutConversation("other", "testuser")
+	if rc != pam.PAMSuccess {
+		t.Fatalf("pam_start: PAM result %d", rc)
+	}
+	defer handle.close()
+
+	got := smAuthenticate(handle, []string{"socket=" + broker.socketPath, "timeout=10"})
+	if got != pam.PAMAuthError {
+		t.Fatalf("authentication with no conversation function: got PAM result %d, want "+
+			"pam.PAMAuthError (%d)", got, pam.PAMAuthError)
+	}
+	if n := len(broker.received()); n < 2 {
+		t.Fatalf("expected the module to carry on past the undisplayable message and poll, "+
+			"got %d request(s)", n)
+	}
+}
+
+// `debug` is a per-invocation module argument, but the flag it set was a process
+// global that was never cleared. pam_sm_authenticate runs inside sshd, which serves
+// many logins from one process and may run more than one service's stack there, so a
+// single `debug` anywhere — and the shipped ssh and login stacks used to pass it —
+// left every later authentication in that process logging at LOG_DEBUG whatever its
+// own arguments said (#168). What that logged included the whole broker response.
+func TestDebugFlagDoesNotOutliveItsInvocation(t *testing.T) {
+	// Not parallel: debug_enabled is process-wide, which is the subject here.
+	broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+		// Refused up front: no device step, so neither authentication sleeps.
+		return denied("AUTHENTICATION_FAILED")
+	})
+
+	handle, rc := startPAMHandleWithoutConversation("other", "testuser")
+	if rc != pam.PAMSuccess {
+		t.Fatalf("pam_start: PAM result %d", rc)
+	}
+	defer handle.close()
+
+	socketArg := "socket=" + broker.socketPath
+
+	if got := smAuthenticate(handle, []string{"debug", socketArg}); got != pam.PAMAuthError {
+		t.Fatalf("first authentication: got PAM result %d, want pam.PAMAuthError (%d)", got, pam.PAMAuthError)
+	}
+	if !debugLoggingEnabled() {
+		t.Fatal("the `debug` argument did not enable debug logging, so the rest of this test proves nothing")
+	}
+
+	if got := smAuthenticate(handle, []string{socketArg}); got != pam.PAMAuthError {
+		t.Fatalf("second authentication: got PAM result %d, want pam.PAMAuthError (%d)", got, pam.PAMAuthError)
+	}
+	if debugLoggingEnabled() {
+		t.Fatal("an authentication that did not ask for `debug` is still logging at LOG_DEBUG: " +
+			"the flag outlived the invocation that set it, so one service's debug setting " +
+			"applies to every later login in the same sshd process")
+	}
+}
+
 // TestLoginTypeClassificationMatchesGo pins the C module's login-type
 // classification to pam.GetLoginType's. The broker applies per-login-type policy, so
 // if pam_oidc.so and the Go client disagreed, the same login would be evaluated

--- a/configs/pam/README.md
+++ b/configs/pam/README.md
@@ -90,6 +90,11 @@ auth    required    pam_oidc.so
 auth    sufficient  pam_oidc.so debug
 ```
 
+`debug` is for diagnosing a login you are watching, and belongs in the stack only
+while you are watching it. It makes the module log the details of every
+authentication that service handles to `LOG_AUTHPRIV`. It applies to the stack that
+carries it and to nothing else — the shipped stacks do not carry it.
+
 ## Which PAM phases the module participates in
 
 `pam_oidc.so` implements one decision, in the `auth` phase. Everything the
@@ -158,7 +163,7 @@ not consult the PAM auth stack at all.
 
 | Argument | Meaning |
 |---|---|
-| `debug` | Log at `LOG_DEBUG` to syslog (`LOG_AUTHPRIV`). Remove in production. |
+| `debug` | Log at `LOG_DEBUG` to syslog (`LOG_AUTHPRIV`), for the stack that carries it only. Remove in production. |
 | `socket=<path>` | Absolute path to the broker's Unix socket. Defaults to `/var/run/oidc-auth/broker.sock`, matching the broker's own default for `server.socket_path`. Only needed if you changed that. |
 | `timeout=<seconds>` | How long to wait for the user to finish the device flow before refusing the login. Default `90`, accepted range `10`–`900`. |
 

--- a/configs/pam/login
+++ b/configs/pam/login
@@ -8,7 +8,7 @@
 # Always maintain console or SSH access for emergency recovery.
 
 # Authentication stack
-auth    sufficient  pam_oidc.so debug
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_nologin.so
 auth    required    pam_unix.so try_first_pass nullok_secure
 auth    optional    pam_group.so

--- a/configs/pam/ssh
+++ b/configs/pam/ssh
@@ -12,7 +12,7 @@
 # 'sufficient' means a successful OIDC authentication ends the auth phase here;
 # 'requisite pam_deny.so' means anything else is refused immediately. Nothing can
 # follow pam_deny.so -- a pam_unix.so line here would never be reached.
-auth    sufficient  pam_oidc.so debug
+auth    sufficient  pam_oidc.so
 auth    requisite   pam_deny.so
 
 # Account management.
@@ -38,7 +38,9 @@ password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 # CONFIGURATION NOTES:
 # 1. The 'sufficient' control means if pam_oidc.so succeeds, no further auth modules are tried
 # 2. The 'requisite' pam_deny.so refuses everything else, and stops the stack
-# 3. Remove 'debug' from pam_oidc.so in production
+# 3. This stack passes no 'debug' argument, deliberately. Add it while diagnosing
+#    a login and take it out again: it makes the module log the details of every
+#    authentication to LOG_AUTHPRIV, which is not where a login's details belong.
 # 4. The module reads no configuration file; the broker reads
 #    /etc/oidc-auth/broker.yaml itself. The module only needs to reach the
 #    broker's socket (/var/run/oidc-auth/broker.sock by default).


### PR DESCRIPTION
Fixes #168.

## The defects

**1. NULL dereference crashed the login.** `display_message` called through
`conv->conv` on the strength of `pam_get_item(PAM_CONV, …)` answering
`PAM_SUCCESS`, which it does even for a service that set no conversation
function. Showing the device-flow instructions then jumped to address zero and
killed the auth child — under sshd that child *is* the login.

Both the item and the function pointer are checked now, and a message that cannot
be shown is logged at `LOG_WARNING` and skipped. `libpam` will not store a NULL
conv *pointer* (`pam_set_item` refuses it), so the reachable shape is a conv
struct with a NULL function; the guard covers both.

**2. A second NULL dereference, not in the issue, on the same path.**
`get_user_info` applied its `"unknown"`/`"localhost"` substitutes only when
`pam_get_item` *failed*. An item a service never set comes back as `PAM_SUCCESS`
with a NULL pointer, and the next thing that happens to it is
`json_object_new_string()`, i.e. `strlen(NULL)`. `PAM_RHOST` is not set by
services that are not remote and `PAM_TTY` not by services with no terminal, so
this was reachable from any non-sshd stack — `su`, `sudo`, `login`, cron.

I found it because the test for defect 1 crashed here first, before it ever
reached `display_message`; the acceptance criterion ("a test invoking the auth
path with `PAM_CONV` unset that does not crash") cannot be met without it. A NULL
username from `pam_get_user` is now `PAM_USER_UNKNOWN`, following pam_unix's
idiom, rather than being passed on.

**3. Sticky `debug` global that logged whole broker responses.** `debug_enabled`
was a process global, set and never cleared, so a single `debug` anywhere turned
on debug logging for every *later* authentication in the process — and
`pam_sm_authenticate` runs inside sshd, which serves many logins from one process
and may run more than one service's stack there.

- The flag now comes from each invocation's own arguments
  (`pam_oidc_options.debug`), assigned — not OR-ed — on every entry into the
  module. It is settled in its own pass over `argv` before anything else is
  parsed, so `parse_arguments`' own messages obey this invocation's arguments
  whatever order they arrive in.
- **The response body is no longer logged at all, at any level.** This is the part
  of the fix the issue did not ask for and I think it needs: a response carries
  the live device code, the user's email and groups, and whatever the
  broker↔module contract grows next (the contract is owned by oauth2-pam, #179 —
  this module cannot know what is in a response). `LOG_AUTHPRIV` is retained,
  shipped off the host, and readable by everyone who can read `auth.log`, and
  `debug` is turned on by an operator debugging a login, not by the user whose
  response it is. `receive_auth_response` logs the size instead.
- `debug` is gone from `configs/pam/ssh` and `configs/pam/login`, and the ssh
  config's note telling the reader to remove it is replaced by one saying why it
  is not there.

**4. A JSON string accepted as boolean true.** `json_object_get_boolean` answers
true for any non-empty JSON *string*, so `"success":"false"` was a success — and
under `auth sufficient pam_oidc.so` a success is a login. `classify_response` now
requires `json_object_is_type(success_obj, json_type_boolean)`; anything else is
"a response we cannot interpret", `PAM_AUTHINFO_UNAVAIL`, the same as an absent
field. The broker emits a JSON bool, which is why insisting on one costs nothing.

Verified against json-c 0.18 that this was live rather than theoretical:
`{"success":"false"}` → `get_boolean` = 1, `is_type(boolean)` = 0.

**5. Dead `prompt_user`.** Deleted from the `.c` and the header, with a note
saying what was there and why it is not coming back. This module never prompts —
the device flow happens in the user's browser.

## Tests

Four, in the pattern of the existing `device_flow_linux_test.go` cases (cgo
against a fake broker on a Unix socket). Two of them drive `pam_sm_authenticate`
itself rather than `perform_authentication`, over a real `pam_handle_t` from
`pam_start`, so module-argument parsing is part of what is exercised. New Go
wrappers for that live in `auth_linux.go` next to the existing ones, since cgo is
not permitted in `_test.go` files.

- `TestAuthenticateSurvivesAMissingConversationFunction` — a handle whose
  `PAM_CONV` item has no conversation function, against a broker that returns
  device-flow instructions.
- `TestDebugFlagDoesNotOutliveItsInvocation` — one authentication with `debug`,
  then one without, asserting the flag is off after the second. It reads the flag
  through a new `debug_logging_enabled()` accessor, because the module logs to
  syslog and a test cannot read that. Deliberately not `t.Parallel()`: the flag is
  process-wide, which is the subject.
- `TestPerformAuthenticationRequiresABooleanSuccess` — `success` as the string
  `"false"`, the string `"true"`, `1` and `null`, written verbatim by the fake
  broker because the point is the JSON type.
- `TestShippedPAMStacksDoNotEnableDebug` (`configs_test.go`) — scans
  `configs/pam` for an uncommented `pam_oidc.so` line carrying `debug`, and fails
  if it finds no `pam_oidc.so` lines at all so it cannot pass vacuously. No build
  tag: it reads files and needs no cgo. `README.md` is excluded, since it
  documents the argument on purpose.

### Each test run against its defect reintroduced

| Test | With the defect back |
|---|---|
| conversation function | `SIGSEGV … PC=0x0` (a call through a NULL function pointer) inside `_Cfunc_pam_sm_authenticate` |
| defect 2 (`\|\| *rhost == NULL` removed) | `SIGSEGV … PC=0xffff…, fault 0x0, r0=0x0` in libc `strlen`, reached from `pam_sm_authenticate` — this is how the defect was found |
| `debug` sticky | `an authentication that did not ask for 'debug' is still logging at LOG_DEBUG: the flag outlived the invocation that set it, so one service's debug setting applies to every later login in the same sshd process` |
| boolean `success` | `success=the string false was classified as a grant: PAM_SUCCESS from 'auth sufficient pam_oidc.so' is a login` (same for `"true"` and `1`; `null` reported the wrong PAM code) |
| shipped `debug` | `../../configs/pam/ssh:15 ships 'debug', …` and `../../configs/pam/login:11 …` |

## Verification

All clean:

- `docker run … golang:1.25 … go vet ./cmd/pam-module && go test ./cmd/pam-module/...` →
  `ok github.com/scttfrdmn/oidc-pam/cmd/pam-module 3.017s`. The module cannot be
  compiled on macOS (`security/pam_ext.h` does not exist), so every C change was
  built and run in the container; `-Wall -Wextra` is on for the cgo build.
- `go build ./...`, `gofmt -l pkg internal cmd` (no output),
  `go test ./pkg/... ./internal/...` (all `ok`).

## Deliberately left out

- The **request** log lines (`Sending auth request: %s`) still log their JSON at
  `LOG_DEBUG`. A request carries the username, service, tty and pid — no
  credential — and the broker refuses any peer that is not root, so a `session_id`
  read out of `auth.log` is not usable. Narrowing them was not part of this issue.
- `MAX_RESPONSE_SIZE` is untouched (#162, #179).
- `json_get_bool`, used for `requires_device`, is still type-lenient. Every
  non-boolean value there errs toward *pending*, i.e. toward not granting, so it
  is not a widening of the grant condition.
- `debug` still appears in `configs/pam/README.md` (in the "Debug Mode" and
  troubleshooting sections) and in `QUICK-START.md`, where it is being documented
  rather than shipped. Both README mentions now say the flag applies only to the
  stack that carries it and that the shipped stacks do not carry it. The
  acceptance criterion is about the stacks an operator copies into `/etc/pam.d`,
  and the guard test enforces it there.
