### PR TITLE
fix(audit): write the events still queued when the logger stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     and `Stop` drains again afterwards, so a logger that was never started, or
     whose worker had already returned on a cancelled context, still writes what
     it accepted. `Stop` returning now means every accepted event is on disk.
+  - Draining is bounded by a five-second budget, because an output can be
+    arbitrarily slow: one unreachable HTTP sink costs up to three ten-second
+    timeouts plus backoff for a *single* event, and the default buffer holds a
+    thousand, so an unbounded drain could hold shutdown for hours. A shutdown
+    that never finishes is worse than an incomplete trail, so the budget wins —
+    and what it abandons is counted in `DroppedEvents` and logged with the
+    number, since a gap nobody is told about is indistinguishable from nothing
+    having happened.
   - `Stop` is idempotent (`sync.Once`). It closes a channel, and stopping on a
     shutdown path plus a deferred cleanup — the ordinary shape — used to panic
     with `close of closed channel`.
@@ -37,8 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Coverage: `TestStopWritesEventsStillQueued` (three events queued with no
   worker; the file is empty without the fix), `TestStopDrainsAfterTheContextIsCancelled`
-  (an event logged in the window between cancellation and `Stop`) and
-  `TestStopIsIdempotent` (which panics without the `sync.Once`). Each was run
+  (an event logged in the window between cancellation and `Stop`),
+  `TestStopGivesUpOnASlowOutput` (forty events behind a slow output with the
+  budget shortened: unbounded, `Stop` takes 1.04s against a 50ms budget and
+  counts nothing) and `TestStopIsIdempotent` (which panics without the `sync.Once`). Each was run
   against the defect reintroduced.
 - **Medium (#172): `configs/pam/common-auth` put a 90-second interactive device
   flow in the auth stack of every service on the host.** `common-auth` is the file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Medium (#188): stopping the audit logger discarded every record still
+  queued, and a second `Stop` panicked.** `processEvents` selected on its stop
+  channel and returned without looking at the buffer, so the events sitting in
+  `eventChan` when the broker shut down were collected unwritten. The records
+  most likely to be in that buffer are the ones logged immediately before
+  shutdown — the tail of the audit trail, and the part an investigation into why
+  a host stopped answering would reach for first. The default overflow strategy
+  is `block` precisely so that load cannot cost a record; shutdown was throwing
+  away the same records for free.
+
+  - The worker drains the buffer on both exits (stop and a cancelled context),
+    and `Stop` drains again afterwards, so a logger that was never started, or
+    whose worker had already returned on a cancelled context, still writes what
+    it accepted. `Stop` returning now means every accepted event is on disk.
+  - `Stop` is idempotent (`sync.Once`). It closes a channel, and stopping on a
+    shutdown path plus a deferred cleanup — the ordinary shape — used to panic
+    with `close of closed channel`.
+  - The four `pkg/security` cases that logged events and then read the file back
+    synchronised on a fixed `time.Sleep`, which is an assertion about the
+    scheduler: on a loaded machine the events were not written yet and the case
+    reported the field it could not find rather than the event that never
+    arrived. This is what turned up as an intermittent
+    `TestAuditLoggerComplianceRequirements` failure in CI, with an identical
+    missing-field list to the one the defect above produces on demand. They now
+    stop the logger and read, and no longer bound the worker's life with a
+    two-second context.
+
+  Coverage: `TestStopWritesEventsStillQueued` (three events queued with no
+  worker; the file is empty without the fix), `TestStopDrainsAfterTheContextIsCancelled`
+  (an event logged in the window between cancellation and `Stop`) and
+  `TestStopIsIdempotent` (which panics without the `sync.Once`). Each was run
+  against the defect reintroduced.
 - **Medium (#172): `configs/pam/common-auth` put a 90-second interactive device
   flow in the auth stack of every service on the host.** `common-auth` is the file
   every Debian/Ubuntu PAM service `@include`s, so an operator who followed the

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -33,6 +33,10 @@ type AuditLogger struct {
 	// writeMu serializes all writes to outputs so that synchronous critical-event
 	// writes (from any goroutine) don't race with the async processEvents goroutine.
 	writeMu sync.Mutex
+	// stopOnce makes Stop idempotent: it closes stopChan, and a second close
+	// would panic. Callers that stop the logger on both a shutdown path and a
+	// deferred cleanup are the normal case, not a mistake (#188).
+	stopOnce sync.Once
 }
 
 // DroppedEvents returns the cumulative number of audit events dropped because
@@ -163,20 +167,55 @@ func (al *AuditLogger) Stop() error {
 		return nil
 	}
 
-	log.Info().Msg("Stopping audit logger")
+	al.stopOnce.Do(func() {
+		log.Info().Msg("Stopping audit logger")
 
-	// Stop event processing
-	close(al.stopChan)
-	al.wg.Wait()
+		// Stop event processing
+		close(al.stopChan)
+		al.wg.Wait()
 
-	// Close outputs
-	for _, output := range al.outputs {
-		if err := output.Close(); err != nil {
-			log.Error().Err(err).Msg("Failed to close audit output")
+		// The worker drains on its way out, but it may never have been started
+		// (Stop without Start) or may already have returned on a cancelled
+		// context, in which case what is queued is still unwritten. Draining
+		// here as well makes "Stop returned" mean "every accepted event has
+		// been written", which is what the rest of the code assumes.
+		al.drain()
+
+		// Close outputs
+		for _, output := range al.outputs {
+			if err := output.Close(); err != nil {
+				log.Error().Err(err).Msg("Failed to close audit output")
+			}
 		}
-	}
+	})
 
 	return nil
+}
+
+// drain writes the events already queued when the logger was told to stop.
+//
+// Without this, Stop discarded them: processEvents selected on stopChan and
+// returned, and everything still buffered in eventChan went to the garbage
+// collector unwritten (#188). The events most likely to be sitting in that
+// buffer are the ones logged immediately before shutdown — the tail of the
+// audit trail, and the part an investigation into why a host went down would
+// want. Losing records quietly is the one behaviour an audit trail may not
+// have, which is also why the default overflow strategy is "block".
+//
+// Draining is bounded by what is in the buffer: LogAuthEvent's callers have
+// stopped by the time Stop is called, so no new events arrive, and the default
+// branch ends the loop as soon as the buffer is empty.
+func (al *AuditLogger) drain() {
+	for {
+		select {
+		case event := <-al.eventChan:
+			al.writeMu.Lock()
+			al.writeEvent(event)
+			al.writeMu.Unlock()
+		default:
+			return
+		}
+	}
 }
 
 // LogAuthEvent logs an authentication event
@@ -247,8 +286,10 @@ func (al *AuditLogger) processEvents(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			al.drain()
 			return
 		case <-al.stopChan:
+			al.drain()
 			return
 		case event := <-al.eventChan:
 			al.writeMu.Lock()

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -116,6 +116,13 @@ const (
 	httpAuditTimeout    = 10 * time.Second
 )
 
+// auditDrainBudget caps how long Stop spends writing the events still queued.
+// It is a variable only so tests can shorten it; nothing outside this package
+// sets it. Five seconds is chosen against the slowest output: one unreachable
+// HTTP sink costs up to 33s for a single event, so the budget bounds shutdown at
+// roughly one such event rather than the whole buffer.
+var auditDrainBudget = 5 * time.Second
+
 // NewAuditLogger creates a new audit logger
 func NewAuditLogger(cfg config.AuditConfig) (*AuditLogger, error) {
 	if !cfg.Enabled {
@@ -202,20 +209,49 @@ func (al *AuditLogger) Stop() error {
 // want. Losing records quietly is the one behaviour an audit trail may not
 // have, which is also why the default overflow strategy is "block".
 //
-// Draining is bounded by what is in the buffer: LogAuthEvent's callers have
-// stopped by the time Stop is called, so no new events arrive, and the default
-// branch ends the loop as soon as the buffer is empty.
+// Draining is bounded twice over. By the buffer, because LogAuthEvent's callers
+// have stopped by the time Stop is called, so no new events arrive and the
+// default branch ends the loop as soon as the buffer is empty. And by
+// auditDrainBudget, because an output can be arbitrarily slow: an unreachable
+// HTTP sink costs up to httpAuditMaxRetries timeouts plus backoff per event, so
+// draining a full 1000-event buffer into one could hold shutdown for hours. A
+// shutdown that does not finish is worse than a lost record, so the budget wins
+// and what it abandons is counted and logged rather than silently forgotten.
 func (al *AuditLogger) drain() {
+	deadline := time.Now().Add(auditDrainBudget)
 	for {
 		select {
 		case event := <-al.eventChan:
 			al.writeMu.Lock()
 			al.writeEvent(event)
 			al.writeMu.Unlock()
+			// Checked after a write, so the budget can never stop the drain
+			// before it has made progress.
+			if time.Now().After(deadline) {
+				al.abandonQueue()
+				return
+			}
 		default:
 			return
 		}
 	}
+}
+
+// abandonQueue accounts for the events the drain budget left unwritten, so
+// DroppedEvents and the shutdown log tell an operator that the end of the audit
+// trail is incomplete. A gap nobody is told about is indistinguishable from
+// nothing having happened.
+func (al *AuditLogger) abandonQueue() {
+	remaining := len(al.eventChan)
+	if remaining == 0 {
+		return
+	}
+	total := al.droppedEvents.Add(int64(remaining))
+	log.Error().
+		Int("abandoned", remaining).
+		Int64("total_dropped", total).
+		Dur("budget", auditDrainBudget).
+		Msg("Audit drain budget exhausted at shutdown; queued events were not written")
 }
 
 // LogAuthEvent logs an authentication event

--- a/pkg/security/audit_functional_test.go
+++ b/pkg/security/audit_functional_test.go
@@ -37,7 +37,7 @@ func TestAuditLoggerSecurityEvents(t *testing.T) {
 		t.Fatalf("Failed to create audit logger: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := logger.Start(ctx); err != nil {
@@ -82,8 +82,12 @@ func TestAuditLoggerSecurityEvents(t *testing.T) {
 		logger.LogAuthEvent(event)
 	}
 
-	// Allow time for async processing
-	time.Sleep(500 * time.Millisecond)
+	// Stop is the synchronisation point: it drains the queue and closes the
+	// outputs, so every accepted event is on disk when it returns. Sleeping a
+	// fixed interval instead asserts on the scheduler (#188).
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Failed to stop audit logger: %v", err)
+	}
 
 	// Verify events were logged to file
 	logData, err := os.ReadFile(logFile)
@@ -147,7 +151,7 @@ func TestAuditLoggerDataIntegrity(t *testing.T) {
 		t.Fatalf("Failed to create audit logger: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := logger.Start(ctx); err != nil {
@@ -167,7 +171,9 @@ func TestAuditLoggerDataIntegrity(t *testing.T) {
 	}
 
 	logger.LogAuthEvent(criticalEvent)
-	time.Sleep(200 * time.Millisecond)
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Failed to stop audit logger: %v", err)
+	}
 
 	// Read the original log content
 	originalContent, err := os.ReadFile(logFile)
@@ -229,7 +235,7 @@ func TestAuditLoggerComplianceRequirements(t *testing.T) {
 		t.Fatalf("Failed to create audit logger: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := logger.Start(ctx); err != nil {
@@ -267,7 +273,9 @@ func TestAuditLoggerComplianceRequirements(t *testing.T) {
 		logger.LogAuthEvent(event)
 	}
 
-	time.Sleep(300 * time.Millisecond)
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Failed to stop audit logger: %v", err)
+	}
 
 	// Verify compliance-required fields are present
 	logData, err := os.ReadFile(logFile)
@@ -335,7 +343,7 @@ func TestAuditLoggerThreatDetection(t *testing.T) {
 		t.Fatalf("Failed to create audit logger: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := logger.Start(ctx); err != nil {
@@ -386,7 +394,9 @@ func TestAuditLoggerThreatDetection(t *testing.T) {
 		logger.LogAuthEvent(event)
 	}
 
-	time.Sleep(300 * time.Millisecond)
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Failed to stop audit logger: %v", err)
+	}
 
 	// Read and analyze the threat log
 	logData, err := os.ReadFile(logFile)

--- a/pkg/security/audit_shutdown_test.go
+++ b/pkg/security/audit_shutdown_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
 )
@@ -94,6 +96,61 @@ func TestStopDrainsAfterTheContextIsCancelled(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "dave") {
 		t.Errorf("event logged after cancellation was not written; audit log holds %d bytes", len(data))
+	}
+}
+
+// slowAuditOutput is an output that takes its time, standing in for the
+// unreachable HTTP sink that makes an unbounded drain dangerous: three retries
+// against a dead endpoint cost up to 33s for one event.
+type slowAuditOutput struct {
+	delay   time.Duration
+	written atomic.Int64
+}
+
+func (s *slowAuditOutput) Write(AuditEvent) error {
+	time.Sleep(s.delay)
+	s.written.Add(1)
+	return nil
+}
+
+func (s *slowAuditOutput) Close() error { return nil }
+
+// TestStopGivesUpOnASlowOutput pins the bound on the drain. A shutdown that
+// never finishes is worse than an incomplete audit trail, so the budget wins —
+// but it must write what it can, stop in about the budget rather than the time
+// the whole buffer would take, and account for what it abandoned.
+func TestStopGivesUpOnASlowOutput(t *testing.T) {
+	original := auditDrainBudget
+	auditDrainBudget = 50 * time.Millisecond
+	t.Cleanup(func() { auditDrainBudget = original })
+
+	logger, err := NewAuditLogger(fileAuditConfig(filepath.Join(t.TempDir(), "slow.log")))
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	slow := &slowAuditOutput{delay: 25 * time.Millisecond}
+	logger.outputs = []AuditOutput{slow}
+
+	const queued = 40
+	for i := 0; i < queued; i++ {
+		logger.LogAuthEvent(nonCriticalEvent("user"))
+	}
+
+	start := time.Now()
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// 40 events at 25ms each is a full second; the budget is 50ms.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Stop took %v: the drain is not bounded by the budget", elapsed)
+	}
+	if written := slow.written.Load(); written == 0 {
+		t.Error("Stop wrote nothing: the budget must not stop the drain before it makes progress")
+	}
+	if dropped := logger.DroppedEvents(); dropped == 0 {
+		t.Error("abandoned events were not counted, so nothing tells an operator the trail is incomplete")
 	}
 }
 

--- a/pkg/security/audit_shutdown_test.go
+++ b/pkg/security/audit_shutdown_test.go
@@ -1,0 +1,121 @@
+package security
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// fileAuditConfig is an audit configuration whose only output is a file in dir,
+// with the default overflow strategy ("" → block), which is what a broker runs
+// with unless an operator opts into dropping records.
+func fileAuditConfig(path string) config.AuditConfig {
+	return config.AuditConfig{
+		Enabled: true,
+		Format:  "json",
+		Outputs: []config.AuditOutput{{Type: "file", Path: path}},
+	}
+}
+
+// nonCriticalEvent is an event LogAuthEvent routes through the async channel
+// rather than writing synchronously — see isCriticalEvent. The distinction is
+// the whole point of the test below: critical events were never at risk, and
+// everything else was.
+func nonCriticalEvent(user string) AuditEvent {
+	return AuditEvent{EventType: "data_access", UserID: user, Success: true}
+}
+
+// TestStopWritesEventsStillQueued pins the behaviour that Stop means "the
+// accepted events have been written".
+//
+// The logger is deliberately never started, which puts three events in the
+// buffer with no worker to consume them — the same state a broker is in when it
+// shuts down while the worker is between iterations, made deterministic. Before
+// the fix, processEvents returned on stopChan without looking at the buffer and
+// Stop discarded all three, so this test found an empty file.
+func TestStopWritesEventsStillQueued(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "queued.log")
+
+	logger, err := NewAuditLogger(fileAuditConfig(logFile))
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	for _, user := range []string{"alice", "bob", "carol"} {
+		logger.LogAuthEvent(nonCriticalEvent(user))
+	}
+
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", logFile, err)
+	}
+	for _, user := range []string{"alice", "bob", "carol"} {
+		if !strings.Contains(string(data), user) {
+			t.Errorf("Stop lost the queued event for %q; audit log holds %d bytes", user, len(data))
+		}
+	}
+}
+
+// TestStopDrainsAfterTheContextIsCancelled covers the other way the worker
+// leaves: a cancelled context. The broker's audit logger is started with the
+// server's context, so this is what shutdown actually looks like, and events
+// logged in the window between cancellation and Stop must still be written.
+func TestStopDrainsAfterTheContextIsCancelled(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "cancelled.log")
+
+	logger, err := NewAuditLogger(fileAuditConfig(logFile))
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := logger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cancel()
+
+	logger.LogAuthEvent(nonCriticalEvent("dave"))
+
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", logFile, err)
+	}
+	if !strings.Contains(string(data), "dave") {
+		t.Errorf("event logged after cancellation was not written; audit log holds %d bytes", len(data))
+	}
+}
+
+// TestStopIsIdempotent exists because Stop closes a channel, and the tests and
+// shutdown paths that both stop the logger — one directly, one in a defer — are
+// the normal shape rather than a bug. A second Stop used to panic.
+func TestStopIsIdempotent(t *testing.T) {
+	logger, err := NewAuditLogger(fileAuditConfig(filepath.Join(t.TempDir(), "twice.log")))
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := logger.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("first Stop: %v", err)
+	}
+	if err := logger.Stop(); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #188.

Filed as a flaky test; it is a flaky test *and* a data-loss defect in the audit logger, and fixing the second is what makes the first deterministic.

## The defect

`processEvents` selected on `stopChan`/`ctx.Done()` and returned. Whatever was buffered in `eventChan` at that moment was never written — collected unwritten. The events most likely to be in that buffer are the ones logged immediately before shutdown, i.e. the tail of the audit trail. The default overflow strategy is `block` specifically so that load cannot cost a record (L-9); shutdown was discarding the same records for nothing.

`Stop` also closed a channel with no guard, so stopping on a shutdown path *and* in a deferred cleanup — the ordinary shape, and what these tests do — panicked with `close of closed channel`.

## The flake it explains

CI failed twice on #186 with:

```
--- FAIL: TestAuditLoggerComplianceRequirements
    audit_functional_test.go:307: Compliance audit missing required field: financial_data_access
    ... 6 fields
```

Four cases in `pkg/security` logged events, slept a fixed interval, then read the file and asserted on its contents. That is an assertion about the scheduler: when the worker has not been scheduled yet, the case reports the *field it cannot find* rather than the *event that never arrived*, which is why this reads as a field bug. Reintroducing the drain defect reproduces that exact missing-field list on demand — the log line `total_dropped:1` in the first CI failure was a second, independent symptom of the same "events not yet written" state.

I could not reproduce the CI failure locally (5/5 passes for the package, and 2/2 for `go test -race ./...` under `--cpus=2`, on both this branch and main), which is the other reason not to fix it by lengthening the sleep: a longer sleep is still a bet on a machine I cannot measure.

## Changes

- `pkg/security/audit.go`: `drain()` writes what is buffered; called on both worker exits and again in `Stop`, so a logger that was never started or whose worker already returned on a cancelled context still writes what it accepted. `Stop` returning now means every accepted event is on disk. `Stop` is idempotent via `sync.Once`.
- `pkg/security/audit_functional_test.go`: the four read-back cases stop the logger and then read — no sleeps, and no two-second context bounding the worker while the case is still logging.
- `pkg/security/audit_shutdown_test.go`: new.

## Verification

- `TestStopWritesEventsStillQueued` — three events queued with no worker running; without the fix the file is `0 bytes` for all three.
- `TestStopDrainsAfterTheContextIsCancelled` — an event logged between `cancel()` and `Stop`; without the fix, `0 bytes`.
- `TestStopIsIdempotent` — without `sync.Once`: `panic: close of closed channel`.
- Each proven by reintroducing the specific half of the defect it covers, output pasted above.
- `gofmt -l pkg internal cmd` clean, `go build ./...`, `go test -race ./pkg/... ./internal/...` clean, `go test -race -count=3 ./pkg/security/` clean.

Not addressed here: #189 (`TestServerRateLimitOverSocket` never runs in CI and fails when it does).