### PR TITLE
fix(auth): require an ID token, prefer it over /userinfo, and check every endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inheriting the first's `debug`, and `success` as the string `"false"`, the string
   `"true"`, `1` and `null` each refused rather than granted. A fourth test reads
   `configs/pam` and fails if a shipped stack passes `debug`.
+- **Medium (#167): a token response with no `id_token` was accepted with nothing
+  verified at all, an unsigned `/userinfo` body outranked the signed token where the
+  two disagreed, and two of the three endpoints the broker sends credentials to were
+  never checked.** The whole verification block in `PollDeviceAuthorization` —
+  signature, `iss`, `aud`, `exp`, the nonce replay check and `validateIDTokenClaims`
+  — sat behind `if tokenResp.IDToken != ""`, so a provider that simply omitted the
+  field got an identity read out of `/userinfo` and vouched for by nothing but TLS
+  and the bearer token. Where an ID token *was* present, the merge that decides which
+  claim authorizes the login preferred `/userinfo` anyway. The endpoint gap is the
+  sharpest of the three and needs no misbehaving provider: `validateEndpoint` ran on
+  the device authorization endpoint only, while the token and userinfo endpoints were
+  taken from the discovery document unvalidated, so a discovery response naming
+  `http://` had the broker post the device code to, and carry the access token to, a
+  plaintext endpoint — with `trusted_ca_bundle`, `skip_tls_verify` and the
+  certificate pins all bypassed, because none of them apply to a connection that
+  never negotiates TLS.
+
+  - `require_id_token`, per provider, defaults to **on**: a granted authorization
+    with no `id_token` is refused, leaves no session and no SSH key, and is audited
+    as `ID_TOKEN_MISSING` naming the key that would permit it. The field is a
+    `*bool`, so unset means required in configs built in Go as well as in loaded
+    YAML — the fail-closed direction for every deployment that has never heard of
+    the key. An operator whose provider genuinely does not issue an ID token for the
+    device grant sets it to false and gets the old behaviour, deliberately.
+  - The ID token now wins over `/userinfo` wherever the two disagree. Claims only
+    `/userinfo` returns are still used, since the signed token says nothing about
+    them, so this changes which value is believed in a conflict and not how much of
+    the identity is available.
+  - The token, userinfo and device authorization endpoints are all checked when the
+    provider is built, which refuses a provider like this at broker startup rather
+    than one login at a time. Only the scheme is enforced there, deliberately: a
+    token endpoint on a host other than the issuer's is ordinary — Google's issuer
+    is `accounts.google.com` and its token endpoint is on `oauth2.googleapis.com` —
+    so extending the issuer-host match that the device endpoint has always demanded
+    would refuse real providers outright. What an endpoint cannot be is plaintext.
+  - Loopback is still exempt from that check, for local development and the test
+    issuer, but is matched exactly now rather than by prefix: the old
+    `strings.HasPrefix(u.Host, "localhost")` took `localhost.attacker.example` for
+    the local machine and allowed plaintext to it.
+  - Out of scope, and both left alone on purpose: refresh responses, where RFC 6749
+    §6 makes `id_token` optional and the refresh path derives no identity from
+    claims; and `security.tls_verification.pin_certificates` as documented in
+    `CONFIGURATION-GUIDE.md`, which matches no config field and so pins nothing
+    (#170).
+
+  Coverage: five tests in `pkg/auth/provider_trust_test.go`. Three drive the real
+  poll loop against the in-process issuer — a grant with the `id_token` withheld
+  refused and audited as `ID_TOKEN_MISSING`; the same grant admitted under
+  `require_id_token: false`, so the escape hatch is known to work; and an ID token
+  and a `/userinfo` body naming different users, asserted in both directions, so
+  that the signed claim is the one that binds *and* the unsigned one cannot
+  authorize a login the signature contradicts. The other two go through
+  `NewOIDCProvider` against a discovery document naming `http://` for each endpoint
+  in turn, and against configured endpoints under `skip_discovery`, including the
+  `localhost.…` host and a legitimate cross-host HTTPS token endpoint that must
+  still be accepted. Reintroducing any one of the three defects fails the
+  corresponding test.
 - **Low (#166): `allowed_groups` and `allowed_roles` denied nothing.** Both were
   applied while claims were being read, where the only thing they could do was drop
   the group and role names that were not in the list. A user in **none** of the

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -411,6 +411,50 @@ audit:
     - "policy_violations"
 ```
 
+### 6. How Far the Provider Is Trusted
+
+Two things about a device-flow login are checked by the broker rather than taken on
+the provider's word, and both are on by default.
+
+**An ID token is required.** The ID token is the only part of a token response the
+broker can verify: the signature, the issuing `iss`, the `aud` that says the token was
+minted for *this* client, the expiry, and the nonce that makes a replayed token
+useless are all claims inside it. A response without one leaves the identity coming
+from `/userinfo`, which is authenticated by nothing but TLS and the bearer token, so
+the broker refuses it and audits `ID_TOKEN_MISSING`. Where the two sources disagree
+the ID token wins; claims that only `/userinfo` returns are still used, since the
+signed token says nothing about them.
+
+Set `require_id_token: false` only for a provider that genuinely does not issue an ID
+token for the device grant, understanding that its logins are then authorized by an
+unsigned JSON body:
+
+```yaml
+oidc:
+  providers:
+    - name: legacy-idp
+      issuer: "https://idp.example.com"
+      client_id: "oidc-pam"
+      scopes: ["openid", "email", "profile"]
+      # Accepts an identity asserted only by /userinfo: no signature, audience,
+      # expiry or replay check is then possible. Check the scopes first — a missing
+      # `openid` scope is the usual reason a provider returns no id_token.
+      require_id_token: false
+      enabled_for_login: true
+```
+
+**Every endpoint must be HTTPS.** The token, userinfo and device authorization
+endpoints all come out of the provider's `/.well-known/openid-configuration` (or, under
+`skip_discovery`, out of this file), and each of them receives either the device code
+or an access token. The broker refuses at startup to use one that names `http://`,
+because a plaintext connection silently bypasses `trusted_ca_bundle` and the
+certificate pins — those only apply to a connection that negotiates TLS. Loopback
+(`localhost`, `127.0.0.1`, `::1`) is the sole exception, for local development.
+
+The host is not required to match the issuer: a token endpoint on a different host is
+ordinary — Google's issuer is `accounts.google.com` and its token endpoint is on
+`oauth2.googleapis.com`. Only the scheme is enforced.
+
 ## Binding an OIDC Identity to a Local Account
 
 `user_mapping.username_claim` names the claim whose value must equal the local

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -49,6 +49,13 @@ oidc:
       # verification_only: this provider may confirm an identity but must never
       # be the one a login is issued against.
       verification_only: false
+      # require_id_token is the default, and is spelled out here only to say so: the
+      # ID token is the only part of a token response that can be verified at all
+      # (signature, aud, exp, nonce), and without one the identity comes from
+      # /userinfo with nothing vouching for it but TLS and the bearer token. Set it
+      # to false only for a provider that does not issue an ID token for the device
+      # grant. See CONFIGURATION-GUIDE.md, "How Far the Provider Is Trusted".
+      require_id_token: true
 
     # Example: Azure AD configuration  
     - name: "azure-corporate"

--- a/internal/testoidc/issuer.go
+++ b/internal/testoidc/issuer.go
@@ -51,8 +51,11 @@ type Issuer struct {
 	script      []Outcome
 	polls       int
 	claims      map[string]any
+	userInfo    map[string]any    // what /userinfo returns, when it differs; see SetUserInfoClaims
 	devices     map[string]string // device_code -> nonce received at the device endpoint
 	uriPadBytes int               // extra bytes in verification_uri, see SetVerificationURIPadding
+	omitIDToken bool              // grant without an id_token, see SetOmitIDToken
+	endpoints   map[string]string // discovery overrides, see SetEndpointOverride
 }
 
 // DefaultClaims is the claim set a fresh Issuer puts in ID tokens and returns
@@ -140,6 +143,47 @@ func (i *Issuer) Claims() map[string]any {
 	return i.claims
 }
 
+// SetUserInfoClaims makes /userinfo answer with its own claim set instead of the
+// one the ID token carries, so the two can disagree.
+//
+// Real providers differ between the two endpoints all the time — different scopes
+// are reflected in each, and some claims are only ever returned by /userinfo — and
+// an issuer whose two answers are identical cannot show which of them a client
+// believes. That is what #167 was: /userinfo took precedence, so the value that
+// authorized the login came from an unsigned JSON body even when a signed ID token
+// said something else. Pass nil to go back to serving the ID token's claims.
+func (i *Issuer) SetUserInfoClaims(claims map[string]any) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.userInfo = claims
+}
+
+// SetOmitIDToken makes a granting token response leave out id_token, as a provider
+// that does not implement OIDC on the device grant does. Everything a client can
+// verify is in that token, so an identity built from such a response is asserted by
+// nothing but TLS and the bearer token (#167).
+func (i *Issuer) SetOmitIDToken(omit bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.omitIDToken = omit
+}
+
+// SetEndpointOverride makes the discovery document advertise url for the named
+// endpoint ("token_endpoint", "userinfo_endpoint", ...) instead of this issuer's
+// own. An empty url drops the key from the document entirely.
+//
+// Both a legitimate and a hostile provider do this: Google's token endpoint is on
+// a different host from its issuer, while a tampered discovery response naming
+// http:// is how a client ends up posting an access token in cleartext (#167).
+func (i *Issuer) SetEndpointOverride(name, url string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.endpoints == nil {
+		i.endpoints = make(map[string]string)
+	}
+	i.endpoints[name] = url
+}
+
 // Polls is the number of token-endpoint requests received since the issuer was
 // created or last Reset.
 func (i *Issuer) Polls() int {
@@ -186,8 +230,11 @@ func (i *Issuer) Reset() {
 	defer i.mu.Unlock()
 	i.polls = 0
 	i.claims = DefaultClaims()
+	i.userInfo = nil
 	i.devices = make(map[string]string)
 	i.uriPadBytes = 0
+	i.omitIDToken = false
+	i.endpoints = nil
 }
 
 // Handler serves the OIDC endpoints. The paths are also what the discovery
@@ -204,8 +251,15 @@ func (i *Issuer) Handler() http.Handler {
 }
 
 func (i *Issuer) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
-	base := i.IssuerURL()
-	writeJSON(w, http.StatusOK, map[string]any{
+	i.mu.Lock()
+	base := i.issuerURL
+	overrides := make(map[string]string, len(i.endpoints))
+	for name, url := range i.endpoints {
+		overrides[name] = url
+	}
+	i.mu.Unlock()
+
+	doc := map[string]any{
 		"issuer":                                base,
 		"authorization_endpoint":                base + "/authorize",
 		"token_endpoint":                        base + "/token",
@@ -217,7 +271,15 @@ func (i *Issuer) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
 			"authorization_code",
 			"urn:ietf:params:oauth:grant-type:device_code",
 		},
-	})
+	}
+	for name, url := range overrides {
+		if url == "" {
+			delete(doc, name)
+			continue
+		}
+		doc[name] = url
+	}
+	writeJSON(w, http.StatusOK, doc)
 }
 
 func (i *Issuer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
@@ -289,6 +351,7 @@ func (i *Issuer) handleToken(w http.ResponseWriter, r *http.Request) {
 	outcome := i.script[min(i.polls, len(i.script)-1)]
 	i.polls++
 	claims := i.claims
+	omitIDToken := i.omitIDToken
 	i.mu.Unlock()
 
 	if !known {
@@ -306,18 +369,21 @@ func (i *Issuer) handleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	idToken, err := i.signIDToken(claims, nonce)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "server_error"})
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	grant := map[string]any{
 		"access_token":  "access-" + randomString(),
 		"refresh_token": "refresh-" + randomString(),
-		"id_token":      idToken,
 		"token_type":    "Bearer",
 		"expires_in":    3600,
-	})
+	}
+	if !omitIDToken {
+		idToken, err := i.signIDToken(claims, nonce)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "server_error"})
+			return
+		}
+		grant["id_token"] = idToken
+	}
+	writeJSON(w, http.StatusOK, grant)
 }
 
 // checkClient rejects a request that does not identify itself as the client this
@@ -341,7 +407,13 @@ func (i *Issuer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "invalid_token"})
 		return
 	}
-	writeJSON(w, http.StatusOK, i.Claims())
+	i.mu.Lock()
+	claims := i.userInfo
+	if claims == nil {
+		claims = i.claims
+	}
+	i.mu.Unlock()
+	writeJSON(w, http.StatusOK, claims)
 }
 
 // signIDToken builds an RS256 JWT over claims, with the registered claims the

--- a/internal/testoidc/testoidc.go
+++ b/internal/testoidc/testoidc.go
@@ -64,5 +64,17 @@ func (s *Server) Script(outcomes ...Outcome) { s.iss.Script(outcomes...) }
 // See Issuer.SetClaims.
 func (s *Server) SetClaims(claims map[string]any) { s.iss.SetClaims(claims) }
 
+// SetUserInfoClaims makes /userinfo answer with its own claim set, so it can
+// disagree with the ID token. See Issuer.SetUserInfoClaims.
+func (s *Server) SetUserInfoClaims(claims map[string]any) { s.iss.SetUserInfoClaims(claims) }
+
+// SetOmitIDToken makes a granting token response leave out id_token. See
+// Issuer.SetOmitIDToken.
+func (s *Server) SetOmitIDToken(omit bool) { s.iss.SetOmitIDToken(omit) }
+
+// SetEndpointOverride changes what the discovery document advertises for one
+// endpoint. See Issuer.SetEndpointOverride.
+func (s *Server) SetEndpointOverride(name, url string) { s.iss.SetEndpointOverride(name, url) }
+
 // Polls is the number of token-endpoint requests received so far.
 func (s *Server) Polls() int { return s.iss.Polls() }

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -1637,6 +1637,14 @@ func classifyPollError(err error) string {
 	}
 	msg := strings.ToLower(err.Error())
 	switch {
+	// A grant carrying no id_token at all (#167). Its own code, because nothing
+	// was wrong with an ID token — there was none to check — and the operator's
+	// next move is a provider scope or claim-mapping change, not an
+	// investigation of this user. Matched on the underscore spelling, and first,
+	// so that the wording of a message that has to explain what could not be
+	// verified cannot land it in one of the cases below.
+	case strings.Contains(msg, "no id_token"):
+		return "ID_TOKEN_MISSING"
 	case strings.Contains(msg, "nonce"):
 		return "NONCE_INVALID"
 	case strings.Contains(msg, "verify id token"), strings.Contains(msg, "claim validation"):

--- a/pkg/auth/classify_poll_error_test.go
+++ b/pkg/auth/classify_poll_error_test.go
@@ -18,6 +18,11 @@ func TestClassifyPollError(t *testing.T) {
 		"failed to decode token response":           "DECODE_ERROR",
 		"failed to poll device authorization: dial": "NETWORK_ERROR",
 		"something entirely unexpected":             "POLL_FAILED",
+		// (#167) A grant carrying no ID token at all is its own condition, and the
+		// message has to be able to say which checks were impossible without being
+		// classified as one of them having failed.
+		`provider "idp" granted the device authorization but returned no id_token, so this ` +
+			`authorization cannot be verified at all`: "ID_TOKEN_MISSING",
 	}
 	for msg, want := range cases {
 		var err error

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -231,6 +232,20 @@ func NewOIDCProvider(providerCfg OIDCProviderConfig, secCfg config.SecurityConfi
 		}
 	}
 
+	// Every endpoint the broker is about to send credentials to has to be checked,
+	// not just the device authorization endpoint (#167). The token endpoint and
+	// /userinfo come straight out of the discovery document, and a discovery
+	// response naming http:// meant the access token went over the wire in
+	// cleartext — with the CA bundle, the skip-verify flag and the certificate pins
+	// above all bypassed, since none of them apply to a plaintext connection.
+	//
+	// Load time is the place for it: all three URLs are fixed when the provider is
+	// built, so checking here refuses at broker startup rather than mid-login, and
+	// there is no later moment at which they can change.
+	if err := validateProviderEndpoints(providerCfg.Name, provider); err != nil {
+		return nil, err
+	}
+
 	return &OIDCProvider{
 		Name:           providerCfg.Name,
 		Config:         providerCfg,
@@ -293,6 +308,77 @@ func buildTLSConfig(secCfg config.SecurityConfig) (*tls.Config, error) {
 	}
 
 	return tlsCfg, nil
+}
+
+// validateProviderEndpoints refuses a provider whose token, userinfo or device
+// authorization endpoint is not reachable over TLS. The three URLs are whatever
+// discovery returned (or, under skip_discovery, whatever was configured), and each
+// one receives either the device code, the client's credentials or the access
+// token.
+//
+// Only the scheme is checked, deliberately, and not the host: a token endpoint on
+// a different host from the issuer is normal rather than suspicious — Google's
+// issuer is accounts.google.com and its token endpoint is on
+// oauth2.googleapis.com, and Cognito's userinfo lives on a different domain again.
+// Requiring an issuer-host match here (as the device authorization endpoint does,
+// where it has always held) would refuse those providers outright. What it cannot
+// be is plaintext, because that is what silently disables every TLS control the
+// operator configured.
+func validateProviderEndpoints(name string, provider *oidc.Provider) error {
+	if provider == nil {
+		return fmt.Errorf("provider %q was not initialized", name)
+	}
+	endpoints := []struct {
+		label string
+		url   string
+	}{
+		{"token_endpoint", provider.Endpoint().TokenURL},
+		{"userinfo_endpoint", provider.UserInfoEndpoint()},
+		{"device_authorization_endpoint", provider.Endpoint().DeviceAuthURL},
+	}
+	for _, e := range endpoints {
+		// An absent endpoint is a different problem, handled where it is needed:
+		// a missing userinfo endpoint falls back to the ID token's claims, and a
+		// missing device endpoint is rediscovered by StartDeviceFlow.
+		if e.url == "" {
+			continue
+		}
+		if err := requireTLSEndpoint(e.url); err != nil {
+			return fmt.Errorf("provider %q: %s %w", name, e.label, err)
+		}
+	}
+	return nil
+}
+
+// requireTLSEndpoint reports whether an endpoint URL can be spoken to without
+// giving up the transport. Loopback is exempt so the test issuer (and a local
+// development provider) can be served over plain HTTP without a certificate;
+// nothing else is, in any mode.
+func requireTLSEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid URL: %w", endpoint, err)
+	}
+	if u.Scheme == "https" || isLoopbackHost(u.Host) {
+		return nil
+	}
+	return fmt.Errorf("%q must use HTTPS, got scheme %q", endpoint, u.Scheme)
+}
+
+// isLoopbackHost reports whether a URL host (which may carry a port) is the local
+// machine. Matched exactly rather than by prefix: "localhost.attacker.example" is
+// not loopback.
+func isLoopbackHost(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 // StartDeviceFlow initiates the OAuth2 device authorization flow
@@ -443,6 +529,21 @@ func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode, 
 		return nil, fmt.Errorf("no access token in response")
 	}
 
+	// (#167) No ID token used to mean no verification of any kind: the whole block
+	// below — signature, issuer, audience, expiry, the nonce replay check and
+	// validateIDTokenClaims — is conditional on there being one, so a response
+	// without an id_token produced an identity read out of /userinfo and vouched
+	// for by nothing but TLS and the bearer token. Refuse it by default instead,
+	// and let an operator whose provider really does not issue ID tokens for the
+	// device grant say so explicitly.
+	if tokenResp.IDToken == "" && p.Config.IDTokenRequired() {
+		return nil, fmt.Errorf("provider %q granted the device authorization but returned no id_token, "+
+			"so this authorization cannot be verified at all — the signature, audience, expiry and "+
+			"replay check all live in the ID token. Request the openid scope, or set "+
+			"require_id_token: false on this provider to accept an identity asserted only by /userinfo",
+			p.Name)
+	}
+
 	// Parse and verify ID token if present
 	var claims map[string]interface{}
 	if tokenResp.IDToken != "" {
@@ -544,13 +645,16 @@ func (p *OIDCProvider) GetUserInfo(token *Token) (*UserInfo, error) {
 		return nil, fmt.Errorf("failed to decode userinfo response: %w", err)
 	}
 
-	// Merge with ID token claims if available
-	if token.Claims != nil {
-		for key, value := range token.Claims {
-			if _, exists := userInfoClaims[key]; !exists {
-				userInfoClaims[key] = value
-			}
-		}
+	// Merge the two claim sets, with the ID token winning wherever they disagree
+	// (#167). It used to be the other way round — /userinfo filled gaps *and* took
+	// precedence — which meant the value that authorizes the login, username_claim,
+	// could come from this unsigned JSON body even when a signed ID token said
+	// something else. The ID token is the assertion the provider actually signed
+	// and the verifier checked; /userinfo is authenticated by TLS and a bearer
+	// token, and is often the richer of the two, so claims it alone carries are
+	// still kept.
+	for key, value := range token.Claims {
+		userInfoClaims[key] = value
 	}
 
 	return p.extractUserInfoFromClaims(userInfoClaims)
@@ -702,16 +806,17 @@ func (p *OIDCProvider) getDeviceAuthorizationEndpoint() (string, error) {
 		return "", fmt.Errorf("invalid issuer URL: %w", err)
 	}
 
-	// validateEndpoint ensures the endpoint uses HTTPS (or localhost/127.0.0.1 for testing)
-	// and that its host matches the issuer host.
+	// validateEndpoint ensures the endpoint uses HTTPS (or loopback for testing)
+	// and that its host matches the issuer host. The scheme half is shared with the
+	// token and userinfo endpoints, which are checked when the provider is built
+	// (#167); the issuer-host half is specific to this endpoint.
 	validateEndpoint := func(endpoint string) error {
+		if err := requireTLSEndpoint(endpoint); err != nil {
+			return fmt.Errorf("endpoint %w", err)
+		}
 		u, err := url.Parse(endpoint)
 		if err != nil {
 			return fmt.Errorf("invalid endpoint URL: %w", err)
-		}
-		isLocalhost := strings.HasPrefix(u.Host, "localhost") || strings.HasPrefix(u.Host, "127.0.0.1")
-		if u.Scheme != "https" && !isLocalhost {
-			return fmt.Errorf("endpoint must use HTTPS, got %q", u.Scheme)
 		}
 		if u.Host != issuerURL.Host {
 			return fmt.Errorf("endpoint host %q does not match issuer host %q", u.Host, issuerURL.Host)

--- a/pkg/auth/provider_trust_test.go
+++ b/pkg/auth/provider_trust_test.go
@@ -1,0 +1,304 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/internal/testoidc"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// These tests are about how much the broker takes the provider's word for (#167).
+// Each one runs through Broker.pollDeviceAuthorization against the in-process
+// issuer, or through NewOIDCProvider against its discovery document, because all
+// three defects were in what the *real* path accepts rather than in any single
+// function's logic: the verification block was skipped for want of an ID token, the
+// merge that decided which claim authorizes a login preferred the unsigned one, and
+// two of the three endpoints were never checked before credentials went to them.
+
+// requireIDToken is the pointer form of the per-provider flag, so a test can say
+// which of the two states it means rather than relying on the zero value.
+func requireIDToken(v bool) *bool { return &v }
+
+// A granting token response with no id_token is refused under the default.
+//
+// The ID token is the only verifiable part of that response: signature, issuer,
+// audience, expiry and the nonce the broker sent are all in it, and every one of
+// those checks sat behind `if tokenResp.IDToken != ""`. A provider that simply
+// omitted the field therefore produced a session whose identity came from
+// /userinfo — a JSON body vouched for by nothing but TLS and the bearer token —
+// with no audience check at all, so a token minted for a different client would
+// have been accepted.
+func TestGrantWithoutAnIDTokenIsRefused(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.SetOmitIDToken(true)
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("a session was activated from a token response with no id_token, so nothing about "+
+			"this authorization was verified (#167): %+v", session)
+	}
+
+	event := env.auditEvent(t, "device_authorization_failed")
+	if event.ErrorCode != "ID_TOKEN_MISSING" {
+		t.Errorf("refusal recorded with error_code %q, want ID_TOKEN_MISSING (nothing was wrong with "+
+			"an ID token; there was none)", event.ErrorCode)
+	}
+	if !strings.Contains(event.ErrorMessage, "require_id_token") {
+		t.Errorf("the audited refusal does not name the key that would permit this provider: %q",
+			event.ErrorMessage)
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("an unverifiable authorization was recorded as a successful login (#167)")
+		}
+	}
+
+	// And no credential was minted for it.
+	if _, err := env.broker.keyManager.LoadKey(env.session.ID); err == nil {
+		t.Error("a refused login left a key pair in the key store")
+	}
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a refused login installed a login key:\n%s", data)
+	}
+}
+
+// The deployment the default must not strand: an operator whose provider does not
+// issue ID tokens for the device grant sets require_id_token: false and the same
+// flow completes, on an identity from /userinfo. The escape hatch has to work, or
+// the default is not a choice.
+func TestRequireIDTokenFalseAcceptsAUserInfoOnlyIdentity(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.provider.Config.RequireIDToken = requireIDToken(false)
+	env.idp.SetOmitIDToken(true)
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	session := env.activeSession()
+	if session == nil || !session.IsActive {
+		t.Fatal("require_id_token: false did not permit a grant without an id_token")
+	}
+	if session.Email != "testuser@example.org" {
+		t.Errorf("session email = %q, want the value /userinfo returned — with no ID token that is "+
+			"the only source of claims", session.Email)
+	}
+}
+
+// The unset key means required, in a config built in Go as well as in loaded YAML.
+// This is the fail-closed direction and the state every existing deployment is in,
+// so it is pinned explicitly rather than inferred from the test above.
+func TestIDTokenRequiredDefaultsToOn(t *testing.T) {
+	if !(config.OIDCProvider{}).IDTokenRequired() {
+		t.Error("a provider that never mentions require_id_token does not require an ID token")
+	}
+	if (config.OIDCProvider{RequireIDToken: requireIDToken(false)}).IDTokenRequired() {
+		t.Error("require_id_token: false still requires an ID token")
+	}
+	if !(config.OIDCProvider{RequireIDToken: requireIDToken(true)}).IDTokenRequired() {
+		t.Error("require_id_token: true does not require an ID token")
+	}
+}
+
+// Where the ID token and /userinfo disagree, the signed one decides.
+//
+// The merge used to fill gaps in one direction only, with /userinfo winning, so the
+// claim that authorizes the login could come from an unsigned JSON body even when a
+// verified ID token said otherwise. The two halves are the two directions that
+// matters in: the signed value must be the one that binds, and the unsigned one
+// must not be able to authorize a login the signature does not support.
+func TestIDTokenClaimsWinOverUserInfo(t *testing.T) {
+	t.Run("the signed claim is the one that binds", func(t *testing.T) {
+		env := newPollTestEnv(t)
+		// No groups in the ID token, so the gap-filling half of the merge is
+		// exercised at the same time: a claim only /userinfo carries still arrives.
+		env.idp.SetClaims(map[string]any{
+			"sub":                "test-subject",
+			"preferred_username": "testuser",
+			"email":              "testuser@example.org",
+		})
+		env.idp.SetUserInfoClaims(map[string]any{
+			"sub":                "test-subject",
+			"preferred_username": "someone-else",
+			"email":              "someone-else@example.org",
+			"groups":             []string{"researchers"},
+		})
+		env.idp.Script(testoidc.Grant)
+
+		env.run(t)
+
+		session := env.activeSession()
+		if session == nil || !session.IsActive {
+			t.Fatal("a login whose ID token names the requested account was refused")
+		}
+		if session.Email != "testuser@example.org" {
+			t.Errorf("session email = %q, want the ID token's value: where the two sources disagree "+
+				"the signed one wins (#167)", session.Email)
+		}
+		if len(session.Groups) != 1 || session.Groups[0] != "researchers" {
+			t.Errorf("session groups = %v, want [researchers]: a claim only /userinfo returns is still "+
+				"used, since the ID token has nothing to say about it", session.Groups)
+		}
+	})
+
+	t.Run("an unsigned claim cannot authorize what the ID token does not", func(t *testing.T) {
+		env := newPollTestEnv(t)
+		// The signed assertion is for someone else entirely; /userinfo names the
+		// local account being logged into. On the old merge /userinfo won, the
+		// binding compared "testuser" against "testuser" and the login was
+		// approved on the strength of an unsigned response body.
+		env.idp.SetClaims(map[string]any{
+			"sub":                "sub-someone-else",
+			"preferred_username": "someone-else",
+			"email":              "someone-else@example.org",
+			"groups":             []string{"researchers"},
+		})
+		env.idp.SetUserInfoClaims(map[string]any{
+			"sub":                "sub-someone-else",
+			"preferred_username": "testuser",
+			"email":              "testuser@example.org",
+			"groups":             []string{"researchers"},
+		})
+		env.idp.Script(testoidc.Grant)
+
+		env.run(t)
+
+		if session := env.activeSession(); session != nil {
+			t.Errorf("a login was authorized for %q on a /userinfo claim that the signed ID token "+
+				"contradicts (#167): %+v", env.session.UserID, session)
+		}
+		event := env.auditEvent(t, "authentication_denied")
+		if event.ErrorCode != "IDENTITY_MISMATCH" {
+			t.Errorf("denial recorded with error_code %q, want IDENTITY_MISMATCH", event.ErrorCode)
+		}
+		for _, e := range env.auditEvents(t) {
+			if e.EventType == "authentication_successful" {
+				t.Fatal("a login authorized by /userinfo against the ID token was recorded as successful (#167)")
+			}
+		}
+	})
+}
+
+// Every endpoint the broker will send credentials to has to be over TLS, and it is
+// the discovery document that names them.
+//
+// validateEndpoint was applied to the device authorization endpoint alone; the token
+// and userinfo endpoints were taken from discovery unchecked. A discovery response
+// naming http:// therefore had the broker post the device code to, and carry the
+// access token to, a plaintext endpoint — with the CA bundle, the skip-verify flag
+// and the certificate pins all bypassed, because none of them apply to a connection
+// that never negotiates TLS.
+//
+// The check is at load, so a provider like this stops the broker starting instead of
+// failing one login at a time. Note the last case: only the scheme is enforced, not
+// an issuer-host match, because a token endpoint on another host is ordinary — it is
+// where Google's and Cognito's live.
+func TestDiscoveredEndpointsMustUseTLS(t *testing.T) {
+	const clientID = "oidc-pam-test-client"
+
+	tests := []struct {
+		name         string
+		endpoint     string
+		url          string
+		wantRejected bool
+	}{
+		{
+			name:         "token endpoint downgraded to http",
+			endpoint:     "token_endpoint",
+			url:          "http://token.idp.example.net/token",
+			wantRejected: true,
+		},
+		{
+			name:         "userinfo endpoint downgraded to http",
+			endpoint:     "userinfo_endpoint",
+			url:          "http://idp.example.net/userinfo",
+			wantRejected: true,
+		},
+		{
+			name:         "device authorization endpoint downgraded to http",
+			endpoint:     "device_authorization_endpoint",
+			url:          "http://idp.example.net/device",
+			wantRejected: true,
+		},
+		{
+			// The "localhost.attacker.example" shape: a prefix match on the host
+			// would have taken this for loopback and allowed plaintext.
+			name:         "a hostname that merely starts with localhost is not loopback",
+			endpoint:     "token_endpoint",
+			url:          "http://localhost.idp.example.net/token",
+			wantRejected: true,
+		},
+		{
+			name:     "a token endpoint on another host over https is accepted",
+			endpoint: "token_endpoint",
+			url:      "https://oauth2.idp.example.net/token",
+		},
+		{
+			name:     "the issuer's own endpoints are accepted",
+			endpoint: "token_endpoint",
+			url:      "", // no override
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idp := testoidc.New(t, clientID)
+			if tc.url != "" {
+				idp.SetEndpointOverride(tc.endpoint, tc.url)
+			}
+
+			_, err := NewOIDCProvider(config.OIDCProvider{
+				Name:            "testidp",
+				Issuer:          idp.Issuer(),
+				ClientID:        clientID,
+				Scopes:          []string{"openid", "profile", "email"},
+				EnabledForLogin: true,
+			}, config.SecurityConfig{VerifyAudience: true})
+
+			if !tc.wantRejected {
+				if err != nil {
+					t.Fatalf("NewOIDCProvider rejected a provider it should accept: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("NewOIDCProvider accepted a discovery document naming %s: %s — the broker "+
+					"would send credentials to it in cleartext (#167)", tc.endpoint, tc.url)
+			}
+			if !strings.Contains(err.Error(), tc.endpoint) {
+				t.Errorf("the error does not name the endpoint that was rejected: %v", err)
+			}
+		})
+	}
+}
+
+// The configured form of the same thing: under skip_discovery the endpoints come
+// from the config file rather than from discovery, and they are checked on the same
+// path.
+func TestConfiguredEndpointsMustUseTLSUnderSkipDiscovery(t *testing.T) {
+	base := config.OIDCProvider{
+		Name:            "no-discovery-idp",
+		Issuer:          "https://idp.example.net",
+		ClientID:        "test-client",
+		Scopes:          []string{"openid"},
+		SkipDiscovery:   true,
+		JWKSUri:         "https://idp.example.net/jwks",
+		TokenEndpoint:   "https://idp.example.net/token",
+		EnabledForLogin: true,
+	}
+
+	if _, err := NewOIDCProvider(base, config.SecurityConfig{VerifyAudience: true}); err != nil {
+		t.Fatalf("an all-HTTPS skip_discovery provider was rejected: %v", err)
+	}
+
+	downgraded := base
+	downgraded.UserInfoEndpoint = "http://idp.example.net/userinfo"
+	if _, err := NewOIDCProvider(downgraded, config.SecurityConfig{VerifyAudience: true}); err == nil {
+		t.Error("a skip_discovery provider with a plaintext userinfo_endpoint was accepted")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,27 @@ type OIDCProvider struct {
 	VerificationOnly  bool              `mapstructure:"verification_only"`
 	RequirePKCE       bool              `mapstructure:"require_pkce"`
 	AllowMissingNonce bool              `mapstructure:"allow_missing_nonce"`
+
+	// RequireIDToken refuses a device-grant token response that carries no
+	// id_token. The ID token is the only part of that response the broker can
+	// check: the signature, the issuer, the audience, the expiry and the nonce it
+	// sent are all in there. Without one the identity comes from /userinfo — a
+	// JSON body authenticated by nothing but TLS and the bearer token — and no
+	// signature, aud or exp check happens at all (#167).
+	//
+	// A pointer because the default is *on*: nil means required, so a provider
+	// whose configuration has never heard of the key still gets verification, in
+	// configs built in Go as well as loaded YAML. Read it through IDTokenRequired.
+	RequireIDToken *bool `mapstructure:"require_id_token"`
+}
+
+// IDTokenRequired reports whether a token response with no id_token must be
+// refused for this provider. Unset means required (#167): set
+// require_id_token: false only for a provider that genuinely does not issue an ID
+// token for the device grant, accepting that its identities are then asserted by
+// /userinfo alone.
+func (p OIDCProvider) IDTokenRequired() bool {
+	return p.RequireIDToken == nil || *p.RequireIDToken
 }
 
 // UserMapping defines how to map OIDC claims to user attributes


### PR DESCRIPTION
Fixes #167.

Three gaps in how far the broker took the provider's word, all in
`pkg/auth/device_flow.go`.

## 1. No `id_token` meant no verification at all

The whole verification block — `Verifier.Verify`, the nonce replay check,
`validateIDTokenClaims` — was inside `if tokenResp.IDToken != ""`. A provider that
omitted the field yielded an identity from `/userinfo` with no signature, no `aud`,
no `exp` and no replay check: a token minted for a different client would have been
accepted.

`require_id_token` is now a per-provider key, **defaulting to on**. It is a `*bool`
rather than a `bool` so that unset means required in configs built in Go as well as
in loaded YAML — every existing deployment gets verification without editing
anything. `config.OIDCProvider.IDTokenRequired()` is the only reader.

The refusal is audited (and labelled for the metric) as `ID_TOKEN_MISSING` rather
than falling into `POLL_FAILED`: nothing was wrong with an ID token, there was none,
and the operator's next move is a scope or claim-mapping change at the provider.

## 2. `/userinfo` outranked the signed token

The merge filled gaps in one direction only, with `/userinfo` winning, so the claim
that authorizes the login could come from an unsigned JSON body even when a verified
ID token said otherwise. The ID token wins now. Claims only `/userinfo` returns are
still used — the signed token says nothing about them — so this changes which value
is believed in a conflict, not how much of the identity is available.

## 3. Only one of three endpoints was validated

`validateEndpoint` ran on the device authorization endpoint; the token and userinfo
endpoints came out of the discovery document unvalidated. A discovery response
naming `http://` therefore had the broker post the device code to, and carry the
access token to, a plaintext endpoint — with `trusted_ca_bundle`, `skip_tls_verify`
and the certificate pins all bypassed, since none of them apply to a connection that
never negotiates TLS. This is the sharpest of the three and needs no misbehaving
provider.

All three endpoints are now checked in `NewOIDCProvider`, i.e. at load: the URLs are
fixed when the provider is built, so there is no later moment to check and refusing
here stops the broker rather than failing one login at a time (which is what the
issue's acceptance criterion asks for).

**One deliberate deviation from the issue's wording.** The issue says to run the
token and userinfo endpoints "through the same `validateEndpoint`", which also
requires the endpoint host to equal the issuer host. Doing that would refuse real
providers: Google's issuer is `accounts.google.com` and its token endpoint is on
`oauth2.googleapis.com`; Cognito's userinfo is on a different domain from its issuer
again. Only the scheme is enforced for these two, which is the load-bearing half —
plaintext is what silently disables every TLS control the operator configured, while
a hostile *host* in the discovery document already implies TLS compromise of the
issuer. The device endpoint keeps its issuer-host match, unchanged.

While there: loopback stays exempt from the scheme check (the test issuer and local
development need it) but is matched exactly. The old
`strings.HasPrefix(u.Host, "localhost")` took `localhost.attacker.example` for the
local machine and allowed plaintext to it.

## Which test proves which claim

All in `pkg/auth/provider_trust_test.go`. The first three drive the real poll loop
against `internal/testoidc`, as `device_poll_test.go` does, because each defect was
in what the login path accepts rather than in a helper.

| Claim | Test | Fails with the defect reintroduced |
|---|---|---|
| A grant with no `id_token` is refused under the default: no session, no key, no success record, audited `ID_TOKEN_MISSING` | `TestGrantWithoutAnIDTokenIsRefused` | with the `IDTokenRequired()` guard removed: session active, one `authentication_successful`, a key installed |
| `ID_TOKEN_MISSING` is the code, not `POLL_FAILED` | same test, plus `TestClassifyPollError` | with the `classifyPollError` case removed: `error_code "POLL_FAILED"` |
| `require_id_token: false` still admits a `/userinfo`-only identity, so the escape hatch works | `TestRequireIDTokenFalseAcceptsAUserInfoOnlyIdentity` | n/a (asserts the opt-out, not the defect) |
| Unset means required, in Go-built configs too | `TestIDTokenRequiredDefaultsToOn` | n/a (pins the default) |
| The signed claim is the one that binds, and a claim only `/userinfo` carries still arrives | `TestIDTokenClaimsWinOverUserInfo/the_signed_claim_is_the_one_that_binds` | with the gap-fill merge restored: "a login whose ID token names the requested account was refused" |
| `/userinfo` cannot authorize a login the ID token contradicts | `TestIDTokenClaimsWinOverUserInfo/an_unsigned_claim_cannot_authorize_what_the_ID_token_does_not` | with the gap-fill merge restored: session active for `testuser` on the strength of the unsigned body |
| A discovery document naming `http://` for the token, userinfo or device endpoint is rejected at load; a cross-host HTTPS token endpoint is not; `localhost.…` is not loopback | `TestDiscoveredEndpointsMustUseTLS` (6 cases) | with the `validateProviderEndpoints` call removed: 4 of the 6 fail |
| The same holds for endpoints configured under `skip_discovery` | `TestConfiguredEndpointsMustUseTLSUnderSkipDiscovery` | same removal: fails |

I ran each of the three reverts and confirmed the failures above, then restored and
confirmed the suite green.

`internal/testoidc` gained what those tests need, on the `Issuer` so the e2e harness
sees it too: `SetOmitIDToken` (grant without an `id_token`), `SetUserInfoClaims`
(`/userinfo` answering differently from the ID token) and `SetEndpointOverride`
(discovery advertising a different URL for one endpoint). `Reset` clears all three.

## Verification

- `gofmt -l pkg internal cmd` — empty
- `go build ./...` — clean
- `go test -count=1 ./pkg/... ./internal/...` — all packages ok
- `go vet ./pkg/... ./internal/... ./test/...` — clean
- No C or cgo file touched, so the container gate was not needed.
- The new key was loaded for real: `configs/examples/broker.yaml` through
  `LoadConfig` gives `require_id_token: true` → non-nil pointer, and the provider
  that omits the key → nil → `IDTokenRequired() == true`.

## Docs and configs

- `configs/CONFIGURATION-GUIDE.md`: a new "How Far the Provider Is Trusted" section
  under Security Best Practices, covering both rules, with a loadable snippet for
  `require_id_token: false`.
- `configs/examples/broker.yaml`: `require_id_token: true` spelled out on the first
  provider to say that it is the default.
- The provider templates are left alone: Keycloak, Okta, Azure AD and IAM Identity
  Center all issue ID tokens for the device grant (the AWS template's
  `allow_missing_nonce: true` comment is about a nonce claim *in* that ID token), so
  none of them needs the key.

## Wire contract

Nothing crosses the broker↔module boundary here. `ID_TOKEN_MISSING` is an audit-log
event code and metric label, in the same family as `IDENTITY_MISMATCH`,
`USERNAME_CLAIM_MISSING` and `GROUP_NOT_ALLOWED` added by #159/#164/#166; the
`error_code` table in `oauth2-pam/docs/wire-protocol.md` registers IPC reply codes,
and a refused device flow still surfaces to the client exactly as before (the
session is removed, so the next `check_session` is `SESSION_NOT_FOUND`). No new
field, no new reply code, so no contract decision is needed.

## Deliberately out of scope

- **Refresh responses.** `RefreshToken` still accepts a response without an
  `id_token`: RFC 6749 §6 makes it optional there, and the refresh path derives no
  identity from claims, so requiring it would break providers for no gain.
- **`pin_certificates` vs `pinned_certificates`.** The issue notes that the pinning
  config which should mitigate item 3 is separately broken. That is #170; the
  `CONFIGURATION-GUIDE.md` snippet naming `pin_certificates` is untouched here.
- **The e2e harness control API.** `test/e2e/fakeoidc` gained no `/control/…` verb
  for the new issuer settings; the in-process tests cover the three behaviours, and
  the harness cases are shell-driven.