### PR TITLE
fix(ipc): send source_ip, and target_host as the host being logged into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `broker.yaml`. Proven against the defect: restoring the old files fails seven
   of the config cases and five of the document cases, naming `cloud`, `logging`,
   `policy`, `ssh`, `format` and `pin_certificates` by path.
+- **High (#169): the network access controls could not work, and every audit record
+  named the client as the host being logged into.** Neither client ever sent
+  `source_ip`, and both sent `PAM_RHOST` — the address the login comes *from* — as
+  `target_host`, so the two ends of the connection were swapped on the wire. Every
+  policy that reads `source_ip` was therefore evaluating the empty string:
+  `require_private_network` and `require_tailscale` ask `net.ParseIP` about it, which
+  answers no, so enabling either refused **every login on the host** including the
+  ones it was configured to admit — and `configs/production/broker-enterprise.yaml`
+  ships with both on. `ip_allowlist`/`ip_denylist` and the geo checks matched nothing
+  for the same reason, the location history recorded an entry with an empty subnet
+  that made every subsequent login for that user score as an unusual location, and
+  the audit trail recorded the client's address in `target_host` — so an
+  investigation could not tell which machine a login reached.
+
+  - Both clients now send `source_ip` from `PAM_RHOST` and `target_host` from this
+    host's own name, per the **oauth2-pam wire protocol (version 1)**: `source_ip` is
+    "the client address, if the login has one and it really is an address" and
+    `target_host` is "the host being logged **into** — this host". That project owns
+    the contract and this one consumes it (#179), so the field meanings, the 45- and
+    253-byte bounds and the decision to leave `source_ip` optional are taken from
+    there rather than settled here.
+  - A resolved hostname is not an address, so an `rhost` that is a name (what sshd
+    supplies with `UseDNS yes`) yields no `source_ip` rather than a string no policy
+    can evaluate. The unabridged `rhost` reaches the broker in `metadata.rhost`, as
+    audit context that nothing consults for a decision.
+  - **An absent `source_ip` is now a third answer — "origin unknown" — and what it
+    means is the operator's, not the zero value's.** A console login legitimately has
+    no address, so a network requirement now needs
+    `authentication.network_requirements.unknown_source_ip: deny|allow` alongside it;
+    the broker refuses to start with the requirement enabled and the question
+    unanswered, rather than reaching the old implicit answer (deny everything) at the
+    first login. `allow` is audited per login as `network_requirement_waived`: a
+    requirement that was configured and then not applied must not be invisible. Risk
+    scoring counts an unknown origin the same 25 as a public one — it is not evidence
+    of safety — but names it "Unknown network origin" so the score can be read.
+  - A login with no location is no longer recorded in the location history at all,
+    which is what turned one unrecordable first login into a permanent "unusual
+    location" verdict for that user.
+  - `internal/ipc` now bounds `source_ip` at 45 bytes and `target_host` at 253 at the
+    boundary, and accepts a zoned IPv6 literal (`fe80::1%eth0`), which `net.ParseIP`
+    rejects on its own.
+  - Coverage on both sides of the boundary, since the defect was identical in each: a
+    cgo test asserting what the C module puts on the wire, a Go test doing the same
+    against a fake broker, policy tests that a private source address is now
+    distinguishable from a public one (impossible to write against the defect — both
+    cases were the empty string and both were denied), a config test that every
+    shipped config answers the unknown-origin question, and an e2e case asserting the
+    login came from `127.0.0.1` and arrived at this host. Each was proven to fail with
+    the defect reintroduced.
 - **High (#168): the shipped PAM stacks logged every login's broker response to
   syslog, and a service with no PAM conversation crashed the login outright.** Five
   defects in the C module, grouped because they are one PR's worth of work.

--- a/cmd/pam-helper/main.go
+++ b/cmd/pam-helper/main.go
@@ -33,10 +33,13 @@ const (
 func main() {
 	// Parse command line flags
 	var (
-		configFile  = flag.String("config", "/etc/oidc-auth/pam.conf", "Path to configuration file")
-		username    = flag.String("user", "", "Username to authenticate")
-		service     = flag.String("service", "unknown", "Service requesting authentication")
-		rhost       = flag.String("rhost", "localhost", "Remote host")
+		configFile = flag.String("config", "/etc/oidc-auth/pam.conf", "Path to configuration file")
+		username   = flag.String("user", "", "Username to authenticate")
+		service    = flag.String("service", "unknown", "Service requesting authentication")
+		// (#169) Defaults to empty, not "localhost": rhost becomes the request's
+		// source_ip, and inventing a peer for a login that has none is the mistake
+		// this flag would otherwise hand the broker.
+		rhost       = flag.String("rhost", "", "Address the login is coming from (PAM_RHOST); empty for a local login")
 		tty         = flag.String("tty", "unknown", "TTY")
 		debug       = flag.Bool("debug", false, "Enable debug logging")
 		showVersion = flag.Bool("version", false, "Show version information")

--- a/cmd/pam-module/cgo_bridge.h
+++ b/cmd/pam-module/cgo_bridge.h
@@ -6,6 +6,7 @@
 #include <security/pam_ext.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <arpa/inet.h>
 #include <syslog.h>
 #include <string.h>
 #include <errno.h>
@@ -48,6 +49,14 @@
 // Longest session ID the module will accept from the broker, matching
 // maxSessionIDLen in internal/ipc/validate.go (plus the NUL).
 #define MAX_SESSION_ID_SIZE 129
+
+// Bounds the wire protocol (version 1) sets on the two fields that say where a
+// login came from and where it is going: 45 bytes is an IPv6 literal with a zone,
+// 253 a DNS name. The broker refuses anything longer
+// (maxSourceIPLen/maxTargetHostLen in internal/ipc/validate.go), so the module
+// declines to send it rather than having the login refused as INVALID_REQUEST.
+#define MAX_SOURCE_IP_LEN 45
+#define MAX_TARGET_HOST_LEN 253
 
 // Default socket path for the OIDC broker. Must match the default of
 // server.socket_path in pkg/config/config.go; override per-service with the

--- a/cmd/pam-module/cgo_bridge_linux.c
+++ b/cmd/pam-module/cgo_bridge_linux.c
@@ -160,22 +160,80 @@ const char *classify_login_type(const char *service, const char *tty) {
     return "unknown";
 }
 
+// Derive the request's source_ip from PAM_RHOST: where the login is coming from.
+//
+// (#169) Returns NULL unless rhost really is an address. source_ip carries an
+// address or nothing, and sshd hands PAM a resolved hostname when UseDNS is on;
+// passing that through would be worse than omitting it, because the broker's
+// network policies and IP allowlists would then evaluate a string that is not a
+// location and nothing downstream re-resolves it. The unabridged rhost still goes
+// out in metadata.rhost, which is audit context and decides nothing.
+static const char *source_ip_from_rhost(const char *rhost) {
+    char addr[MAX_SOURCE_IP_LEN + 1];
+    struct in_addr v4;
+    struct in6_addr v6;
+    char *zone;
+    size_t len;
+
+    if (rhost == NULL) {
+        return NULL;
+    }
+    len = strlen(rhost);
+    if (len == 0 || len > MAX_SOURCE_IP_LEN) {
+        return NULL;
+    }
+
+    // A zone ("fe80::1%eth0") names an interface on the sending host, which
+    // inet_pton will not parse, so it is validated without and sent with.
+    memcpy(addr, rhost, len);
+    addr[len] = '\0';
+    zone = strchr(addr, '%');
+    if (zone != NULL) {
+        *zone = '\0';
+    }
+
+    if (inet_pton(AF_INET, addr, &v4) == 1 || inet_pton(AF_INET6, addr, &v6) == 1) {
+        return rhost;
+    }
+    return NULL;
+}
+
+// The request's target_host: the host being logged *into*, which is this one.
+//
+// (#169) Returns NULL rather than a guess when the name cannot be had or does not
+// fit, since a wrong target_host selects the wrong per-resource policy.
+static const char *this_host(char *buf, size_t size) {
+    if (gethostname(buf, size) != 0) {
+        return NULL; // includes ENAMETOOLONG: a truncated hostname is a wrong one
+    }
+    buf[size - 1] = '\0'; // POSIX does not promise termination on truncation
+    if (buf[0] == '\0') {
+        return NULL;
+    }
+    return buf;
+}
+
 // Send authentication request to broker
 int send_auth_request(int sock, const char *username, const char *service, const char *rhost, const char *tty) {
     json_object *request = json_object_new_object();
     json_object *type = json_object_new_string("authenticate");
     json_object *user_id = json_object_new_string(username);
-    json_object *target_host = json_object_new_string(rhost);
     json_object *metadata = json_object_new_object();
     json_object *service_obj = json_object_new_string(service);
     json_object *tty_obj = json_object_new_string(tty);
 
     const char *login_type_str = classify_login_type(service, tty);
+    const char *source_ip = source_ip_from_rhost(rhost);
+    char host_buf[MAX_TARGET_HOST_LEN + 1];
+    const char *target_host = this_host(host_buf, sizeof(host_buf));
 
     // Add metadata
     json_object_object_add(metadata, "service", service_obj);
     json_object_object_add(metadata, "tty", tty_obj);
     json_object_object_add(metadata, "pid", json_object_new_int(getpid()));
+    if (rhost != NULL && rhost[0] != '\0') {
+        json_object_object_add(metadata, "rhost", json_object_new_string(rhost));
+    }
 
     // Build request. Each value is added exactly once and owned by the tree, so
     // a single json_object_put(request) frees everything (L-11: previously the
@@ -183,9 +241,18 @@ int send_auth_request(int sock, const char *username, const char *service, const
     json_object_object_add(request, "type", type);
     json_object_object_add(request, "user_id", user_id);
     json_object_object_add(request, "login_type", json_object_new_string(login_type_str));
-    json_object_object_add(request, "target_host", target_host);
+    // (#169) Both fields are omitted rather than sent empty when unknown: absent
+    // and empty mean the same thing to the broker, and an omitted field is the one
+    // the wire protocol describes. This used to send rhost as target_host and no
+    // source_ip at all, which inverted the two ends of the connection.
+    if (source_ip != NULL) {
+        json_object_object_add(request, "source_ip", json_object_new_string(source_ip));
+    }
+    if (target_host != NULL) {
+        json_object_object_add(request, "target_host", json_object_new_string(target_host));
+    }
     json_object_object_add(request, "metadata", metadata);
-    
+
     // Convert to string
     const char *request_str = json_object_to_json_string(request);
     size_t request_len = strlen(request_str);

--- a/cmd/pam-module/source_ip_linux_test.go
+++ b/cmd/pam-module/source_ip_linux_test.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/pam"
+)
+
+// What the C client actually puts on the wire for the two fields that say where a
+// login came from and where it is going (#169).
+//
+// The module sent no source_ip at all, and sent PAM_RHOST — the address the user
+// connects *from* — as target_host. Downstream, an empty source_ip is not treated
+// as "unknown" but as "bad": require_private_network went through
+// isPrivateIP(""), which is false, and refused every login on the host.
+//
+// This is the C half of the same claim TestAuthenticateSendsSourceIPAndThisHost
+// makes about the Go client in pkg/pam. The defect was identical in both, which is
+// what a boundary with a test on only one side of it produces.
+func TestAuthRequestCarriesSourceIPAndThisHost(t *testing.T) {
+	t.Parallel()
+
+	thisHost, err := os.Hostname()
+	if err != nil {
+		t.Skipf("no hostname on this machine: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		rhost        string
+		wantSourceIP string // "" means the field must be absent
+		wantRHost    string // metadata.rhost; "" means absent
+	}{
+		{"an IPv4 peer", "10.0.0.1", "10.0.0.1", "10.0.0.1"},
+		{"an IPv6 peer", "2001:db8::1", "2001:db8::1", "2001:db8::1"},
+		{"an IPv6 peer with a zone", "fe80::1%eth0", "fe80::1%eth0", "fe80::1%eth0"},
+		// sshd hands PAM a resolved name when UseDNS is on. source_ip carries an
+		// address or nothing, so the name is audit context only.
+		{"a resolved hostname is not an address", "client.example.com", "", "client.example.com"},
+		// A console login has no peer, and the broker must be able to tell that from
+		// a peer it could not evaluate.
+		{"no peer at all", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return authenticated("sess-src")
+			})
+
+			if got := performAuthentication(broker.socketPath, "testuser", "sshd", tt.rhost, "pts/0", 30); got != pam.PAMSuccess {
+				t.Fatalf("performAuthentication = %d, want pam.PAMSuccess", got)
+			}
+
+			requests := broker.received()
+			if len(requests) != 1 {
+				t.Fatalf("expected exactly one request, got %d", len(requests))
+			}
+			req := requests[0]
+
+			if got := jsonString(req, "source_ip"); got != tt.wantSourceIP {
+				t.Errorf("source_ip = %q, want %q (PAM_RHOST was %q)", got, tt.wantSourceIP, tt.rhost)
+			}
+			if got := jsonString(req, "target_host"); got != thisHost {
+				t.Errorf("target_host = %q, want this host %q — target_host is the machine being "+
+					"logged into, not the address the login came from", got, thisHost)
+			}
+			metadata, _ := req["metadata"].(map[string]interface{})
+			if got := jsonString(metadata, "rhost"); got != tt.wantRHost {
+				t.Errorf("metadata.rhost = %q, want %q: the unabridged rhost belongs in the audit "+
+					"context even when it is not an address", got, tt.wantRHost)
+			}
+		})
+	}
+}
+
+func jsonString(m map[string]interface{}, key string) string {
+	s, _ := m[key].(string)
+	return s
+}

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -83,10 +83,18 @@ authentication:
   require_groups: ["linux-users"]
   
   # Network requirements
+  #
+  # require_tailscale and require_private_network are checked against the login's
+  # source_ip. A login can legitimately have none — one at the physical console,
+  # or one whose PAM_RHOST is a resolved hostname rather than an address — so
+  # enabling either of them requires unknown_source_ip as well, saying what
+  # happens to those: "deny" (fail closed) or "allow" (permitted, and audited as
+  # network_requirement_waived). The broker refuses to start without it.
   network_requirements:
     require_tailscale: false
     validate_device_trust: false
     require_private_network: false
+    # unknown_source_ip: "deny"
     
   # Resource-specific policies
   # A policy is selected by its NAME: "default" applies to every host, any other

--- a/configs/production/broker-enterprise.yaml
+++ b/configs/production/broker-enterprise.yaml
@@ -189,6 +189,14 @@ authentication:
     tailscale_api_key: "tskey-api-your-key-here"
     validate_device_trust: true
     require_private_network: true
+    # What the two requirements above do with a login that reports no source_ip:
+    # one at the physical console, or one whose PAM_RHOST is a hostname rather
+    # than an address. Required whenever either is enabled, and "deny" is the
+    # fail-closed answer — on these hosts a console login is expected to go
+    # through the same network requirements as any other, and there is no address
+    # to check it against. Set it to "allow" only if console logins must work,
+    # and expect a network_requirement_waived audit event for each one.
+    unknown_source_ip: "deny"
 
   # Time-based access controls
   time_based_policies:

--- a/docs/design/tailscale_oidc_integration.md
+++ b/docs/design/tailscale_oidc_integration.md
@@ -197,6 +197,9 @@ authentication:
     require_tailscale: true
     tailscale_api_key: "${TAILSCALE_API_KEY}"
     validate_device_trust: true
+    # Required alongside require_tailscale (#169): what happens to a login with
+    # no source_ip, such as one at the physical console.
+    unknown_source_ip: "deny"
     
   policies:
     production:

--- a/internal/brokerclient/client.go
+++ b/internal/brokerclient/client.go
@@ -16,6 +16,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -41,6 +43,13 @@ const (
 )
 
 // Request is an IPC request. It mirrors ipc.Request.
+//
+// SourceIP is where the login came from and TargetHost is where it is going: this
+// machine. (#169) Both clients used to send PAM_RHOST — the address the user is
+// connecting *from* — as TargetHost and send no SourceIP at all, which left every
+// audit record naming the client as the host being logged into and every policy
+// that reads source_ip evaluating the empty string. Use SourceIPFromRHost and
+// ThisHost rather than filling them in by hand.
 type Request struct {
 	Type       string                 `json:"type"`
 	UserID     string                 `json:"user_id,omitempty"`
@@ -51,6 +60,49 @@ type Request struct {
 	DeviceID   string                 `json:"device_id,omitempty"`
 	SessionID  string                 `json:"session_id,omitempty"`
 	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// MaxSourceIPLen is the wire contract's bound on source_ip: an IPv6 literal with
+// a zone. The broker refuses anything longer.
+const MaxSourceIPLen = 45
+
+// SourceIPFromRHost derives the request's source_ip from PAM's PAM_RHOST.
+//
+// source_ip carries an address or nothing, so an rhost that is a hostname — which
+// is what sshd supplies with UseDNS on — yields "". Passing the hostname through
+// would be worse than omitting it: a policy would evaluate a string that is not a
+// location, and no downstream check re-resolves it. The unabridged rhost still
+// reaches the broker in metadata.rhost, where it is audit context and nothing
+// consults it for a decision.
+//
+// An empty result therefore means "this login has no address the broker can act
+// on", which is a state the broker handles deliberately
+// (network_requirements.unknown_source_ip) rather than one it infers.
+func SourceIPFromRHost(rhost string) string {
+	if rhost == "" || len(rhost) > MaxSourceIPLen {
+		return ""
+	}
+	// A zone ("fe80::1%eth0") names an interface on the sending host, and
+	// net.ParseIP rejects it, so it is validated without and returned with.
+	addr := rhost
+	if i := strings.IndexByte(addr, '%'); i >= 0 {
+		addr = addr[:i]
+	}
+	if net.ParseIP(addr) == nil {
+		return ""
+	}
+	return rhost
+}
+
+// ThisHost is the request's target_host: the host being logged into. A hostname
+// that cannot be determined is omitted rather than guessed, since a wrong one
+// selects the wrong per-resource policy.
+func ThisHost() string {
+	name, err := os.Hostname()
+	if err != nil || len(name) > 253 {
+		return ""
+	}
+	return name
 }
 
 // Response is an IPC response. It mirrors ipc.Response.

--- a/internal/brokerclient/client_test.go
+++ b/internal/brokerclient/client_test.go
@@ -468,3 +468,45 @@ func TestAuthenticateAndWaitDoesNotOvershootTheBudget(t *testing.T) {
 		t.Errorf("waited %s, want exactly the 30s budget", elapsed)
 	}
 }
+
+// (#169) source_ip is where the login came from, and it carries an address or
+// nothing. A hostname — what PAM_RHOST holds when sshd runs with UseDNS on — is
+// dropped rather than passed through, because the broker's network policies, IP
+// allowlists and location history all treat what is in this field as a location
+// and nothing re-resolves it.
+func TestSourceIPFromRHost(t *testing.T) {
+	tests := []struct {
+		name  string
+		rhost string
+		want  string
+	}{
+		{"IPv4", "10.0.0.1", "10.0.0.1"},
+		{"IPv6", "2001:db8::1", "2001:db8::1"},
+		{"IPv6 with zone", "fe80::1%eth0", "fe80::1%eth0"},
+		{"loopback", "127.0.0.1", "127.0.0.1"},
+		{"a resolved hostname is not an address", "client.example.com", ""},
+		{"the module's old stand-in for a local login", "localhost", ""},
+		{"a local login has no peer", "", ""},
+		{"longer than the contract allows", "1234567890123456789012345678901234567890123456", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SourceIPFromRHost(tt.rhost); got != tt.want {
+				t.Errorf("SourceIPFromRHost(%q) = %q, want %q", tt.rhost, got, tt.want)
+			}
+		})
+	}
+}
+
+// target_host is the host being logged into, which is this one — not the client's
+// address, which is what both clients used to send.
+func TestThisHostIsThisHost(t *testing.T) {
+	want, err := os.Hostname()
+	if err != nil {
+		t.Skipf("no hostname on this machine: %v", err)
+	}
+	if got := ThisHost(); got != want {
+		t.Errorf("ThisHost() = %q, want this machine's name %q", got, want)
+	}
+}

--- a/internal/ipc/validate.go
+++ b/internal/ipc/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strings"
 	"unicode"
 )
 
@@ -28,6 +29,13 @@ const (
 
 	// maxFieldLen is the maximum length for generic string fields.
 	maxFieldLen = 256
+
+	// maxSourceIPLen and maxTargetHostLen are the wire contract's bounds for these
+	// two fields: 45 bytes is an IPv6 literal with a zone, 253 a DNS name. They are
+	// what Broker.Authenticate already enforces, applied at the boundary instead so
+	// an over-long value is refused before it is copied anywhere.
+	maxSourceIPLen   = 45
+	maxTargetHostLen = 253
 
 	// maxMetadataKeys is the maximum number of entries in the metadata map.
 	maxMetadataKeys = 32
@@ -63,7 +71,7 @@ func validateRequest(req *Request) error {
 		if err := validateStringField(req.UserAgent, "user_agent", maxFieldLen); err != nil {
 			return err
 		}
-		if err := validateStringField(req.TargetHost, "target_host", maxFieldLen); err != nil {
+		if err := validateStringField(req.TargetHost, "target_host", maxTargetHostLen); err != nil {
 			return err
 		}
 		if err := validateStringField(req.LoginType, "login_type", maxFieldLen); err != nil {
@@ -123,13 +131,30 @@ func validateUserID(id string) error {
 	return nil
 }
 
-// validateSourceIP checks that a source IP is a valid IP address.
-// An empty string is allowed (source IP is optional).
+// validateSourceIP checks that source_ip is an IP address, or absent.
+//
+// Empty stays legal, because the wire contract makes source_ip conditional on the
+// login having an address at all ("the client address, if the login has one"), and
+// a console login has none. What used to be wrong was not the validation but what
+// the policy engine made of the gap: see applyNetworkPolicies (#169). A hostname
+// is refused rather than accepted as a location — an unresolvable claim in
+// source_ip is worse than nothing, since a policy would evaluate it — and clients
+// put the unabridged PAM_RHOST in metadata.rhost instead.
 func validateSourceIP(ip string) error {
 	if ip == "" {
 		return nil
 	}
-	if net.ParseIP(ip) == nil {
+	if len(ip) > maxSourceIPLen {
+		return fmt.Errorf("source_ip exceeds maximum length of %d characters", maxSourceIPLen)
+	}
+	// An IPv6 literal may carry a zone ("fe80::1%eth0"), which net.ParseIP rejects
+	// on its own. The zone names an interface on the sending host and means nothing
+	// here, so it is accepted and ignored.
+	addr := ip
+	if i := strings.IndexByte(addr, '%'); i >= 0 {
+		addr = addr[:i]
+	}
+	if net.ParseIP(addr) == nil {
 		return fmt.Errorf("source_ip is not a valid IP address")
 	}
 	return nil

--- a/internal/ipc/validate_test.go
+++ b/internal/ipc/validate_test.go
@@ -58,6 +58,13 @@ func TestValidateSourceIP(t *testing.T) {
 		{"path traversal", "../../etc", true},
 		{"too many octets", "1.2.3.4.5", true},
 		{"out of range", "256.1.1.1", true},
+		// (#169) A resolved hostname, which is what PAM_RHOST holds when sshd runs
+		// with UseDNS on, is not a location the policy engine can evaluate. Clients
+		// send it as metadata.rhost and leave source_ip out.
+		{"hostname", "client.example.com", true},
+		// An IPv6 zone is part of the literal the wire contract's 45 bytes allow for.
+		{"IPv6 with zone", "fe80::1%eth0", false},
+		{"longer than the contract allows", strings.Repeat("1", 46), true},
 	}
 
 	for _, tt := range tests {
@@ -163,6 +170,17 @@ func TestValidateRequest(t *testing.T) {
 				Type:     "authenticate",
 				UserID:   "testuser",
 				SourceIP: "not-an-ip",
+			},
+			wantErr: true,
+		},
+		{
+			// (#169) target_host is a DNS name (this host), so the contract bounds it
+			// at 253 rather than at maxFieldLen.
+			name: "authenticate over-long target_host",
+			req: Request{
+				Type:       "authenticate",
+				UserID:     "testuser",
+				TargetHost: strings.Repeat("h", maxTargetHostLen+1),
 			},
 			wantErr: true,
 		},

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -354,6 +354,25 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		}, nil
 	}
 
+	// (#169) A network requirement that was configured and then not applied is an
+	// event in its own right, not a detail of a successful login: the operator
+	// asked for unknown_source_ip: allow, and this is the record of what that
+	// admitted. Without it, "require_private_network is on" and "this login was
+	// never checked against it" are indistinguishable in the audit trail.
+	if waived, ok := policyResult.Metadata[MetadataSourceIPUnknown].(bool); ok && waived {
+		b.auditLogger.LogAuthEvent(security.AuditEvent{
+			EventType:    "network_requirement_waived",
+			UserID:       req.UserID,
+			TargetHost:   req.TargetHost,
+			Success:      true,
+			RiskScore:    policyResult.RiskScore,
+			RiskFactors:  policyResult.RiskFactors,
+			ErrorMessage: "login reported no source_ip; network requirements waived by unknown_source_ip: allow",
+			Metadata:     map[string]interface{}{"login_type": req.LoginType},
+			Timestamp:    time.Now(),
+		})
+	}
+
 	// Select appropriate provider
 	provider := b.selectProvider()
 	if provider == nil {
@@ -1092,6 +1111,10 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 			// successful login without the identity it authenticated (#153) — while
 			// the denial paths, which build their events from `userInfo` directly,
 			// carried it correctly.
+			// (#169) source_ip is on the event because it is where the login that was
+			// admitted came from, and until it was populated by the clients this
+			// record could only ever have carried an empty one — so it carried
+			// nothing, while every denial path recorded it.
 			b.auditLogger.LogAuthEvent(security.AuditEvent{
 				EventType: "authentication_successful",
 				UserID:    updated.UserID,
@@ -1099,6 +1122,7 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 				Groups:    updated.Groups,
 				SessionID: updated.ID,
 				Provider:  provider.Name,
+				SourceIP:  updated.SourceIP,
 				Success:   true,
 				Timestamp: time.Now(),
 			})

--- a/pkg/auth/location_history.go
+++ b/pkg/auth/location_history.go
@@ -107,9 +107,18 @@ func (lh *LocationHistory) IsUnusual(userID, ip, country string) bool {
 //   - When the per-user cap (MaxLocationsPerUser) is reached, the oldest entry
 //     is evicted to make room.
 //
+// A login with no usable location is not recorded at all. (#169) An entry with an
+// empty Subnet and an empty Country can never match anything IsUnusual is asked
+// about, but it does end the "no history yet" exemption — so recording one made
+// every subsequent login for that user score as an unusual location for as long
+// as the entry lived.
+//
 // If PersistPath is configured the updated history is saved asynchronously.
 func (lh *LocationHistory) RecordLocation(userID, ip, country string) {
 	subnet := subnetKey(ip)
+	if subnet == "" && country == "" {
+		return
+	}
 	now := time.Now()
 	cutoff := now.Add(-lh.historyWindow())
 	maxLocs := lh.cfg.MaxLocationsPerUser

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -211,9 +211,39 @@ func (pe *PolicyEngine) applyGlobalPolicies(req *AuthRequest, result *PolicyResu
 	return nil
 }
 
+// MetadataSourceIPUnknown marks a result the network requirements let through
+// only because the operator chose unknown_source_ip: allow. The broker audits
+// it: a waived requirement is a security-relevant event, not a detail.
+const MetadataSourceIPUnknown = "source_ip_unknown"
+
 // applyNetworkPolicies applies network-related policies
 func (pe *PolicyEngine) applyNetworkPolicies(req *AuthRequest, result *PolicyResult) error {
 	netReq := pe.config.Authentication.NetworkRequirements
+
+	if !netReq.RequireTailscale && !netReq.RequirePrivateNetwork {
+		return nil
+	}
+
+	// (#169) An absent source_ip means the broker does not know where this login
+	// came from — not that it came from somewhere bad. Both checks below ask
+	// net.ParseIP a question about a string, and both answer "no" for "", so an
+	// unknown origin used to be reported as a public one and every login on the
+	// host was refused. What happens instead is the operator's decision, made in
+	// config and validated at startup (validateNetworkRequirements).
+	if req.SourceIP == "" {
+		if netReq.UnknownSourceIP == config.UnknownSourceIPAllow {
+			result.RiskFactors = append(result.RiskFactors, "Network requirement waived: origin unknown")
+			result.Metadata[MetadataSourceIPUnknown] = true
+			log.Warn().
+				Str("user_id", req.UserID).
+				Str("login_type", req.LoginType).
+				Msg("Login reported no source_ip; network requirements waived by unknown_source_ip: allow")
+			return nil
+		}
+		result.Allowed = false
+		result.Reason = "Access requires a known network origin; this login reported no source IP"
+		return nil
+	}
 
 	// Check if Tailscale is required
 	if netReq.RequireTailscale {
@@ -528,8 +558,15 @@ func (pe *PolicyEngine) calculateRiskScore(req *AuthRequest, result *PolicyResul
 		result.RiskFactors = append(result.RiskFactors, "Unknown device")
 	}
 
-	// Network-based risk
-	if !pe.isPrivateIP(req.SourceIP) {
+	// Network-based risk. (#169) An unknown origin scores the same as a public one
+	// — it is not evidence of safety — but it is named for what it is, because the
+	// risk factors are what an operator reads out of the audit trail to work out
+	// why a login scored what it did.
+	switch {
+	case req.SourceIP == "":
+		score += 25
+		result.RiskFactors = append(result.RiskFactors, "Unknown network origin")
+	case !pe.isPrivateIP(req.SourceIP):
 		score += 25
 		result.RiskFactors = append(result.RiskFactors, "Public network access")
 	}

--- a/pkg/auth/policy_source_ip_test.go
+++ b/pkg/auth/policy_source_ip_test.go
@@ -1,0 +1,224 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// networkPolicyEngine builds an engine whose only opinion is the network
+// requirement under test.
+func networkPolicyEngine(t *testing.T, nr config.NetworkRequirements) *PolicyEngine {
+	t.Helper()
+
+	pe, err := NewPolicyEngine(&config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:       time.Hour,
+			NetworkRequirements: nr,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	t.Cleanup(pe.Close)
+	return pe
+}
+
+func evaluate(t *testing.T, pe *PolicyEngine, req *AuthRequest) *PolicyResult {
+	t.Helper()
+
+	result, err := pe.EvaluateRequest(req)
+	if err != nil {
+		t.Fatalf("EvaluateRequest: %v", err)
+	}
+	return result
+}
+
+// The headline regression test for #169: require_private_network has to be able to
+// tell a private source address from a public one.
+//
+// It could not, because no client ever sent source_ip and isPrivateIP("") is
+// false, so the requirement refused every login on the host — including the ones
+// it was configured to admit. This test was impossible to write against that
+// defect: both cases were the empty string and both were denied.
+func TestRequirePrivateNetworkDistinguishesPrivateFromPublic(t *testing.T) {
+	pe := networkPolicyEngine(t, config.NetworkRequirements{
+		RequirePrivateNetwork: true,
+		UnknownSourceIP:       config.UnknownSourceIPDeny,
+	})
+
+	tests := []struct {
+		name        string
+		sourceIP    string
+		wantAllowed bool
+	}{
+		{"RFC 1918 /8", "10.11.12.13", true},
+		{"RFC 1918 /12", "172.16.4.5", true},
+		{"RFC 1918 /16", "192.168.1.100", true},
+		{"a public address", "203.0.113.7", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluate(t, pe, &AuthRequest{
+				UserID:    "alice",
+				SourceIP:  tt.sourceIP,
+				LoginType: "ssh",
+				Timestamp: time.Now(),
+			})
+			if result.Allowed != tt.wantAllowed {
+				t.Errorf("require_private_network with source_ip %q: allowed = %v (%s), want %v",
+					tt.sourceIP, result.Allowed, result.Reason, tt.wantAllowed)
+			}
+		})
+	}
+}
+
+func TestRequireTailscaleDistinguishesTailscaleFromEverythingElse(t *testing.T) {
+	pe := networkPolicyEngine(t, config.NetworkRequirements{
+		RequireTailscale: true,
+		UnknownSourceIP:  config.UnknownSourceIPDeny,
+	})
+
+	if result := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: "100.101.102.103"}); !result.Allowed {
+		t.Errorf("a Tailscale address was refused: %s", result.Reason)
+	}
+	if result := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: "192.168.1.100"}); result.Allowed {
+		t.Error("require_tailscale admitted an address outside 100.64.0.0/10")
+	}
+}
+
+// An absent source_ip is "the broker does not know where this came from", which is
+// a third answer and not the same as "a public network". Which way it falls is the
+// operator's, stated in config: the zero value used to decide it, and it decided
+// deny for every login including the console.
+func TestUnknownSourceIPIsTheOperatorsDecision(t *testing.T) {
+	t.Run("deny fails closed", func(t *testing.T) {
+		pe := networkPolicyEngine(t, config.NetworkRequirements{
+			RequirePrivateNetwork: true,
+			UnknownSourceIP:       config.UnknownSourceIPDeny,
+		})
+
+		result := evaluate(t, pe, &AuthRequest{UserID: "alice", LoginType: "console"})
+		if result.Allowed {
+			t.Fatal("unknown_source_ip: deny admitted a login with no source_ip")
+		}
+		// The reason has to say the origin was unknown, not that it was public: it is
+		// what the operator reads out of the audit trail, and it is the difference
+		// between a misconfiguration and an attack.
+		if want := "requires a known network origin"; !contains(result.Reason, want) {
+			t.Errorf("reason = %q, want it to mention %q", result.Reason, want)
+		}
+	})
+
+	t.Run("allow admits it and marks the waiver", func(t *testing.T) {
+		pe := networkPolicyEngine(t, config.NetworkRequirements{
+			RequirePrivateNetwork: true,
+			UnknownSourceIP:       config.UnknownSourceIPAllow,
+		})
+
+		result := evaluate(t, pe, &AuthRequest{UserID: "alice", LoginType: "console"})
+		if !result.Allowed {
+			t.Fatalf("unknown_source_ip: allow refused a login with no source_ip: %s", result.Reason)
+		}
+		// Broker.Authenticate turns this into a network_requirement_waived audit
+		// event. A requirement that was configured and then not applied must not be
+		// invisible.
+		if waived, ok := result.Metadata[MetadataSourceIPUnknown].(bool); !ok || !waived {
+			t.Errorf("result.Metadata[%q] = %v, want true", MetadataSourceIPUnknown, result.Metadata[MetadataSourceIPUnknown])
+		}
+	})
+
+	t.Run("allow does not admit a public address", func(t *testing.T) {
+		pe := networkPolicyEngine(t, config.NetworkRequirements{
+			RequirePrivateNetwork: true,
+			UnknownSourceIP:       config.UnknownSourceIPAllow,
+		})
+
+		if result := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: "203.0.113.7"}); result.Allowed {
+			t.Error("unknown_source_ip: allow waived the requirement for a login that did report an address")
+		}
+	})
+
+	t.Run("no requirement, no opinion", func(t *testing.T) {
+		pe := networkPolicyEngine(t, config.NetworkRequirements{})
+
+		if result := evaluate(t, pe, &AuthRequest{UserID: "alice", LoginType: "console"}); !result.Allowed {
+			t.Errorf("a login with no source_ip was refused with no network requirement configured: %s", result.Reason)
+		}
+	})
+}
+
+// The second half of #169's impact: every user scored 70 from their second login
+// on. A first login recorded a location with an empty subnet and an empty country,
+// which matches nothing — but its existence ended the "no history yet" exemption,
+// so IsUnusual fell through to true for every login after it, forever.
+func TestRepeatLoginFromTheSameSubnetIsNotUnusual(t *testing.T) {
+	pe := networkPolicyEngine(t, config.NetworkRequirements{})
+
+	const sourceIP = "192.168.1.100"
+	pe.RecordLocation("alice", sourceIP)
+
+	result := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: sourceIP, LoginType: "ssh"})
+	for _, factor := range result.RiskFactors {
+		if factor == "Unusual location" {
+			t.Errorf("a second login from %s was scored as an unusual location; factors: %v",
+				sourceIP, result.RiskFactors)
+		}
+	}
+
+	// A different /24 still is unusual: the exemption above must not be a blanket one.
+	elsewhere := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: "203.0.113.7", LoginType: "ssh"})
+	if !containsString(elsewhere.RiskFactors, "Unusual location") {
+		t.Errorf("a login from a subnet with no history was not scored as unusual; factors: %v",
+			elsewhere.RiskFactors)
+	}
+}
+
+// A login with no address cannot be recorded as a location, and recording it
+// anyway is what turned the whole history into a permanent "unusual" verdict.
+func TestALoginWithNoLocationIsNotRecorded(t *testing.T) {
+	pe := networkPolicyEngine(t, config.NetworkRequirements{})
+
+	pe.RecordLocation("alice", "")
+	if n := pe.locationHistory.Len("alice"); n != 0 {
+		t.Fatalf("recorded %d location(s) for a login with no source_ip, want 0", n)
+	}
+
+	// And the next real login is still that user's first, so it is not unusual.
+	result := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: "192.168.1.100", LoginType: "ssh"})
+	if containsString(result.RiskFactors, "Unusual location") {
+		t.Errorf("the first locatable login was scored as unusual; factors: %v", result.RiskFactors)
+	}
+}
+
+// An unknown origin is named as unknown rather than reported as a public network,
+// because the risk factors are what an operator reads to find out why a login
+// scored what it did.
+func TestRiskFactorsNameAnUnknownOriginAsUnknown(t *testing.T) {
+	pe := networkPolicyEngine(t, config.NetworkRequirements{})
+
+	unknown := evaluate(t, pe, &AuthRequest{UserID: "alice", LoginType: "console"})
+	if !containsString(unknown.RiskFactors, "Unknown network origin") {
+		t.Errorf("factors for a login with no source_ip = %v, want one naming the unknown origin",
+			unknown.RiskFactors)
+	}
+	if containsString(unknown.RiskFactors, "Public network access") {
+		t.Errorf("a login with no source_ip was reported as public network access: %v", unknown.RiskFactors)
+	}
+
+	public := evaluate(t, pe, &AuthRequest{UserID: "alice", SourceIP: "203.0.113.7", LoginType: "ssh"})
+	if !containsString(public.RiskFactors, "Public network access") {
+		t.Errorf("factors for a public source_ip = %v, want one naming the public network", public.RiskFactors)
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,7 +204,28 @@ type NetworkRequirements struct {
 	TailscaleAPIKey       string `mapstructure:"tailscale_api_key"`
 	ValidateDeviceTrust   bool   `mapstructure:"validate_device_trust"`
 	RequirePrivateNetwork bool   `mapstructure:"require_private_network"`
+
+	// UnknownSourceIP decides what the requirements above do with a login the
+	// broker cannot place on any network: one that arrived with no source_ip.
+	// That is neither rare nor an attack — a login at the physical console has no
+	// peer address, and neither does one whose PAM_RHOST is a resolved hostname
+	// rather than an address, since source_ip carries an address or nothing.
+	//
+	// (#169) It is required, and has no default, whenever a requirement above is
+	// enabled: the implicit answer was the defect. An absent source_ip went
+	// through isPrivateIP(""), came back false, and denied every login on the
+	// host. "Unknown" and "on a public network" are different facts, and the
+	// operator is the only one who can say which way an unknown falls.
+	UnknownSourceIP string `mapstructure:"unknown_source_ip"`
 }
+
+// The values UnknownSourceIP takes. Deny is the fail-closed answer and the one
+// to prefer; Allow is for a host whose console logins matter more than the
+// requirement, and every login it lets through is audited as a waiver.
+const (
+	UnknownSourceIPDeny  = "deny"
+	UnknownSourceIPAllow = "allow"
+)
 
 // TimeBasedPolicies defines time-based access controls
 type TimeBasedPolicies struct {
@@ -610,7 +631,41 @@ func (c *Config) Validate() error {
 			c.Authentication.RefreshThreshold, c.Authentication.TokenLifetime)
 	}
 
+	if err := validateNetworkRequirements(c.Authentication.NetworkRequirements); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// validateNetworkRequirements refuses a network requirement whose behaviour on a
+// login with no source_ip has been left implicit.
+//
+// (#169) A requirement is evaluated against source_ip, and some logins have none
+// — the console, and any PAM_RHOST that is a hostname rather than an address.
+// Until the operator says so, the broker cannot tell whether such a login is
+// meant to pass or to be refused, and the answer it used to reach on its own
+// (isPrivateIP("") is false, therefore deny) refused every login on the host.
+// Refused at startup rather than at first login, for the same reason as the
+// email-domain check above: an operator who mis-set this should find out when the
+// broker starts.
+func validateNetworkRequirements(nr NetworkRequirements) error {
+	switch nr.UnknownSourceIP {
+	case UnknownSourceIPDeny, UnknownSourceIPAllow:
+		return nil
+	case "":
+		if !nr.RequirePrivateNetwork && !nr.RequireTailscale {
+			return nil // nothing consults it
+		}
+		return fmt.Errorf("authentication.network_requirements.unknown_source_ip must be %q or %q "+
+			"when require_private_network or require_tailscale is enabled: a login with no source_ip "+
+			"(one at the console, or one whose PAM_RHOST is a hostname rather than an address) cannot "+
+			"satisfy a network requirement, and leaving that implicit denied every login",
+			UnknownSourceIPDeny, UnknownSourceIPAllow)
+	default:
+		return fmt.Errorf("authentication.network_requirements.unknown_source_ip is %q; must be %q or %q",
+			nr.UnknownSourceIP, UnknownSourceIPDeny, UnknownSourceIPAllow)
+	}
 }
 
 // validateHTTPSEndpoint ensures a configured OIDC endpoint URL uses HTTPS.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -916,3 +916,117 @@ func TestShippedConfigsPinTheirDomains(t *testing.T) {
 		}
 	}
 }
+
+// (#169) A network requirement is checked against source_ip, and some logins
+// legitimately have none — one at the physical console, or one whose PAM_RHOST is a
+// hostname rather than an address. The broker used to answer that on its own, via
+// isPrivateIP("") being false, and the answer was "deny", so require_private_network
+// refused every login on the host. So the operator has to say, and has to say it
+// before the broker starts rather than at the first login that hits it.
+func TestNetworkRequirementNeedsAnAnswerForAnUnknownSourceIP(t *testing.T) {
+	withNetwork := func(nr NetworkRequirements) *Config {
+		return &Config{
+			Server: ServerConfig{SocketPath: "/tmp/test.sock"},
+			OIDC: OIDCConfig{Providers: []OIDCProvider{{
+				Name:     "test",
+				Issuer:   "https://test.example.com",
+				ClientID: "test-client",
+				Scopes:   []string{"openid"},
+			}}},
+			Authentication: AuthenticationConfig{
+				TokenLifetime:         time.Hour,
+				RefreshThreshold:      time.Minute,
+				MaxConcurrentSessions: 5,
+				NetworkRequirements:   nr,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		network NetworkRequirements
+		wantErr string
+	}{
+		{
+			name:    "no requirement, nothing to answer",
+			network: NetworkRequirements{},
+		},
+		{
+			name:    "private network with an explicit deny",
+			network: NetworkRequirements{RequirePrivateNetwork: true, UnknownSourceIP: UnknownSourceIPDeny},
+		},
+		{
+			name:    "private network with an explicit allow",
+			network: NetworkRequirements{RequirePrivateNetwork: true, UnknownSourceIP: UnknownSourceIPAllow},
+		},
+		{
+			// The shape of the defect: the requirement on, and nothing said about the
+			// logins that cannot satisfy it.
+			name:    "private network with no answer",
+			network: NetworkRequirements{RequirePrivateNetwork: true},
+			wantErr: "unknown_source_ip must be",
+		},
+		{
+			name:    "tailscale with no answer",
+			network: NetworkRequirements{RequireTailscale: true},
+			wantErr: "unknown_source_ip must be",
+		},
+		{
+			name:    "a typo is not a decision",
+			network: NetworkRequirements{RequirePrivateNetwork: true, UnknownSourceIP: "denied"},
+			wantErr: `unknown_source_ip is "denied"`,
+		},
+		{
+			// Answered but unused is inert, not an error: an operator staging the
+			// decision before enabling the requirement is not misconfigured.
+			name:    "an answer with no requirement is allowed",
+			network: NetworkRequirements{UnknownSourceIP: UnknownSourceIPDeny},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := withNetwork(tc.network).Validate()
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Validate() = nil, want an error mentioning %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("Validate() = %v, want an error mentioning %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// The shipped configs have to satisfy the rule above or the broker refuses to
+// start with them. configs/production/broker-enterprise.yaml enables both
+// requirements, which is how #169 shipped a config that denied every login.
+func TestShippedConfigsAnswerForAnUnknownSourceIP(t *testing.T) {
+	paths, err := filepath.Glob("../../configs/**/*.yaml")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	more, _ := filepath.Glob("../../configs/*.yaml")
+	paths = append(paths, more...)
+	if len(paths) == 0 {
+		t.Skip("no shipped configs found from this working directory")
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		text := string(data)
+		if !strings.Contains(text, "require_private_network: true") &&
+			!strings.Contains(text, "require_tailscale: true") {
+			continue
+		}
+		if !strings.Contains(text, "unknown_source_ip:") {
+			t.Errorf("%s enables a network requirement without unknown_source_ip, so the broker "+
+				"will refuse to start with it", path)
+		}
+	}
+}

--- a/pkg/pam/pam.go
+++ b/pkg/pam/pam.go
@@ -188,15 +188,27 @@ func (p *PAMModule) AuthenticateUserContext(ctx context.Context, username, servi
 		timeout = brokerclient.DefaultAuthTimeout
 	}
 
+	// (#169) rhost is PAM_RHOST: where the login is coming from, so it is the
+	// request's source_ip — the input to every network policy, the IP allowlists
+	// and the location history. target_host is this machine. Sending rhost as
+	// target_host, and nothing as source_ip, is what made require_private_network
+	// refuse every login. The unabridged rhost goes in metadata for the audit
+	// trail, since source_ip carries only an address.
+	metadata := map[string]interface{}{
+		"service": service,
+		"tty":     tty,
+		"pid":     os.Getpid(),
+	}
+	if rhost != "" {
+		metadata["rhost"] = rhost
+	}
+
 	resp, err := client.AuthenticateAndWait(ctx, &brokerclient.Request{
 		UserID:     username,
-		TargetHost: rhost,
+		SourceIP:   brokerclient.SourceIPFromRHost(rhost),
+		TargetHost: brokerclient.ThisHost(),
 		LoginType:  GetLoginType(service, tty),
-		Metadata: map[string]interface{}{
-			"service": service,
-			"tty":     tty,
-			"pid":     os.Getpid(),
-		},
+		Metadata:   metadata,
 	}, timeout)
 	if err != nil {
 		return p.authFailure(err)

--- a/pkg/pam/pam_test.go
+++ b/pkg/pam/pam_test.go
@@ -2,6 +2,7 @@ package pam
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 )
@@ -97,8 +98,19 @@ func TestBuildAuthRequest(t *testing.T) {
 		t.Errorf("Expected login_type 'ssh', got %s", req.LoginType)
 	}
 
-	if req.TargetHost != rhost {
-		t.Errorf("Expected target_host %s, got %s", rhost, req.TargetHost)
+	// (#169) rhost is where the login came from, so it is source_ip; target_host is
+	// this host. The two used to be the wrong way round.
+	if req.SourceIP != rhost {
+		t.Errorf("Expected source_ip %s, got %s", rhost, req.SourceIP)
+	}
+
+	thisHost, err := os.Hostname()
+	if err == nil && req.TargetHost != thisHost {
+		t.Errorf("Expected target_host to be this host (%s), got %s", thisHost, req.TargetHost)
+	}
+
+	if req.Metadata["rhost"] != rhost {
+		t.Errorf("Expected rhost %s in metadata, got %s", rhost, req.Metadata["rhost"])
 	}
 
 	if req.Metadata["service"] != service {

--- a/pkg/pam/protocol.go
+++ b/pkg/pam/protocol.go
@@ -4,14 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/scttfrdmn/oidc-pam/internal/brokerclient"
 )
 
-// AuthRequest represents an authentication request
+// AuthRequest represents an authentication request.
+//
+// SourceIP is where the login came from and TargetHost is where it is going: this
+// host. See BuildAuthRequest (#169).
 type AuthRequest struct {
 	Type       string            `json:"type"`
 	UserID     string            `json:"user_id"`
 	LoginType  string            `json:"login_type"`
-	TargetHost string            `json:"target_host"`
+	SourceIP   string            `json:"source_ip,omitempty"`
+	TargetHost string            `json:"target_host,omitempty"`
 	Metadata   map[string]string `json:"metadata"`
 }
 
@@ -72,7 +78,12 @@ func GetLoginType(service, tty string) string {
 	}
 }
 
-// BuildAuthRequest builds an authentication request
+// BuildAuthRequest builds an authentication request.
+//
+// (#169) rhost is PAM_RHOST — where the login is coming from — so it becomes
+// source_ip, and only when it really is an address; target_host is this machine.
+// This used to put rhost in target_host and send no source_ip, which is the
+// inversion the broker's policies were then evaluated against.
 func BuildAuthRequest(username, service, rhost, tty string) *AuthRequest {
 	loginType := GetLoginType(service, tty)
 
@@ -81,12 +92,16 @@ func BuildAuthRequest(username, service, rhost, tty string) *AuthRequest {
 		"tty":     tty,
 		"pid":     fmt.Sprintf("%d", os.Getpid()),
 	}
+	if rhost != "" {
+		metadata["rhost"] = rhost
+	}
 
 	return &AuthRequest{
 		Type:       "authenticate",
 		UserID:     username,
 		LoginType:  loginType,
-		TargetHost: rhost,
+		SourceIP:   brokerclient.SourceIPFromRHost(rhost),
+		TargetHost: brokerclient.ThisHost(),
 		Metadata:   metadata,
 	}
 }

--- a/pkg/pam/source_ip_test.go
+++ b/pkg/pam/source_ip_test.go
@@ -1,0 +1,139 @@
+package pam
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// What the Go client puts on the wire for the two fields that say where a login
+// came from and where it is going (#169).
+//
+// This is the other half of TestAuthRequestCarriesSourceIPAndThisHost in
+// cmd/pam-module, which asserts the same thing about the C client. The defect
+// lived in both, identically, because there is no test on either side that looks
+// at the request: source_ip was never sent at all, and PAM_RHOST — the address
+// the user connects *from* — was sent as target_host.
+func TestAuthenticateSendsSourceIPAndThisHost(t *testing.T) {
+	thisHost, err := os.Hostname()
+	if err != nil {
+		t.Skipf("no hostname on this machine: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		rhost        string
+		wantSourceIP string // "" means the field must be absent
+		wantRHost    string // metadata.rhost; "" means absent
+	}{
+		{"an IPv4 peer", "10.0.0.1", "10.0.0.1", "10.0.0.1"},
+		{"an IPv6 peer", "2001:db8::1", "2001:db8::1", "2001:db8::1"},
+		{"a resolved hostname is audit context, not a location", "client.example.com", "", "client.example.com"},
+		{"a console login has no peer at all", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			socket, received := brokerRecordingRequests(t)
+
+			module := NewPAMModule(socket, false)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := module.AuthenticateUserContext(ctx, "testuser", "sshd", tt.rhost, "pts/0"); err != nil {
+				t.Fatalf("AuthenticateUserContext: %v", err)
+			}
+
+			requests := received()
+			if len(requests) != 1 {
+				t.Fatalf("expected exactly one request, got %d", len(requests))
+			}
+			req := requests[0]
+
+			if got := stringField(req, "source_ip"); got != tt.wantSourceIP {
+				t.Errorf("source_ip = %q, want %q (rhost was %q)", got, tt.wantSourceIP, tt.rhost)
+			}
+			if got := stringField(req, "target_host"); got != thisHost {
+				t.Errorf("target_host = %q, want this host %q — target_host is the machine being "+
+					"logged into, not the address the login came from", got, thisHost)
+			}
+			metadata, _ := req["metadata"].(map[string]interface{})
+			if got := stringField(metadata, "rhost"); got != tt.wantRHost {
+				t.Errorf("metadata.rhost = %q, want %q: the unabridged rhost belongs in the audit "+
+					"context even when it is not an address", got, tt.wantRHost)
+			}
+		})
+	}
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+// brokerRecordingRequests starts a broker that authorizes immediately and returns
+// a snapshot of every request it was sent. One request/reply per connection, as
+// the real one does.
+func brokerRecordingRequests(t *testing.T) (socketPath string, received func() []map[string]interface{}) {
+	t.Helper()
+
+	// Not t.TempDir(): the path has to fit sockaddr_un.sun_path, and the temp
+	// directory named after the test can be long.
+	dir, err := os.MkdirTemp("", "oidcpam")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	socketPath = filepath.Join(dir, "b.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", socketPath, err)
+	}
+
+	var (
+		mu   sync.Mutex
+		seen []map[string]interface{}
+		wg   sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed by cleanup
+			}
+			var req map[string]interface{}
+			if err := json.NewDecoder(conn).Decode(&req); err == nil {
+				mu.Lock()
+				seen = append(seen, req)
+				mu.Unlock()
+				_ = json.NewEncoder(conn).Encode(map[string]interface{}{
+					"success":    true,
+					"status":     "authorized",
+					"session_id": "sess-1",
+					"user_id":    "testuser",
+				})
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+		_ = os.RemoveAll(dir)
+	})
+
+	return socketPath, func() []map[string]interface{} {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]map[string]interface{}, len(seen))
+		copy(out, seen)
+		return out
+	}
+}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -61,6 +61,7 @@ recorded — not only on what `ssh` did.
 | --- | --- |
 | `waits_while_pending` | **#120.** While nothing is approved, the login is still *waiting*: not granted, no key, no success event. |
 | `approved_login` | The happy path. Approve mid-flow → the login completes, exactly one `@oidc-pam-` key is installed, the event is recorded, and the verification URL reached the client. |
+| `source_ip_is_the_client_address` | **#169.** The request says the login came *from* `127.0.0.1` and is going *to* this host — not the inverse — and the address reaches the audit record. |
 | `never_approved` | A flow nobody approves ends in refusal after the module's whole budget — not a grant, not a hang. |
 | `denied_by_provider` | A provider refusal is terminal (RFC 8628) and the login is refused *because of it* — asserted from the module log and audit trail, not the clock. |
 | `identity_mismatch` | **#90.** An ID token for `carol` cannot log in as `alice`, however valid it is. |

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -317,6 +317,35 @@ case_approved_login() {
     fi
 }
 
+# #169: which end of the connection each field describes. The module used to send
+# PAM_RHOST as target_host and no source_ip at all, so the broker saw every login
+# as arriving from nowhere and going to the client — and require_private_network,
+# which is evaluated against source_ip, refused every login on the host.
+#
+# sshd and the broker are in this container, so the login comes from 127.0.0.1 and
+# arrives at this container's hostname. Those are different strings, which is what
+# makes the inversion visible here and not in either half's own tests.
+case_source_ip_is_the_client_address() {
+    reset_state alice || return 1
+
+    start_login alice
+    wait_for_polls 1 30 || { kill "${LOGIN_PID}" 2>/dev/null; return 1; }
+    control approve >/dev/null
+    reap_login
+
+    expect_login_ok || return 1
+
+    # pam-sshd sets debug, so the module logs the request it sent. json-c prints a
+    # space after the colon; the patterns tolerate either.
+    expect_module_log '"source_ip": *"127.0.0.1"'
+    expect_module_log "\"target_host\": *\"$(hostname)\""
+    expect_no_module_log '"target_host": *"127.0.0.1"'
+
+    # And the address survives the trip: an audit record that does not say where a
+    # login came from cannot be used to investigate one.
+    expect_audit 'authentication_successful.*"source_ip":"127.0.0.1"'
+}
+
 # #120's other half: a device flow nobody ever approves must end in a refusal,
 # not in a grant and not in a hang. The module's own timeout= is what bounds it.
 case_never_approved() {
@@ -697,6 +726,7 @@ case_broker_down() {
 CASES=(
     waits_while_pending
     approved_login
+    source_ip_is_the_client_address
     long_verification_uri
     never_approved
     denied_by_provider


### PR DESCRIPTION
Fixes #169.

## The defect

Neither client ever populated `source_ip`, and both sent `PAM_RHOST` — the address the login comes **from** — as `target_host`. The two ends of the connection were swapped on the wire, and the one field every network policy reads was never sent at all.

Consequences, all on by configuration rather than by attack:

- `require_private_network` and `require_tailscale` are evaluated against `source_ip`. `net.ParseIP("")` is nil, so enabling either **refused every login on the host**, including the ones it was configured to admit. `configs/production/broker-enterprise.yaml` ships with both on.
- `ip_allowlist` / `ip_denylist` and the geo checks matched nothing, for the same reason.
- The location history recorded an entry with an empty subnet. It matches nothing `IsUnusual` is asked about, but it *does* end the "no history yet" exemption — so every login after a user's first scored "Unusual location" (risk 70) for as long as that entry lived.
- The audit trail recorded the client's address in `target_host`, so an investigation could not tell which machine a login reached, and `authentication_successful` carried no `source_ip` at all while every denial path recorded one.

## What the wire protocol says

`/Users/scttfrdmn/src/oauth2-pam/docs/wire-protocol.md` (version 1) is normative here; oidc-pam consumes that contract (#179).

- `source_ip` — "The client address, if the login has one and it really is an address. Max 45 bytes (an IPv6 literal with a scope). A resolved hostname does not belong here." Optional.
- `target_host` — "The host being logged **into** — this host. Max 253 bytes."
- Metadata: "this client sends `service`, `tty`, `pid`, and the unabridged `rhost`."
- The spec even names this bug: "`source_ip` is where the login came from and `target_host` is where it is going; this project shipped them backwards once."

**Two of the issue's suggested fixes were therefore not implemented.** #169 proposes making `source_ip` required and renaming `target_host` to `client_host`; the spec's compatibility table marks "making an optional field required" and "removing a field" as both requiring a protocol version bump. So `source_ip` stays optional-but-real and `target_host` keeps its name and its documented meaning. The empty case is handled deliberately in policy instead — see below.

## What changed

**Both clients** now send the two fields correctly:

- C module (`cmd/pam-module/cgo_bridge_linux.c`, request-sending path only): new `source_ip_from_rhost()` (`inet_pton`, zone-stripped, bounded at 45) and `this_host()` (`gethostname`, NULL rather than a guess on failure or truncation). Both fields are omitted when unknown rather than sent empty.
- Go path (`internal/brokerclient`, `pkg/pam/pam.go`, `pkg/pam/protocol.go`, `cmd/pam-helper`): shared `brokerclient.SourceIPFromRHost()` / `brokerclient.ThisHost()`, so the two clients cannot drift again. `pam-helper`'s `-rhost` default is now `""` rather than `"localhost"` — inventing a peer for a login that has none is the same mistake in miniature.
- A resolved hostname yields no `source_ip` (sshd supplies one with `UseDNS yes`). Passing it through would be worse than omitting it: a policy would evaluate a string that is not a location and nothing re-resolves it. The unabridged `rhost` reaches the broker in `metadata.rhost`, where it is audit context and decides nothing.

**An absent `source_ip` is now a third answer**, and what it means is the operator's:

- `authentication.network_requirements.unknown_source_ip: deny|allow` is **required** whenever `require_private_network` or `require_tailscale` is enabled, validated at startup. Rationale: a console login legitimately has no address, so the answer cannot be inferred; fail-closed would be the project default, but a policy that denies every login is also a defect, and silently choosing either one is what produced this bug. Making it mandatory breaks nothing real — no deployment can currently have these flags on, because they refuse every login.
- The decision may not key on `login_type` or `metadata.rhost`: the spec says `login_type` "selects how instructions are formatted, nothing more" and that extension fields must never be load-bearing for the authorization decision. That is what forced it to be an explicit config value.
- `allow` is audited per login as a new `network_requirement_waived` event. A requirement that was configured and then not applied must not be invisible.
- Risk scoring counts an unknown origin the same 25 as a public one — it is not evidence of safety — but names it "Unknown network origin" so the score can be read.
- `RecordLocation` no-ops for a login with no recordable location, fixing the permanent "unusual location" verdict.
- `internal/ipc` bounds `source_ip` at 45 and `target_host` at 253 at the boundary, and accepts a zoned IPv6 literal (`fe80::1%eth0`), which `net.ParseIP` rejects on its own. `inet_pton` behaves the same way, so the zone is stripped on both ends.

`applyResourcePolicies`' #158 behaviour (matching on this host's own hostname) is untouched.

## Verification

| Gate | Result |
| --- | --- |
| `go build ./...` | clean |
| `gofmt -l pkg internal cmd` | no output |
| `go vet ./pkg/... ./internal/...` | clean |
| `go test ./pkg/... ./internal/...` | all packages ok |
| `go vet ./cmd/pam-module` + `go test ./cmd/pam-module/...` (in `golang:1.25` + libpam0g-dev + libjson-c-dev, since macOS has no `security/pam_ext.h`) | ok, 2.0s |
| `shellcheck test/e2e/cases.sh`, `cases.sh --list` | clean; new case registered |

**Regression gates.** Every new test was run with its defect temporarily reintroduced, and each failed naming the real problem:

- C client (`target_host = rhost`, no `source_ip`) → `source_ip = "", want "10.0.0.1"` and `target_host = "10.0.0.1", want this host "e874ad67c41f" — target_host is the machine being logged into, not the address the login came from`, in the container.
- Go client (same inversion in `pkg/pam`) → the same two failures for four rhost cases.
- Policy (drop the `SourceIP == ""` branch) → `reason = "Access requires private network connection", want it to mention "requires a known network origin"` and `unknown_source_ip: allow refused a login with no source_ip`.
- Risk factors (`isPrivateIP("")` decides) → `a login with no source_ip was reported as public network access`.
- Location history (record an empty location) → `recorded 1 location(s) for a login with no source_ip, want 0`.
- Config (remove the startup check) → three cases fail, including "a typo is not a decision".
- Shipped config (delete `unknown_source_ip` from `broker-enterprise.yaml`) → `enables a network requirement without unknown_source_ip, so the broker will refuse to start with it`.

Two pre-existing tests had encoded the defect and were corrected: `TestBuildAuthRequest` asserted `target_host == rhost`, and `internal/ipc`'s `validateSourceIP` case list accepted a hostname.

The new e2e case `source_ip_is_the_client_address` was **not** run — the suite builds three container images. It is registered in `CASES` and documented in `test/e2e/README.md`. It asserts, after an approved login, that the module's debug log shows `"source_ip": "127.0.0.1"` and `"target_host": "$(hostname)"` (and *not* `target_host: 127.0.0.1`), and that the `authentication_successful` audit record carries the address. sshd and the broker share the client container, so those two strings differ, which is what makes the inversion visible there and not in either half's own tests.

## Deliberately left out

- **The rest of #179.** Only the `source_ip` / `target_host` part of full wire-protocol conformance is here — the part #169 needs. #179 stays open.
- Making `source_ip` required, and renaming `target_host` → `client_host`, as #169 suggests: both need a protocol version bump under the spec.
- No `.github/workflows/` changes; no unrelated reformatting. The only C changes are in the request-sending path, to stay clear of the concurrent #168 work.

## To raise on oauth2-pam

1. **Zoned IPv6 literals.** The spec sizes `source_ip` at "45 bytes (an IPv6 literal with a scope)", so a zone is clearly in scope, but it does not say whether a receiver must accept `fe80::1%eth0` — and the obvious implementation on both sides (`net.ParseIP`, `inet_pton`) rejects it. Both ends here strip the zone before parsing and send it intact. Worth stating explicitly, or the two projects will disagree on a legal value.
2. **What an absent `source_ip` means to a network requirement.** The spec makes the field optional and is silent on the authorization consequence, which is exactly where this bug lived. `unknown_source_ip` is an oidc-pam-side answer; if oauth2-pam has a position, the field semantics belong in the spec.
3. **`metadata.rhost` when it is not an address.** This client now always sends the unabridged `rhost` there, including a resolved hostname, as the audit context for a login with no `source_ip`. The spec lists `rhost` among the metadata this client sends but does not say it may be a name — worth confirming that is intended, since it is the only remaining record of where such a login came from.
