### PR TITLE
fix(ssh): resolve homes from the account database and expire issued keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **High (#171): the SSH key a successful login was granted was written to a
+  directory guessed from the login name, was never removed when the session ended,
+  and accumulated one working credential per login.** The provisioning path was
+  wrong at both ends: the key often did not arrive where sshd reads it, and when it
+  did arrive nothing took it away again.
+
+  The broker joined `/home` with the login name and wrote `<that>/.ssh/authorized_keys`.
+  On any site whose homes are not literally `/home/<user>` — SSSD or LDAP with
+  `/home/<domain>/<user>`, autofs, NFS, a home moved by hand — it created that
+  directory itself, as root and mode 0700, wrote a key list sshd would never read,
+  and reported the login as successful. The user was told they were authenticated
+  and then could not log in, and on the next real login their own home was shadowed
+  by a root-owned directory they could not write. The uid from the passwd database
+  was never consulted, so nothing distinguished "this is the account's home" from
+  "this is a directory belonging to someone else". Where the key *did* land, it was
+  appended on every login and deduplicated only against byte-identical lines, so an
+  account that logged in daily accumulated a live credential per login; each one
+  carried no expiry sshd could see, so it stopped being limited at all the moment
+  the broker forgot the session that owned it — which happens on every restart,
+  since sessions are held only in memory. The shipped systemd unit set
+  `ProtectHome=true`, which makes `/home` an empty tmpfs to the service, so on a
+  host installed from it no key could be written at all.
+
+  - Home directories now come from the account database, through
+    `pkg/ssh.LookupAccount`: `os/user` first, then `getent passwd`. The fallback is
+    not redundancy — the released broker is built `CGO_ENABLED=0`, and without cgo
+    `os/user` parses `/etc/passwd` and never asks NSS, so every SSSD or LDAP account
+    is invisible to it. `getent` asks NSS the way sshd and `login` do, bounded by a
+    timeout and a `WaitDelay` so a wedged directory server cannot hold a login open.
+    Nothing derives a home path any more, and a home that does not exist is refused
+    rather than created.
+  - The owning uid is checked, on the home directory, on `.ssh` and on
+    `authorized_keys` through the open file descriptor. The account or root is
+    accepted, which is what sshd's own `StrictModes` accepts; anything else is
+    refused rather than written through. Files the root broker creates in a home are
+    handed to the account.
+  - A login installs exactly one broker key: every previous `@oidc-pam-` entry is
+    dropped as it is written, and the account's own keys are left alone. The entry
+    carries `expiry-time="…Z"`, so **sshd** enforces the key's lifetime whether or
+    not the broker is running or remembers the session. Both the key store and the
+    `authorized_keys` sweep now use the configured `token_lifetime`; both used to be
+    hardcoded to 24 hours, so a site that had deliberately set `token_lifetime: 1h`
+    still handed out keys good for a day.
+  - Startup revokes what the previous run left behind. The key store survives a
+    restart even though sessions do not, so anything in it at startup belongs to no
+    live session and its `authorized_keys` entry is removed.
+  - A login whose key could not be provisioned is now denied instead of completed.
+    It used to be activated and audited as `authentication_successful` with no usable
+    key anywhere; the failure is recorded as `ssh_key_provisioning_failed` and the
+    session is dropped, which the module already reports through
+    `SESSION_NOT_FOUND` — no change to the broker↔module wire contract.
+  - Revoking a key a later login had already superseded is no longer reported as
+    `ssh_key_revocation_incomplete`. That event means a credential is still live
+    (#165), and firing it for the ordinary two-logins case would have trained
+    operators to ignore it.
+  - `configs/systemd/oidc-auth-broker.service` sets `ProtectHome=false`, lists
+    `/home` in `ReadWritePaths` (`ProtectSystem=strict` otherwise makes it
+    read-only) and declares `StateDirectory=oidc-pam`; `scripts/install-release.sh`
+    creates `/var/lib/oidc-pam/{ssh-keys,locks}` at 0700, and DEPLOYMENT.md's unit
+    matches the shipped one.
+
+  Coverage: `pkg/ssh` tests that a key is written to the home the account database
+  gives and that nothing is created at `/home/<user>`, that a missing home is
+  refused rather than created, that a foreign-owned path is refused, that a second
+  login supersedes the first key while leaving the user's own, that the installed
+  entry carries the `expiry-time` option, and that the sweep measures against the
+  configured lifetime; `pkg/ssh/accounts_test.go` covers the NSS fallback, an
+  unknown account, a wedged account database and the passwd fields that are refused;
+  `pkg/auth` tests that a login whose key cannot be installed is denied and audited,
+  that startup revokes a previous run's keys through `Start` itself, that
+  `token_lifetime` reaches the key manager, and that a superseded revocation is not
+  reported as incomplete; `cmd/broker` pins the unit's `ProtectHome`,
+  `ReadWritePaths` and `StateDirectory`; and two e2e cases cover a second login
+  replacing the first key and a broker restart sweeping the keys it had issued.
 - **Medium (#188): stopping the audit logger discarded every record still
   queued, and a second `Stop` panicked.** `processEvents` selected on its stop
   channel and returned without looking at the buffer, so the events sitting in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     handed to the account.
   - A login installs exactly one broker key: every previous `@oidc-pam-` entry is
     dropped as it is written, and the account's own keys are left alone. The entry
-    carries `expiry-time="…Z"`, so **sshd** enforces the key's lifetime whether or
+    carries `expiry-time="…"`, so **sshd** enforces the key's lifetime whether or
     not the broker is running or remembers the session. Both the key store and the
     `authorized_keys` sweep now use the configured `token_lifetime`; both used to be
     hardcoded to 24 hours, so a site that had deliberately set `token_lifetime: 1h`
     still handed out keys good for a day.
+  - **That option makes OpenSSH 7.7 or newer a requirement**, and it is now stated
+    where an operator will see it: DEPLOYMENT.md's prerequisites, and README.md's
+    platform table, which gains an OpenSSH column and marks Amazon Linux 2 and
+    RHEL/CentOS 7 (both `7.4p1`) unsupported rather than "expected to work". sshd
+    refuses an entire authorized_keys entry that carries an option it does not
+    recognise, so on an older host every key the broker installs is rejected — the
+    same "authenticated, then `Permission denied (publickey)`" outcome, reached a
+    different way. The timespec is written in the host's own time zone, not UTC: the
+    `Z` suffix meaning UTC is OpenSSH 9.1 and newer, and every sshd before that
+    rejects the entry carrying it, which would have limited this to Debian 12-era
+    hosts while breaking RHEL 8 and 9, Debian 11 and Ubuntu 20.04 and 22.04. The
+    broker does not detect the local sshd version; whether it should, refuse to
+    start, or make the option configurable is #199.
   - Startup revokes what the previous run left behind. The key store survives a
     restart even though sessions do not, so anything in it at startup belongs to no
     live session and its `authorized_keys` entry is removed.
@@ -64,10 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (#165), and firing it for the ordinary two-logins case would have trained
     operators to ignore it.
   - `configs/systemd/oidc-auth-broker.service` sets `ProtectHome=false`, lists
-    `/home` in `ReadWritePaths` (`ProtectSystem=strict` otherwise makes it
+    `-/home` in `ReadWritePaths` (`ProtectSystem=strict` otherwise makes it
     read-only) and declares `StateDirectory=oidc-pam`; `scripts/install-release.sh`
     creates `/var/lib/oidc-pam/{ssh-keys,locks}` at 0700, and DEPLOYMENT.md's unit
-    matches the shipped one.
+    matches the shipped one. The `-` prefix is load-bearing: systemd fails a unit
+    whose `ReadWritePaths` names a path that does not exist, and the site told to add
+    its own home path — `/export/home` and the like — is exactly the site with no
+    `/home`, which would have got a broker that refuses to start.
 
   Coverage: `pkg/ssh` tests that a key is written to the home the account database
   gives and that nothing is created at `/home/<user>`, that a missing home is
@@ -79,9 +95,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pkg/auth` tests that a login whose key cannot be installed is denied and audited,
   that startup revokes a previous run's keys through `Start` itself, that
   `token_lifetime` reaches the key manager, and that a superseded revocation is not
-  reported as incomplete; `cmd/broker` pins the unit's `ProtectHome`,
-  `ReadWritePaths` and `StateDirectory`; and two e2e cases cover a second login
-  replacing the first key and a broker restart sweeping the keys it had issued.
+  reported as incomplete; `pkg/ssh/docs_test.go` fails if DEPLOYMENT.md or README.md
+  stops stating the minimum OpenSSH version, or if the timespec written is anything
+  other than the form an older sshd parses; `cmd/broker` pins the unit's
+  `ProtectHome`, its optional `-/home` and `StateDirectory`; and two e2e cases cover
+  a second login replacing the first key and a broker restart sweeping the keys it
+  had issued.
 - **Medium (#188): stopping the audit logger discarded every record still
   queued, and a second `Stop` panicked.** `processEvents` selected on its stop
   channel and returned without looking at the buffer, so the events sitting in

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -112,10 +112,41 @@ into your boot/login automation.
 
 #### Minimum Requirements
 - Linux server with PAM support
+- **OpenSSH 7.7 or newer** on every host the broker provisions keys on
 - 2 CPU cores
 - 4 GB RAM
 - 20 GB storage
 - Network connectivity to OIDC provider
+
+##### Why OpenSSH 7.7 is a hard requirement
+
+The broker writes each login's key into `~/.ssh/authorized_keys` with an
+`expiry-time="…"` option in front of it, so that **sshd** stops honouring the key
+once it is stale. That is deliberate: the broker holds its sessions in memory, so
+before this every key it had issued outlived the process that was meant to revoke
+it (#171), and an expiry only the broker knows about is an expiry a restart
+forgets.
+
+`expiry-time=` was added in OpenSSH 7.7. An sshd that does not recognise an
+authorized_keys option refuses the whole entry, so on anything older **every key
+the broker installs is rejected**: the login is authenticated, the file looks
+correct, and SSH still says `Permission denied (publickey)`. Check with:
+
+```bash
+ssh -V   # OpenSSH_8.4p1 …  -> fine
+```
+
+Versions the common platforms ship: RHEL/CentOS Stream 8 `8.0p1`, RHEL 9 `8.7p1`,
+Debian 11 `8.4p1`, Debian 12 `9.2p1`, Ubuntu 20.04 `8.2p1`, Ubuntu 22.04 `8.9p1`,
+Ubuntu 24.04 `9.6p1` — all fine. **Amazon Linux 2 and RHEL/CentOS 7 ship `7.4p1`
+and cannot run this**; check any other platform with the command above before
+deploying. The broker does not currently detect the local sshd version
+([#199](https://github.com/scttfrdmn/oidc-pam/issues/199)); it writes the option
+unconditionally.
+
+The timespec itself is written in the host's local time zone, not UTC, because the
+`Z` suffix that means UTC was only added in OpenSSH 9.1 and older versions reject
+a timespec carrying it.
 
 #### Recommended Requirements
 - 4+ CPU cores
@@ -125,12 +156,19 @@ into your boot/login automation.
 - Load balancer for multiple instances
 
 #### Supported Operating Systems
-- Ubuntu 20.04 LTS or later
-- CentOS 8 or later
-- RHEL 8 or later
-- Debian 11 or later
-- Amazon Linux 2
-- SUSE Linux Enterprise Server 15+
+- Ubuntu 20.04 LTS or later (OpenSSH 8.2p1+)
+- CentOS Stream 8 or later (8.0p1+)
+- RHEL 8 or later (8.0p1+)
+- Debian 11 or later (8.4p1+)
+- SUSE Linux Enterprise Server 15+ — check `ssh -V` first; the older service packs
+  predate OpenSSH 7.7
+- **Not Amazon Linux 2, and not RHEL/CentOS 7**: both ship OpenSSH 7.4p1, which does
+  not know `expiry-time=` and therefore refuses every key the broker installs. See
+  the OpenSSH requirement above.
+
+Which distribution has actually been tested, and on what, is in
+[README.md](README.md#-supported-platforms) — the list above is what the broker's
+dependencies allow, not a claim that a login has been run on each one.
 
 ### Network Requirements
 
@@ -456,8 +494,10 @@ ProtectHome=false
 # ProtectSystem=strict makes everything read-only, so every path the broker
 # writes is listed: its runtime socket, its logs, its state directory (issued keys
 # and per-user locks), and the home directories it provisions keys into. Add your
-# own home path here if homes are not under /home.
-ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam /home
+# own home path here if homes are not under /home. The "-" prefix makes a missing
+# path non-fatal: without it systemd refuses to start the unit at all on a host
+# that has no /home, which is exactly the host whose homes are somewhere else.
+ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam -/home
 StateDirectory=oidc-pam
 StateDirectoryMode=0700
 CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -425,6 +425,10 @@ consult the PAM auth stack at all.
 ### 4. System Service Configuration
 
 #### Systemd Service (`/etc/systemd/system/oidc-auth-broker.service`)
+
+The unit shipped in `configs/systemd/oidc-auth-broker.service` is the reference; install
+that rather than retyping it. It looks like this:
+
 ```ini
 [Unit]
 Description=OIDC Authentication Broker
@@ -433,18 +437,30 @@ Wants=network.target
 
 [Service]
 Type=simple
-User=oidc-auth
-Group=oidc-auth
-ExecStart=/usr/bin/oidc-auth-broker --config /etc/oidc-auth/broker.yaml
+# root, not a service account: the broker installs each login's SSH key in that
+# account's ~/.ssh/authorized_keys and hands the file to the account, which needs
+# both write access to the home directory and the ability to chown.
+User=root
+Group=root
+ExecStart=/usr/local/bin/oidc-auth-broker --config /etc/oidc-auth/broker.yaml
 Restart=always
-RestartSec=5
+RestartSec=10
 
 # Security hardening
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/log/oidc-auth /var/lib/oidc-auth
+# Must stay off. ProtectHome=true replaces /home with an empty tmpfs for this
+# service, so no authorized_keys can be written at all (#171).
+ProtectHome=false
+# ProtectSystem=strict makes everything read-only, so every path the broker
+# writes is listed: its runtime socket, its logs, its state directory (issued keys
+# and per-user locks), and the home directories it provisions keys into. Add your
+# own home path here if homes are not under /home.
+ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam /home
+StateDirectory=oidc-pam
+StateDirectoryMode=0700
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
 
 # Resource limits
 LimitNOFILE=65536
@@ -457,6 +473,12 @@ Environment=GOGC=100
 [Install]
 WantedBy=multi-user.target
 ```
+
+If a login reports success but the SSH key does not work, check these three things
+first: that `ProtectHome` is not `true`, that the path homes really live on is in
+`ReadWritePaths`, and that `/var/lib/oidc-pam` exists and is writable. A key the
+broker could not install now denies the login rather than completing it, and the
+reason is recorded as an `ssh_key_provisioning_failed` audit event.
 
 ## Security Hardening
 

--- a/README.md
+++ b/README.md
@@ -241,19 +241,29 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 📊 Supported Platforms
 
-| Platform | SSH (`sshd`) | Console (`login`), `su`, `sudo` | Display manager |
-|----------|--------------|---------------------------------|-----------------|
-| Debian 12 (bookworm) | ✅ Tested in CI | Example config, untested | Not supported |
-| Debian 11, Ubuntu 20.04+, Ubuntu 22.04+ | Expected to work | Example config, untested | Not supported |
-| RHEL 8+, CentOS Stream 8+, Fedora 35+ | Expected to work | Example config, untested | Not supported |
+| Platform | OpenSSH | SSH (`sshd`) | Console (`login`), `su`, `sudo` | Display manager |
+|----------|---------|--------------|---------------------------------|-----------------|
+| Debian 12 (bookworm) | 9.2p1 | ✅ Tested in CI | Example config, untested | Not supported |
+| Debian 11, Ubuntu 20.04+, Ubuntu 22.04+ | 8.4p1 / 8.2p1 / 8.9p1 | Expected to work | Example config, untested | Not supported |
+| RHEL 8+, CentOS Stream 8+, Fedora 35+ | 8.0p1 / 8.0p1 / 8.7p1+ | Expected to work | Example config, untested | Not supported |
+| Amazon Linux 2, RHEL/CentOS 7 | 7.4p1 | ❌ Not supported | Not supported | Not supported |
+
+**Requires OpenSSH 7.7 or newer.** The broker writes each login's key with an
+`expiry-time="…"` option so that sshd, not the broker, enforces the key's lifetime.
+That option was added in OpenSSH 7.7, and an sshd that does not recognise an
+authorized_keys option refuses the whole entry — so on an older sshd every key the
+broker installs is rejected and the account is authenticated and then cannot log
+in. The version column above is what each platform ships; check anything not listed
+with `ssh -V`. Nothing detects this for you yet
+([#199](https://github.com/scttfrdmn/oidc-pam/issues/199)).
 
 **Tested in CI** means `test/e2e` performs real SSH logins against the built
 `pam_oidc.so` on that image, with the stack `configs/pam/ssh` ships. That harness
 runs on Debian 12 and covers `sshd` and nothing else.
 
-**Expected to work** means the module builds against that distribution's libpam
-and json-c and nothing about it is known to differ — not that a login has been
-run on it.
+**Expected to work** means the module builds against that distribution's libpam and
+json-c, the platform's sshd is new enough for the `expiry-time=` option above, and
+nothing else about it is known to differ — not that a login has been run on it.
 
 **Example config, untested** means `configs/pam/` carries a stack for the service
 but nobody has verified that its PAM conversation displays the verification URL.

--- a/cmd/broker/systemd_unit_test.go
+++ b/cmd/broker/systemd_unit_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The shipped unit is part of the product: a host built by installing it is the
+// host every deployment guide describes. Two of its settings decide whether SSH key
+// provisioning can work at all, and both were wrong (#171) — so they are pinned
+// here rather than left to be rediscovered on someone's cluster.
+//
+// No build tag: this reads a file and needs no cgo, so it runs everywhere the suite
+// does.
+func TestShippedUnitLetsTheBrokerWriteWhereItMust(t *testing.T) {
+	path := filepath.Join("..", "..", "configs", "systemd", "oidc-auth-broker.service")
+	content, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	settings := unitSettings(string(content))
+
+	// ProtectHome=true replaces /home with an empty tmpfs for the service. The
+	// broker's whole job on a successful login is to write into the account's
+	// ~/.ssh/authorized_keys, so under that setting every provisioning attempt fails
+	// and no login can use SSH — while the unit looks well hardened.
+	if home := settings["ProtectHome"]; home != "false" {
+		t.Errorf("ProtectHome=%q: the broker cannot see /home, so it cannot install any "+
+			"login's SSH key (#171)", home)
+	}
+
+	// ProtectSystem=strict makes the entire hierarchy read-only, so anything the
+	// broker writes has to be named. Missing /home is the same outage as
+	// ProtectHome=true; missing the state directory loses the issued keys and the
+	// locks that serialize authorized_keys writes.
+	readWrite := settings["ReadWritePaths"]
+	for _, required := range []string{"/home", "/var/lib/oidc-pam"} {
+		if !hasPath(readWrite, required) {
+			t.Errorf("ReadWritePaths=%q does not include %s, which ProtectSystem=strict then "+
+				"makes read-only to the broker", readWrite, required)
+		}
+	}
+
+	// The state directory has to exist before the first start; systemd creating it
+	// is one less step an operator can miss.
+	if got := settings["StateDirectory"]; got != "oidc-pam" {
+		t.Errorf("StateDirectory=%q, want oidc-pam so /var/lib/oidc-pam exists on first start", got)
+	}
+	if got := settings["StateDirectoryMode"]; got != "0700" {
+		t.Errorf("StateDirectoryMode=%q, want 0700: the directory holds the private half of "+
+			"every issued key", got)
+	}
+
+	// The hardening that is not in the way stays on, so this test cannot be
+	// satisfied by simply removing the sandbox.
+	for setting, want := range map[string]string{
+		"ProtectSystem":   "strict",
+		"NoNewPrivileges": "true",
+		"PrivateTmp":      "true",
+	} {
+		if got := settings[setting]; got != want {
+			t.Errorf("%s=%q, want %q", setting, got, want)
+		}
+	}
+}
+
+// unitSettings collects the last value of each key in a systemd unit, ignoring
+// comments. Last wins, as systemd does for non-list settings.
+func unitSettings(content string) map[string]string {
+	settings := map[string]string{}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") ||
+			strings.HasPrefix(line, "[") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		settings[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return settings
+}
+
+// hasPath reports whether a space-separated systemd path list contains path
+// exactly, so that /var/lib/oidc-pam-other does not satisfy /var/lib/oidc-pam.
+func hasPath(list, path string) bool {
+	for _, field := range strings.Fields(list) {
+		if strings.TrimPrefix(field, "-") == path {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/broker/systemd_unit_test.go
+++ b/cmd/broker/systemd_unit_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -42,6 +43,16 @@ func TestShippedUnitLetsTheBrokerWriteWhereItMust(t *testing.T) {
 			t.Errorf("ReadWritePaths=%q does not include %s, which ProtectSystem=strict then "+
 				"makes read-only to the broker", readWrite, required)
 		}
+	}
+
+	// /home must be listed as optional. systemd fails the unit's namespace setup
+	// when a ReadWritePaths entry does not exist, and the host whose homes are on
+	// /export/home — the one the comment above ReadWritePaths tells to add its own
+	// path — is exactly the host with no /home at all. Without the prefix, that host
+	// gets a broker that will not start, which is worse than the outage being fixed.
+	if !hasOptionalPath(readWrite, "/home") {
+		t.Errorf("ReadWritePaths=%q lists /home without the \"-\" prefix, so systemd fails "+
+			"the unit on a host that keeps homes elsewhere and has no /home", readWrite)
 	}
 
 	// The state directory has to exist before the first start; systemd creating it
@@ -95,4 +106,11 @@ func hasPath(list, path string) bool {
 		}
 	}
 	return false
+}
+
+// hasOptionalPath reports whether the list contains path with systemd's "-"
+// prefix, which makes a path that does not exist non-fatal instead of a
+// unit-starting failure.
+func hasOptionalPath(list, path string) bool {
+	return slices.Contains(strings.Fields(list), "-"+path)
 }

--- a/configs/systemd/oidc-auth-broker.service
+++ b/configs/systemd/oidc-auth-broker.service
@@ -33,7 +33,12 @@ ProtectHome=false
 #
 # Sites whose home directories are not under /home (autofs, NFS, /home/<domain>/…
 # is fine, but /export/home is not) must add that path here as well.
-ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam /home
+#
+# /home carries a "-" prefix so that a host which has no /home at all — the same
+# site that keeps homes on /export/home — still starts. Without it systemd fails
+# the unit outright when a listed path is missing, which would turn a misconfigured
+# home path into a broker that never runs.
+ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam -/home
 # Creates /var/lib/oidc-pam (0700, root) before ExecStart, so a first start on a
 # host installed by hand does not fail on a missing state directory.
 StateDirectory=oidc-pam

--- a/configs/systemd/oidc-auth-broker.service
+++ b/configs/systemd/oidc-auth-broker.service
@@ -20,12 +20,24 @@ RestartSec=10s
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
+# ProtectHome must stay off: the broker installs each login's SSH key in that
+# account's ~/.ssh/authorized_keys, and ProtectHome=true makes /home an empty
+# tmpfs to this service, so every provisioning attempt failed with "no such
+# directory" while the login itself was reported as successful (#171).
+ProtectHome=false
 # /var/lib/oidc-pam holds the broker's own state: the SSH keys it issues
 # (ssh-keys/) and the per-user locks that serialize its authorized_keys writes
-# (locks/, see #161). ProtectSystem=strict makes /var read-only, so this has to be
-# listed or every key write fails.
-ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam
+# (locks/, see #161). ProtectSystem=strict makes the whole hierarchy read-only, so
+# every path the broker writes has to be listed here — including /home, for the
+# authorized_keys writes above.
+#
+# Sites whose home directories are not under /home (autofs, NFS, /home/<domain>/…
+# is fine, but /export/home is not) must add that path here as well.
+ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam /home
+# Creates /var/lib/oidc-pam (0700, root) before ExecStart, so a first start on a
+# host installed by hand does not fail on a missing state directory.
+StateDirectory=oidc-pam
+StateDirectoryMode=0700
 CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
 
 # Logging

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -214,6 +214,19 @@ func NewBroker(cfg *config.Config) (*Broker, error) {
 		providers[providerConfig.Name] = provider
 	}
 
+	keyManager := sshpkg.NewKeyManager("/var/lib/oidc-pam/ssh-keys")
+	authorizedKeysManager := sshpkg.NewAuthorizedKeysManager(sshpkg.DefaultLockDir)
+
+	// (#171) An SSH key must not outlive the session it was issued for. Both
+	// managers defaulted to 24 hours and neither was ever told otherwise, so a site
+	// that had deliberately configured token_lifetime: 1h still handed out keys good
+	// for a day — and the sweep meant to remove them measured against the same
+	// hardcoded 24 hours.
+	if lifetime := cfg.Authentication.TokenLifetime; lifetime > 0 {
+		keyManager.SetExpiration(lifetime)
+		authorizedKeysManager.SetKeyLifetime(lifetime)
+	}
+
 	broker := &Broker{
 		config:                cfg,
 		providers:             providers,
@@ -221,8 +234,8 @@ func NewBroker(cfg *config.Config) (*Broker, error) {
 		policyEngine:          policyEngine,
 		auditLogger:           auditLogger,
 		sessions:              make(map[string]*Session),
-		keyManager:            sshpkg.NewKeyManager("/var/lib/oidc-pam/ssh-keys"),
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager("/home", sshpkg.DefaultLockDir),
+		keyManager:            keyManager,
+		authorizedKeysManager: authorizedKeysManager,
 		stopChan:              make(chan struct{}),
 	}
 
@@ -245,12 +258,93 @@ func (b *Broker) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start audit logger: %w", err)
 	}
 
+	// Revoke the keys of the sessions this broker lost when it last stopped (#171).
+	b.reconcileIssuedKeys()
+
 	// Start session cleanup goroutine
 	b.wg.Add(1)
 	go b.sessionCleanup(ctx)
 
 	log.Info().Msg("Authentication broker services started successfully")
 	return nil
+}
+
+// reconcileIssuedKeys revokes every key left over from a previous run of the
+// broker.
+//
+// Sessions live only in memory. A broker that stops — a restart, a crash, a
+// package upgrade — therefore forgets every key it issued, while the
+// authorized_keys entries stay exactly where they are and keep authenticating.
+// Nothing removed them: revocation is driven from the session that no longer
+// exists, and the expiry sweep only ran for users who happened to have another
+// session expire afterwards, so a user who never logged in again kept a working
+// credential indefinitely (#171).
+//
+// The broker's own key store is the record of what it issued, and it does survive
+// a restart, so it is the list to work from. Anything in it at startup belongs to
+// no live session by definition.
+func (b *Broker) reconcileIssuedKeys() {
+	if b.keyManager == nil || b.authorizedKeysManager == nil {
+		return
+	}
+
+	infos, unreadable, err := b.keyManager.ListKeyInfo()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to list stored SSH keys at startup; orphaned keys may remain authorized")
+		return
+	}
+	if len(infos) == 0 && unreadable == 0 {
+		return
+	}
+
+	// One pass per account, not per key: RemoveOIDCKeys clears every broker-issued
+	// entry the account has, so a user with several orphans is handled once.
+	usernames := make(map[string]struct{}, len(infos))
+	for _, info := range infos {
+		if info.Username != "" {
+			usernames[info.Username] = struct{}{}
+		}
+		if delErr := b.keyManager.DeleteKey(info.KeyID); delErr != nil {
+			log.Warn().Err(delErr).Str("key_id", info.KeyID).
+				Msg("Failed to delete an orphaned stored SSH key at startup")
+		}
+	}
+
+	removedTotal := 0
+	for username := range usernames {
+		removed, remErr := b.authorizedKeysManager.RemoveOIDCKeys(username)
+		if remErr != nil {
+			// Audited, not just logged: an entry that could not be removed is a
+			// credential still granting access to a session nobody is tracking.
+			log.Error().Err(remErr).Str("user_id", username).
+				Msg("Failed to remove orphaned authorized_keys entries at startup")
+			if b.auditLogger != nil {
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType:    "ssh_key_revocation_incomplete",
+					UserID:       username,
+					Success:      false,
+					ErrorCode:    "ORPHANED_KEYS_NOT_REMOVED",
+					ErrorMessage: remErr.Error(),
+					Timestamp:    time.Now(),
+				})
+			}
+			if b.metrics != nil {
+				b.metrics.RecordSSHKeyOp("revoke", "failure")
+			}
+			continue
+		}
+		removedTotal += removed
+		if removed > 0 && b.metrics != nil {
+			b.metrics.RecordSSHKeyOp("revoke", "success")
+		}
+	}
+
+	log.Info().
+		Int("stored_keys", len(infos)).
+		Int("unreadable_stored_keys", unreadable).
+		Int("accounts", len(usernames)).
+		Int("authorized_keys_entries_removed", removedTotal).
+		Msg("Reconciled SSH keys left over from a previous broker run")
 }
 
 // DroppedAuditEvents returns the cumulative count of audit events dropped by
@@ -1086,10 +1180,24 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 						ErrorMessage: err.Error(),
 						Timestamp:    time.Now(),
 					})
-				} else {
-					updated.SSHKeyID = sshKey.ID
-					updated.SSHPublicKey = sshKey.PublicKey
+					if b.metrics != nil {
+						b.metrics.RecordAuth(provider.Name, "failure", "SSH_KEY_PROVISIONING_FAILED")
+					}
+					// (#171) The login is denied, not completed. It used to be
+					// completed: the session was activated and reported as a
+					// successful authentication with no key installed anywhere, so
+					// the user was told they were authenticated and then could not
+					// log in — and, worse, the *reason* they could not was that the
+					// broker had written the key to a directory that was not their
+					// home, or had failed to at all. Dropping the session makes the
+					// module report the denial it already has a code for
+					// (SESSION_NOT_FOUND on the next poll), so no wire change is
+					// needed to carry this.
+					b.removeSession(updated.ID)
+					return
 				}
+				updated.SSHKeyID = sshKey.ID
+				updated.SSHPublicKey = sshKey.PublicKey
 			}
 
 			b.setSession(&updated)
@@ -1287,8 +1395,9 @@ func (b *Broker) generateSSHKey(session *Session) (*SSHKey, error) {
 		return nil, fmt.Errorf("failed to save SSH key: %w", err)
 	}
 
-	// Append the public key to the user's authorized_keys file
-	if err := b.authorizedKeysManager.AddPublicKey(session.UserID, sshKey.PublicKey); err != nil {
+	// Install the public key in the user's authorized_keys, as their only
+	// broker-issued key, carrying the expiry sshd will enforce on it (#171).
+	if err := b.authorizedKeysManager.AddPublicKey(session.UserID, sshKey.PublicKey, sshKey.ExpiresAt); err != nil {
 		// Best-effort cleanup: remove the stored key if we couldn't authorize it
 		_ = b.keyManager.DeleteKey(session.ID)
 		if b.metrics != nil {
@@ -1356,7 +1465,36 @@ func (b *Broker) revokeSSHKey(session *Session) error {
 	// (having been fused with a comment) could no longer be removed by anything.
 	// Still best effort — the session is gone either way — but audited as the failure
 	// it is, so an operator can find the host and the file.
+	//
+	// (#171) "Nothing matched" now has a second, innocent cause: a later login for
+	// the same user supersedes the earlier entry, because there is one live
+	// broker-issued key per user. Ask whether the key material still authorizes
+	// anything before raising the alarm, so that the alarm keeps meaning what it says
+	// — the key was already gone, which is the outcome revocation wanted.
 	if !removed {
+		if authorized, checkErr := b.authorizedKeysManager.KeyIsAuthorized(session.UserID, sshKey.PublicKey); checkErr == nil && !authorized {
+			log.Info().
+				Str("session_id", session.ID).
+				Str("user_id", session.UserID).
+				Str("ssh_key_id", session.SSHKeyID).
+				Msg("SSH key was already absent from authorized_keys at revocation (superseded by a later login)")
+
+			if b.auditLogger != nil {
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType: "ssh_key_revoked",
+					UserID:    session.UserID,
+					Email:     session.Email,
+					SessionID: session.ID,
+					Success:   true,
+					Timestamp: time.Now(),
+				})
+			}
+			if b.metrics != nil {
+				b.metrics.RecordSSHKeyOp("revoke", "success")
+			}
+			return nil
+		}
+
 		log.Warn().
 			Str("session_id", session.ID).
 			Str("user_id", session.UserID).

--- a/pkg/auth/broker_integration_test.go
+++ b/pkg/auth/broker_integration_test.go
@@ -293,7 +293,7 @@ func TestBrokerSSHKeyMethods(t *testing.T) {
 			},
 		},
 		keyManager:            sshpkg.NewKeyManager(keyDir),
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
+		authorizedKeysManager: testAuthorizedKeysManager(t, homeDir, "test-user-ssh"),
 	}
 
 	// Use a short key size to keep the test fast.

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -119,7 +119,7 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 		auditLogger:           auditLogger,
 		sessions:              make(map[string]*Session),
 		keyManager:            keyManager,
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
+		authorizedKeysManager: testAuthorizedKeysManager(t, homeDir, "testuser", "deploy"),
 		stopChan:              make(chan struct{}),
 		pollIntervalUnit:      testPollUnit,
 		// A fixed passwd table, so the privileged-account guard (#159) behaves the

--- a/pkg/auth/key_provisioning_test.go
+++ b/pkg/auth/key_provisioning_test.go
@@ -1,0 +1,238 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/testoidc"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
+)
+
+// These tests cover #171: the SSH key the broker hands out has to actually be
+// installed where sshd will read it, has to stop working when the session ends, and
+// must not be reported as working when it is not.
+
+// A login whose key could not be installed is a login that cannot be used. It used
+// to be completed anyway: the session was activated and the flow recorded
+// authentication_successful, so the user was told they were authenticated and then
+// found they could not log in — with the broker's own log the only place the reason
+// existed.
+func TestLoginIsDeniedWhenTheKeyCannotBeProvisioned(t *testing.T) {
+	env := newPollTestEnv(t)
+
+	// Provisioning fails for a reason an operator really hits: the account's home
+	// directory is not present on this host. The broker must refuse rather than
+	// create one (as root, mode 0700) and claim success.
+	if err := os.RemoveAll(filepath.Join(env.homeDir, env.session.UserID)); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	env.idp.Script(testoidc.Grant)
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("the session was activated although no key could be installed: %+v", session)
+	}
+
+	types := map[string]int{}
+	for _, event := range env.auditEvents(t) {
+		types[event.EventType]++
+	}
+	if types["ssh_key_provisioning_failed"] != 1 {
+		t.Errorf("want exactly one ssh_key_provisioning_failed event, got %d (events: %v)",
+			types["ssh_key_provisioning_failed"], types)
+	}
+	if types["authentication_successful"] != 0 {
+		t.Error("a login whose SSH key could not be installed was recorded as successful, " +
+			"so the audit trail says the user has access they do not have")
+	}
+	// Nothing may have been left in the account's place either.
+	if _, err := os.Stat(filepath.Join(env.homeDir, env.session.UserID)); err == nil {
+		t.Error("the broker created the missing home directory")
+	}
+}
+
+// The stored key pair and the authorized_keys entry have to agree: a stored key
+// with no entry authorizes nothing, and an entry with no stored key can never be
+// revoked. A failure to write the store must therefore also deny the login.
+func TestLoginIsDeniedWhenTheKeyStoreCannotBeWritten(t *testing.T) {
+	env := newPollTestEnv(t)
+
+	// Point the key store at a path that cannot hold it: a regular file.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocked, nil, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	env.broker.keyManager = sshpkg.NewKeyManager(blocked)
+	env.broker.keyManager.SetKeySize(2048)
+
+	env.idp.Script(testoidc.Grant)
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("the session was activated although the key pair could not be stored: %+v", session)
+	}
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a key was authorized that the broker cannot revoke, since it was never stored:\n%s", data)
+	}
+}
+
+// newReconcileBroker returns a broker with a real key store and an
+// authorized_keys manager rooted at a temporary tree, ready for Start().
+func newReconcileBroker(t *testing.T, homeDir string, usernames ...string) *Broker {
+	t.Helper()
+
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{Enabled: false})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	keyManager := sshpkg.NewKeyManager(t.TempDir())
+	keyManager.SetKeySize(2048)
+
+	return &Broker{
+		config: &config.Config{
+			Authentication: config.AuthenticationConfig{TokenLifetime: time.Hour},
+		},
+		providers:             map[string]*OIDCProvider{},
+		tokenManager:          newTestTokenManager(t),
+		policyEngine:          &PolicyEngine{},
+		auditLogger:           auditLogger,
+		sessions:              make(map[string]*Session),
+		keyManager:            keyManager,
+		authorizedKeysManager: testAuthorizedKeysManager(t, homeDir, usernames...),
+		stopChan:              make(chan struct{}),
+	}
+}
+
+// The keys of a broker that has stopped are orphans: sessions live only in memory,
+// so after a restart nothing remains that would ever revoke them, while the
+// authorized_keys entries keep authenticating. Starting up must revoke them.
+//
+// This drives Start(), not the reconciliation helper directly, because "it happens
+// at startup" is the claim — a helper nothing calls is exactly the shape of the
+// defect (RemoveExpiredKeys was reachable and unreachable for the same reason).
+func TestStartupRevokesKeysLeftByAPreviousRun(t *testing.T) {
+	homeDir := t.TempDir()
+	broker := newReconcileBroker(t, homeDir, "alice")
+
+	// What a previous run left behind: a key pair in the store, and its entry in the
+	// user's authorized_keys, with no session anywhere.
+	orphan, err := broker.keyManager.GenerateKey("alice")
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	const orphanSessionID = "1f2e3d4c5b6a79880f1e2d3c4b5a69780f1e2d3c4b5a69780f1e2d3c4b5a6978"
+	if err := broker.keyManager.SaveKey(orphanSessionID, orphan); err != nil {
+		t.Fatalf("SaveKey: %v", err)
+	}
+	own := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5OWN personal-laptop"
+	path := writeAuthorizedKeys(t, homeDir, "alice",
+		"# Added by OIDC PAM on 2026-01-01 00:00:00",
+		fmt.Sprintf(`expiry-time="%s" %s`,
+			time.Now().Add(time.Hour).UTC().Format("20060102150405Z"),
+			strings.TrimSpace(string(orphan.PublicKey))),
+		own)
+
+	if err := broker.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = broker.Stop() })
+
+	remaining := readAuthorizedKeys(t, path)
+	if strings.Contains(remaining, strings.TrimSpace(string(orphan.PublicKey))) {
+		t.Errorf("a key issued before the restart still authorizes access, and no session "+
+			"remains that would ever revoke it (#171); file is %q", remaining)
+	}
+	if !strings.Contains(remaining, own) {
+		t.Errorf("the user's own key was removed; file is %q", remaining)
+	}
+	// The stored pair goes too: leaving it would make the next startup try again
+	// forever, and the private half is a live credential on disk.
+	if _, err := broker.keyManager.LoadKey(orphanSessionID); err == nil {
+		t.Error("the orphaned key pair is still in the broker's key store")
+	}
+}
+
+// Reconciliation must not touch a user whose only broker entry is the one this run
+// is about to issue — but there is no such user at startup, so the case to pin is
+// the empty store: a broker with nothing stored must leave every authorized_keys
+// file alone.
+func TestStartupLeavesAuthorizedKeysAloneWhenTheStoreIsEmpty(t *testing.T) {
+	homeDir := t.TempDir()
+	broker := newReconcileBroker(t, homeDir, "alice")
+
+	// A key bearing the marker that this broker did *not* issue — a different host's
+	// broker writing a shared NFS home, say. With nothing in the store there is
+	// nothing to reconcile and nothing to remove.
+	line := "ssh-rsa AAAAB3NzaC1yc2EOTHERHOST alice@oidc-pam-1700000000"
+	path := writeAuthorizedKeys(t, homeDir, "alice", line)
+
+	if err := broker.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = broker.Stop() })
+
+	if got := readAuthorizedKeys(t, path); !strings.Contains(got, "OTHERHOST") {
+		t.Errorf("startup rewrote authorized_keys with an empty key store; file is %q", got)
+	}
+}
+
+// The configured token lifetime is what limits a key. Both the key store and the
+// authorized_keys sweep defaulted to 24 hours and neither was ever told the
+// configured value, so a site with token_lifetime: 30m still issued keys good for a
+// day (#171).
+func TestConfiguredTokenLifetimeLimitsTheIssuedKey(t *testing.T) {
+	const lifetime = 30 * time.Minute
+
+	// The real constructor, against an in-process issuer, because the claim is about
+	// what NewBroker wires up — the managers it builds are unexported and reached no
+	// other way.
+	const clientID = "oidc-pam-test-client"
+	idp := testoidc.New(t, clientID)
+
+	broker, err := NewBroker(&config.Config{
+		Server: config.ServerConfig{SocketPath: filepath.Join(t.TempDir(), "broker.sock")},
+		OIDC: config.OIDCConfig{
+			Providers: []config.OIDCProvider{{
+				Name:            "testidp",
+				Issuer:          idp.Issuer(),
+				ClientID:        clientID,
+				Scopes:          []string{"openid", "profile", "email"},
+				EnabledForLogin: true,
+			}},
+		},
+		Security: config.SecurityConfig{
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+		},
+		Authentication: config.AuthenticationConfig{TokenLifetime: lifetime},
+		Audit:          config.AuditConfig{Enabled: false},
+	})
+	if err != nil {
+		t.Fatalf("NewBroker: %v", err)
+	}
+
+	broker.keyManager.SetKeySize(2048)
+	key, err := broker.keyManager.GenerateKey("alice")
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	got := time.Until(key.ExpiresAt)
+	if got > lifetime+time.Minute {
+		t.Errorf("a key issued under token_lifetime=%s expires in %s; the configured lifetime "+
+			"is not what limits the key", lifetime, got.Round(time.Second))
+	}
+	if got < lifetime-time.Minute {
+		t.Errorf("a key issued under token_lifetime=%s expires in %s, sooner than the session "+
+			"it belongs to", lifetime, got.Round(time.Second))
+	}
+}

--- a/pkg/auth/key_revocation_test.go
+++ b/pkg/auth/key_revocation_test.go
@@ -56,7 +56,7 @@ func newRevokeTestEnv(t *testing.T) *revokeTestEnv {
 		providers:             map[string]*OIDCProvider{},
 		auditLogger:           auditLogger,
 		keyManager:            keyManager,
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
+		authorizedKeysManager: testAuthorizedKeysManager(t, homeDir, "alice", "bob", "carol"),
 		metrics:               oidcmetrics.New(registry, nil),
 	}
 
@@ -68,8 +68,16 @@ func newRevokeTestEnv(t *testing.T) *revokeTestEnv {
 func (e *revokeTestEnv) provision(t *testing.T, username string) *Session {
 	t.Helper()
 
+	return e.provisionSession(t, username, "a3f1c9d2e5b48706"+username)
+}
+
+// provisionSession is provision with the session ID chosen by the caller, for the
+// case where one account has two sessions at once.
+func (e *revokeTestEnv) provisionSession(t *testing.T, username, sessionID string) *Session {
+	t.Helper()
+
 	session := &Session{
-		ID:           "a3f1c9d2e5b48706" + username,
+		ID:           sessionID,
 		UserID:       username,
 		Email:        username + "@example.com",
 		CreatedAt:    time.Now(),
@@ -244,6 +252,55 @@ func TestRevocationThatMatchesNothingIsNotAuditedAsSuccess(t *testing.T) {
 	// The line that could not be revoked is still there; the audit trail now says so.
 	if remaining := env.authorizedKeys(t, "bob"); !strings.Contains(remaining, "# Added by OIDC PAM") {
 		t.Errorf("the unmatched line was removed after all; file is %q", remaining)
+	}
+}
+
+// A second login supersedes the first: one live broker-issued key per account is
+// the invariant, so the earlier entry is gone by the time the earlier session
+// expires. That removal must not then be reported as a failure — it is the
+// intended state, and calling it ssh_key_revocation_incomplete would train
+// operators to ignore the one event that means a credential is still live (#165,
+// #171).
+func TestRevokingASupersededKeyIsNotReportedAsIncomplete(t *testing.T) {
+	env := newRevokeTestEnv(t)
+
+	first := env.provision(t, "carol")
+	// A second login for the same account, with its own session ID, as the broker
+	// mints them.
+	second := env.provisionSession(t, "carol", "b7e4d5c6a1f09283b7e4d5c6a1f09283b7e4d5c6a1f09283b7e4d5c6a1f09283")
+
+	remaining := env.authorizedKeys(t, "carol")
+	if strings.Contains(remaining, strings.TrimSpace(first.SSHPublicKey)) {
+		t.Fatalf("the first login's key is still authorized after a second login; the account "+
+			"has two live broker keys (#171). File is %q", remaining)
+	}
+	if !strings.Contains(remaining, strings.TrimSpace(second.SSHPublicKey)) {
+		t.Fatalf("the second login's key was not authorized; file is %q", remaining)
+	}
+
+	// Now the first session expires and its key is revoked. There is nothing left to
+	// remove, but nothing is wrong either.
+	if err := env.broker.revokeSSHKey(first); err != nil {
+		t.Fatalf("revokeSSHKey: %v", err)
+	}
+
+	types := env.auditEventTypes(t)
+	if recorded(types, "ssh_key_revocation_incomplete") {
+		t.Errorf("revoking a key that a later login had already superseded was reported as an "+
+			"incomplete revocation; events: %v", types)
+	}
+	if !recorded(types, "ssh_key_revoked") {
+		t.Errorf("revoking a superseded key recorded %v, want ssh_key_revoked", types)
+	}
+	if got := env.revokeMetric(t, "failure"); got != 0 {
+		t.Errorf("revoke failure metric = %v for a superseded key, want 0", got)
+	}
+	if got := env.revokeMetric(t, "success"); got != 1 {
+		t.Errorf("revoke success metric = %v, want 1", got)
+	}
+	// The live login keeps working: revoking the older session must not disturb it.
+	if after := env.authorizedKeys(t, "carol"); !strings.Contains(after, strings.TrimSpace(second.SSHPublicKey)) {
+		t.Errorf("revoking the superseded key removed the live one; file is %q", after)
 	}
 }
 

--- a/pkg/auth/key_sweep_test.go
+++ b/pkg/auth/key_sweep_test.go
@@ -15,6 +15,26 @@ import (
 	sshpkg "github.com/scttfrdmn/oidc-pam/pkg/ssh"
 )
 
+// testAuthorizedKeysManager returns an AuthorizedKeysManager that resolves homes
+// under homeDir, and creates the home directories of the named accounts.
+//
+// (#171) The manager no longer takes a base directory: it resolves each account's
+// home through the account database, and refuses a home that does not exist rather
+// than creating one as root. Tests substitute the lookup instead of creating real
+// accounts on the machine running the suite.
+func testAuthorizedKeysManager(t *testing.T, homeDir string, usernames ...string) *sshpkg.AuthorizedKeysManager {
+	t.Helper()
+
+	for _, username := range usernames {
+		if err := os.MkdirAll(filepath.Join(homeDir, username), 0700); err != nil {
+			t.Fatalf("MkdirAll home for %s: %v", username, err)
+		}
+	}
+	akm := sshpkg.NewAuthorizedKeysManager(t.TempDir())
+	akm.SetAccountLookup(sshpkg.HomeRootLookup(homeDir))
+	return akm
+}
+
 // newSweepTestBroker returns a broker whose AuthorizedKeysManager is rooted at a
 // temporary directory standing in for /home.
 func newSweepTestBroker(t *testing.T) (*Broker, string) {
@@ -35,7 +55,7 @@ func newSweepTestBroker(t *testing.T) (*Broker, string) {
 		sessionMutex:          sync.RWMutex{},
 		providers:             map[string]*OIDCProvider{},
 		auditLogger:           auditLogger,
-		authorizedKeysManager: sshpkg.NewAuthorizedKeysManager(homeDir, t.TempDir()),
+		authorizedKeysManager: testAuthorizedKeysManager(t, homeDir),
 	}
 
 	return broker, homeDir

--- a/pkg/ssh/accounts.go
+++ b/pkg/ssh/accounts.go
@@ -1,0 +1,229 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Account is what the broker has to know about a local account before it writes
+// into that account's ~/.ssh: where the home directory really is, and who owns it.
+//
+// (#171) Both facts used to be assumed. The broker joined "/home" with the login
+// name and wrote there, so on any site whose homes are not literally /home/<user>
+// — LDAP/SSSD with /home/<domain>/<user>, autofs, NFS, a home moved by hand — it
+// wrote an authorized_keys sshd never reads, reported success, and let the login
+// through with no working key. The uid was never looked at at all, so the same
+// code would happily create /home/<user> itself, root-owned and mode 0700, and
+// lock a user out of their own home directory.
+type Account struct {
+	// Username is the login name as resolved, echoed back so a caller logging an
+	// Account does not have to carry the name separately.
+	Username string
+	// Home is the account's home directory from the passwd database. It is used as
+	// given: this package never derives, guesses or creates it.
+	Home string
+	UID  int
+	GID  int
+}
+
+// AccountLookup resolves a local login name to its passwd entry.
+//
+// It is a function type so that the manager's dependency on the host's account
+// database is explicit and substitutable — production uses LookupAccount, tests
+// present a table of their own (see HomeRootLookup).
+type AccountLookup func(username string) (Account, error)
+
+// ErrUnknownAccount is returned when the login name has no passwd entry. It is
+// distinct because "this account does not exist" is a configuration or
+// identity-mapping problem an operator can act on, while any other lookup error
+// is a fault in the account database.
+var ErrUnknownAccount = errors.New("no such local account")
+
+// getentPath is the program consulted when os/user cannot answer. Overridden by
+// tests; see lookupViaGetent.
+var getentPath = "/usr/bin/getent"
+
+// getentTimeout bounds the fallback lookup. A wedged NSS backend must not hold a
+// login open until sshd's LoginGraceTime kills it. A variable so the test for that
+// does not have to wait out the production value.
+var getentTimeout = 5 * time.Second
+
+// LookupAccount resolves an account through the host's account database. This is
+// the production AccountLookup.
+//
+// It asks os/user first and falls back to getent(1). The fallback is not
+// belt-and-braces: the released broker is built with CGO_ENABLED=0
+// (.github/workflows/release.yml), and without cgo os/user does not go through
+// NSS at all — it parses /etc/passwd directly. Every account that comes from
+// SSSD, LDAP or any other NSS source is therefore invisible to it, which is
+// precisely the population #171 is about. getent asks NSS the same way sshd and
+// login do, so the broker resolves the same home directory they do.
+func LookupAccount(username string) (Account, error) {
+	if err := validateUsername(username); err != nil {
+		return Account{}, err
+	}
+
+	usr, err := user.Lookup(username)
+	if err == nil {
+		return accountFromStrings(username, usr.HomeDir, usr.Uid, usr.Gid)
+	}
+
+	var unknown user.UnknownUserError
+	if !errors.As(err, &unknown) {
+		return Account{}, fmt.Errorf("failed to look up account %q: %w", username, err)
+	}
+
+	account, getentErr := lookupViaGetent(username)
+	if getentErr == nil {
+		return account, nil
+	}
+	if errors.Is(getentErr, ErrUnknownAccount) {
+		return Account{}, fmt.Errorf("%w: %q", ErrUnknownAccount, username)
+	}
+	return Account{}, fmt.Errorf("failed to look up account %q via getent: %w", username, getentErr)
+}
+
+// lookupViaGetent reads one passwd entry through NSS.
+//
+// The username is validated by every caller before it gets here, and is passed as
+// a separate argument to an absolute program path — there is no shell, so no
+// quoting question.
+func lookupViaGetent(username string) (Account, error) {
+	if _, err := os.Stat(getentPath); err != nil {
+		return Account{}, fmt.Errorf("%w (getent is unavailable at %s)", ErrUnknownAccount, getentPath)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), getentTimeout)
+	defer cancel()
+
+	// #nosec G204 -- getentPath is a fixed absolute path (a test hook, not
+	// configuration) and username has passed validateUsername, which admits only
+	// POSIX login names.
+	cmd := exec.CommandContext(ctx, getentPath, "passwd", username)
+	cmd.Env = []string{"LC_ALL=C", "PATH=/usr/bin:/bin"}
+	// The context alone does not bound this. Killing getent does not close the pipe
+	// its output is read through if getent has forked a child that inherited it, and
+	// Output waits for the pipe, not the process — so a wedged NSS backend could
+	// still hold the lookup open for as long as that child lived. WaitDelay makes the
+	// wait give up and close the pipes.
+	cmd.WaitDelay = getentTimeout
+
+	out, runErr := cmd.Output()
+	if ctx.Err() != nil {
+		return Account{}, fmt.Errorf("getent passwd %q did not answer within %s", username, getentTimeout)
+	}
+	if runErr != nil {
+		// getent exits 2 for "key not found", which is an answer, not a failure.
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) && exitErr.ExitCode() == 2 {
+			return Account{}, ErrUnknownAccount
+		}
+		return Account{}, runErr
+	}
+
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return Account{}, ErrUnknownAccount
+	}
+	// name:passwd:uid:gid:gecos:home:shell
+	fields := strings.Split(strings.SplitN(line, "\n", 2)[0], ":")
+	if len(fields) < 7 {
+		return Account{}, fmt.Errorf("getent returned a passwd line with %d fields: %q", len(fields), line)
+	}
+	if fields[0] != username {
+		return Account{}, fmt.Errorf("getent answered for %q when asked about %q", fields[0], username)
+	}
+	return accountFromStrings(username, fields[5], fields[2], fields[3])
+}
+
+// accountFromStrings builds an Account from the string fields both lookups
+// produce, refusing an entry the broker cannot act on. An empty home directory is
+// refused rather than defaulted: a default is how #171 started.
+func accountFromStrings(username, home, uid, gid string) (Account, error) {
+	if strings.TrimSpace(home) == "" {
+		return Account{}, fmt.Errorf("account %q has no home directory in the passwd database", username)
+	}
+	numericUID, err := strconv.Atoi(uid)
+	if err != nil {
+		return Account{}, fmt.Errorf("account %q has a non-numeric uid %q", username, uid)
+	}
+	numericGID, err := strconv.Atoi(gid)
+	if err != nil {
+		return Account{}, fmt.Errorf("account %q has a non-numeric gid %q", username, gid)
+	}
+	return Account{Username: username, Home: home, UID: numericUID, GID: numericGID}, nil
+}
+
+// HomeRootLookup returns an AccountLookup that places every account's home at
+// <root>/<username> and attributes it to the uid and gid this process runs as.
+//
+// It exists so that tests can exercise the write paths against a temporary tree
+// without creating real accounts on the machine running the suite. It is not the
+// old behaviour under a new name: production passes LookupAccount, and nothing in
+// this package derives a home directory from a base directory any more.
+func HomeRootLookup(root string) AccountLookup {
+	return func(username string) (Account, error) {
+		if err := validateUsername(username); err != nil {
+			return Account{}, err
+		}
+		return Account{
+			Username: username,
+			Home:     root + string(os.PathSeparator) + username,
+			UID:      os.Geteuid(),
+			GID:      os.Getegid(),
+		}, nil
+	}
+}
+
+// statUID returns the owning uid of an already-stat'ed file.
+func statUID(info fs.FileInfo) (int, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(stat.Uid), true
+}
+
+// checkOwner refuses a path that belongs to neither the account nor root.
+//
+// Root is accepted because sshd accepts it: under StrictModes every component of
+// the path to authorized_keys must be owned by the target user or by root. A file
+// owned by any *third* account is a different matter — someone else can rewrite
+// it — and the broker will not read a key list, or write one, through it.
+func checkOwner(what, path string, info fs.FileInfo, account Account) error {
+	uid, ok := statUID(info)
+	if !ok {
+		// No Stat_t means an OS this package is not built for; refuse rather than
+		// silently skip the check that the rest of the path's safety rests on.
+		return fmt.Errorf("cannot determine the owner of %s %q", what, path)
+	}
+	if uid == account.UID || uid == 0 {
+		return nil
+	}
+	return fmt.Errorf("refusing to use %s %q: it is owned by uid %d, not by %s (uid %d) or root",
+		what, path, uid, account.Username, account.UID)
+}
+
+// chownToAccount gives a path to the account, so that a file the root broker
+// created in someone's home stays theirs to manage.
+//
+// Only root can hand a file to another user, so this is a no-op for an unprivileged
+// process — which is every test, and any development run.
+func chownToAccount(path string, account Account) error {
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	if err := os.Chown(path, account.UID, account.GID); err != nil {
+		return fmt.Errorf("failed to give %q to %s (uid %d): %w", path, account.Username, account.UID, err)
+	}
+	return nil
+}

--- a/pkg/ssh/accounts_test.go
+++ b/pkg/ssh/accounts_test.go
@@ -1,0 +1,255 @@
+package ssh
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubGetent replaces the getent(1) the fallback lookup runs with a shell script
+// that behaves as the test describes, and restores the real path afterwards.
+func stubGetent(t *testing.T, script string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "getent")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0700); err != nil { // #nosec G306 -- must be executable
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	previous := getentPath
+	getentPath = path
+	t.Cleanup(func() { getentPath = previous })
+}
+
+// The reason the fallback exists: the released broker is built without cgo, so
+// os/user parses /etc/passwd and never asks NSS. An account that only NSS knows
+// about — every SSSD or LDAP account — must still resolve, and must resolve to the
+// home directory NSS gives, not to /home/<name> (#171).
+func TestAnAccountKnownOnlyToNSSResolvesThroughGetent(t *testing.T) {
+	stubGetent(t, `
+if [ "$1" = passwd ] && [ "$2" = alice ]; then
+  echo 'alice:x:4242:4243:Alice Example:/home/ldap-domain/alice:/bin/bash'
+  exit 0
+fi
+exit 2
+`)
+
+	account, err := LookupAccount("alice")
+	if err != nil {
+		// A host that really has a local "alice" would answer from os/user first and
+		// never reach the stub; skip rather than fail on someone's laptop.
+		if _, lookupErr := user.Lookup("alice"); lookupErr == nil {
+			t.Skip("this host has a local alice, so the NSS fallback is not reached")
+		}
+		t.Fatalf("LookupAccount: %v", err)
+	}
+
+	if account.Home != "/home/ldap-domain/alice" {
+		t.Errorf("home = %q, want the passwd entry's /home/ldap-domain/alice; a broker that "+
+			"assumes /home/<user> writes authorized_keys where sshd will not read it", account.Home)
+	}
+	if account.UID != 4242 || account.GID != 4243 {
+		t.Errorf("uid/gid = %d/%d, want 4242/4243", account.UID, account.GID)
+	}
+	if account.Username != "alice" {
+		t.Errorf("username = %q, want alice", account.Username)
+	}
+}
+
+// getent exits 2 for "key not found". That is an answer, and it has to be
+// distinguishable from a broken account database: one means "no such user", the
+// other means the broker cannot tell and must not guess.
+func TestAnAccountNothingKnowsAboutIsReportedAsUnknown(t *testing.T) {
+	stubGetent(t, "exit 2\n")
+
+	name := "oidc-pam-no-such-account"
+	_, err := LookupAccount(name)
+	if err == nil {
+		t.Fatalf("LookupAccount(%q) succeeded", name)
+	}
+	if !errors.Is(err, ErrUnknownAccount) {
+		t.Errorf("error is %v, want one matching ErrUnknownAccount so callers can tell "+
+			"\"no such user\" from \"the account database is broken\"", err)
+	}
+}
+
+// A getent that never answers — a wedged LDAP backend is the usual cause — must
+// not hold the login open. The lookup is bounded, so this returns instead of
+// hanging until the test binary's timeout.
+func TestAWedgedAccountDatabaseDoesNotHangTheLookup(t *testing.T) {
+	stubGetent(t, "sleep 300\n")
+
+	previousTimeout := getentTimeout
+	getentTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { getentTimeout = previousTimeout })
+
+	name := "oidc-pam-no-such-account"
+	if _, err := user.Lookup(name); err == nil {
+		t.Skipf("this host has a local %s", name)
+	}
+
+	done := make(chan error, 1)
+	go func() { _, err := LookupAccount(name); done <- err }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a getent that never answered produced an account")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("LookupAccount did not return; a wedged account database blocks the login " +
+			"until sshd's LoginGraceTime kills it")
+	}
+}
+
+// getent answering about a different account than the one asked about means the
+// database is not to be trusted for this decision; the broker must not write into
+// whatever home came back.
+func TestAnAnswerAboutTheWrongAccountIsRefused(t *testing.T) {
+	stubGetent(t, "echo 'root:x:0:0:root:/root:/bin/sh'\nexit 0\n")
+
+	name := "oidc-pam-no-such-account"
+	if _, err := user.Lookup(name); err == nil {
+		t.Skipf("this host has a local %s", name)
+	}
+
+	account, err := LookupAccount(name)
+	if err == nil {
+		t.Fatalf("LookupAccount accepted an answer about %q, returning home %q",
+			account.Username, account.Home)
+	}
+}
+
+// The passwd fields the broker cannot act on. An empty home is refused rather than
+// defaulted, because defaulting it is exactly how #171 started.
+func TestPasswdEntriesTheBrokerCannotActOnAreRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		home, uid, gid   string
+		wantSubstringErr string
+	}{
+		{name: "no home directory", home: "", uid: "1000", gid: "1000", wantSubstringErr: "no home directory"},
+		{name: "blank home directory", home: "   ", uid: "1000", gid: "1000", wantSubstringErr: "no home directory"},
+		{name: "non-numeric uid", home: "/home/alice", uid: "alice", gid: "1000", wantSubstringErr: "non-numeric uid"},
+		{name: "non-numeric gid", home: "/home/alice", uid: "1000", gid: "staff", wantSubstringErr: "non-numeric gid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := accountFromStrings("alice", tc.home, tc.uid, tc.gid)
+			if err == nil {
+				t.Fatalf("accountFromStrings(home=%q, uid=%q, gid=%q) succeeded", tc.home, tc.uid, tc.gid)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstringErr) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.wantSubstringErr)
+			}
+		})
+	}
+}
+
+// A negative uid is what a passwd entry with a wrapped or bogus id looks like, and
+// it must not become an ownership check that passes by accident.
+func TestAnAccountResolvesToTheUIDInTheDatabase(t *testing.T) {
+	account, err := accountFromStrings("alice", "/home/alice", "0", "0")
+	if err != nil {
+		t.Fatalf("accountFromStrings: %v", err)
+	}
+	if account.UID != 0 {
+		t.Errorf("uid = %d, want 0", account.UID)
+	}
+}
+
+// The lookup must not be handed a name that is not a login name at all: "../.."
+// resolving to a home directory is a path-traversal write into someone else's tree.
+func TestLookupRefusesSomethingThatIsNotALoginName(t *testing.T) {
+	for _, name := range []string{"", "../../etc", "root/../alice", "alice\nbob", "-alice"} {
+		if _, err := LookupAccount(name); err == nil {
+			t.Errorf("LookupAccount(%q) succeeded; it is not a POSIX login name", name)
+		}
+	}
+}
+
+// checkOwner is what stands between the broker and a home directory someone else
+// controls. sshd's own StrictModes accepts the user or root and nothing else, so
+// this must too.
+func TestOwnershipAcceptsTheAccountAndRootAndNobodyElse(t *testing.T) {
+	dir := t.TempDir()
+	info, err := os.Lstat(dir)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	owner, ok := statUID(info)
+	if !ok {
+		t.Skip("no syscall.Stat_t on this platform")
+	}
+
+	// Owned by the account: accepted.
+	if err := checkOwner("home directory", dir, info, Account{Username: "alice", UID: owner}); err != nil {
+		t.Errorf("a path owned by the account was refused: %v", err)
+	}
+
+	// Owned by somebody else entirely: refused. This is the case that matters —
+	// following it means writing a key list a third party can rewrite.
+	stranger := Account{Username: "alice", UID: owner + 1}
+	err = checkOwner("home directory", dir, info, stranger)
+	if err == nil {
+		t.Error("a path owned by a third account was accepted")
+	} else if !strings.Contains(err.Error(), strconv.Itoa(owner)) {
+		t.Errorf("the refusal does not say who owns the path: %v", err)
+	}
+
+	// Owned by root: accepted, because sshd accepts it.
+	rootInfo, err := os.Lstat("/")
+	if err != nil {
+		t.Fatalf("Lstat /: %v", err)
+	}
+	if uid, ok := statUID(rootInfo); !ok || uid != 0 {
+		t.Skip("/ is not owned by root on this host")
+	}
+	if err := checkOwner("home directory", "/", rootInfo, stranger); err != nil {
+		t.Errorf("a root-owned path was refused, but sshd's StrictModes accepts one: %v", err)
+	}
+}
+
+// HomeRootLookup is a test seam, and the thing it must not do is what the defect
+// did: bring a directory into existence.
+func TestHomeRootLookupCreatesNothing(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "homes")
+
+	account, err := HomeRootLookup(root)("alice")
+	if err != nil {
+		t.Fatalf("HomeRootLookup: %v", err)
+	}
+	if want := filepath.Join(root, "alice"); account.Home != want {
+		t.Errorf("home = %q, want %q", account.Home, want)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("looking an account up created %q (Stat error: %v)", root, err)
+	}
+	if account.UID != os.Geteuid() {
+		t.Errorf("uid = %d, want this process's %d", account.UID, os.Geteuid())
+	}
+}
+
+// A last guard on the fallback's own preconditions: with no getent on the host,
+// an account os/user cannot see is unknown rather than a hard error, so the caller
+// still gets an actionable message.
+func TestAMissingGetentLeavesTheAccountUnknown(t *testing.T) {
+	previous := getentPath
+	getentPath = filepath.Join(t.TempDir(), "no-getent-here")
+	t.Cleanup(func() { getentPath = previous })
+
+	_, err := lookupViaGetent("alice")
+	if err == nil {
+		t.Fatal("lookupViaGetent succeeded with no getent installed")
+	}
+	if !errors.Is(err, ErrUnknownAccount) {
+		t.Errorf("error is %v, want one matching ErrUnknownAccount", err)
+	}
+	if !strings.Contains(err.Error(), "getent is unavailable") {
+		t.Errorf("error %v does not say why the lookup could not be made", err)
+	}
+}

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -1,12 +1,11 @@
 package ssh
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -139,17 +138,22 @@ func ensureLockDir(lockDir string) error {
 // or authorized_keys within it, at an arbitrary file (e.g. /etc/passwd) so that
 // the root process follows the link and writes/truncates the target.
 //
-// It rejects the operation if .ssh exists but is a symlink or not a directory.
-// Callers must additionally open files within it using O_NOFOLLOW (see
-// openAuthorizedKeysForAppend / writeAuthorizedKeysAtomic).
-func ensureSecureSSHDir(sshDir string) error {
+// It rejects the operation if .ssh exists but is a symlink, is not a directory,
+// or belongs to some third account. Callers must additionally open files within it
+// using O_NOFOLLOW (see writeAuthorizedKeysAtomic).
+//
+// (#171) A .ssh directory the broker creates is handed to the account rather than
+// kept by root. It sits in the user's home and the user has to be able to manage
+// their own keys in it; a root-owned 0700 .ssh takes that away with no way for
+// them to get it back.
+func ensureSecureSSHDir(sshDir string, account Account) error {
 	info, err := os.Lstat(sshDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if mkErr := os.MkdirAll(sshDir, 0700); mkErr != nil {
 				return fmt.Errorf("failed to create .ssh directory: %w", mkErr)
 			}
-			return nil
+			return chownToAccount(sshDir, account)
 		}
 		return fmt.Errorf("failed to stat .ssh directory: %w", err)
 	}
@@ -159,7 +163,7 @@ func ensureSecureSSHDir(sshDir string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("refusing to use .ssh: %q is not a directory", sshDir)
 	}
-	return nil
+	return checkOwner(".ssh directory", sshDir, info, account)
 }
 
 // rejectIfSymlink returns an error if path exists and is a symbolic link. Used
@@ -179,16 +183,47 @@ func rejectIfSymlink(path string) error {
 	return nil
 }
 
-// openAuthorizedKeysForAppend opens the authorized_keys file for appending with
-// O_NOFOLLOW, refusing to follow a symlink at the final path component.
-func openAuthorizedKeysForAppend(path string) (*os.File, error) {
+// readAuthorizedKeysLines reads a user's authorized_keys and returns its lines.
+// A missing file yields no lines and no error: a user who has never had a key is
+// the normal case, not a failure.
+//
+// (#171) The file is opened O_NOFOLLOW and then *fstat'ed through the open
+// descriptor*, and the descriptor is refused unless it belongs to the account or
+// to root. Checking the path instead of the descriptor is a TOCTOU: the directory
+// is writable by the user, so between a stat and an open the name can be made to
+// point somewhere else. What is verified has to be the thing that was opened.
+func readAuthorizedKeysLines(path string, account Account) ([]string, error) {
 	if err := rejectIfSymlink(path); err != nil {
 		return nil, err
 	}
-	// #nosec G304 -- path is built from an allowlisted username (validateUsername)
-	// under the broker's base dir; the final component is symlink-checked above
-	// and opened with O_NOFOLLOW so a planted symlink cannot redirect the write.
-	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW, 0600)
+	// #nosec G304 -- path is <resolved home>/.ssh/authorized_keys for a validated
+	// login name; symlink-checked above, opened O_NOFOLLOW, and the descriptor's
+	// ownership is verified below.
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open authorized_keys file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat the open authorized_keys file: %w", err)
+	}
+	if err := checkOwner("authorized_keys", path, info, account); err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read authorized_keys file: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	return strings.Split(strings.TrimRight(string(data), "\n"), "\n"), nil
 }
 
 // writeAuthorizedKeysAtomic writes content to the authorized_keys file safely:
@@ -196,7 +231,10 @@ func openAuthorizedKeysForAppend(path string) (*os.File, error) {
 // directory (created with O_NOFOLLOW|O_EXCL), then atomically renames over the
 // target. Rename replaces the directory entry rather than following/truncating
 // a link, so a planted symlink cannot redirect the write.
-func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
+// The replacement is given to the account before the rename (#171): the broker
+// runs as root, and a file it created would otherwise leave the user unable to
+// edit their own authorized_keys.
+func writeAuthorizedKeysAtomic(sshDir, path string, content []byte, account Account) error {
 	if err := rejectIfSymlink(path); err != nil {
 		return err
 	}
@@ -217,6 +255,10 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
 	if err := tmp.Close(); err != nil {
 		cleanup()
 		return fmt.Errorf("failed to close temp authorized_keys: %w", err)
+	}
+	if err := chownToAccount(tmpPath, account); err != nil {
+		cleanup()
+		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		cleanup()
@@ -240,7 +282,7 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte) error {
 //
 // Sharing one write path is the point: two callers deriving the file's tail
 // independently is what allowed them to differ in the first place.
-func writeAuthorizedKeysLines(sshDir, path string, lines []string) error {
+func writeAuthorizedKeysLines(sshDir, path string, lines []string, account Account) error {
 	// Trailing blanks are dropped so that a caller's choice of line splitting
 	// cannot change the file's tail, then the last real line is terminated.
 	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
@@ -250,30 +292,109 @@ func writeAuthorizedKeysLines(sshDir, path string, lines []string) error {
 	if len(lines) > 0 {
 		content = []byte(strings.Join(lines, "\n") + "\n")
 	}
-	return writeAuthorizedKeysAtomic(sshDir, path, content)
+	return writeAuthorizedKeysAtomic(sshDir, path, content, account)
 }
+
+// DefaultKeyLifetime is the age at which a broker-issued authorized_keys entry is
+// treated as stale when nothing better is known about it. It is only a fallback:
+// the broker sets the configured token_lifetime with SetKeyLifetime, and entries
+// written by this version carry their own expiry-time= option.
+const DefaultKeyLifetime = 24 * time.Hour
 
 // AuthorizedKeysManager manages authorized_keys files for users
 type AuthorizedKeysManager struct {
-	baseDir     string
-	lockDir     string
-	lockTimeout time.Duration
+	lookupAccount AccountLookup
+	lockDir       string
+	lockTimeout   time.Duration
+	keyLifetime   time.Duration
 }
 
 // NewAuthorizedKeysManager creates a new authorized keys manager.
 //
-// baseDir is the parent of the users' home directories (production: /home).
 // lockDir is where the per-user write locks live and must be a directory only the
 // broker can write to — production passes DefaultLockDir. It is a required
 // argument rather than a default with an override because a lock directory the
 // protected user can reach is the whole of #161, and that is not something to
 // arrive at by forgetting to pass an option.
-func NewAuthorizedKeysManager(baseDir, lockDir string) *AuthorizedKeysManager {
+//
+// (#171) There is no base-directory argument any more. This used to be
+// constructed with "/home" and every path was <baseDir>/<username>/.ssh, which is
+// a guess: it is wrong on every site whose homes come from LDAP/SSSD, autofs or
+// NFS, and being wrong meant writing a key list sshd never reads while reporting
+// success. Homes now come from the account database (LookupAccount).
+func NewAuthorizedKeysManager(lockDir string) *AuthorizedKeysManager {
 	return &AuthorizedKeysManager{
-		baseDir:     baseDir,
-		lockDir:     lockDir,
-		lockTimeout: lockAcquireTimeout,
+		lookupAccount: LookupAccount,
+		lockDir:       lockDir,
+		lockTimeout:   lockAcquireTimeout,
+		keyLifetime:   DefaultKeyLifetime,
 	}
+}
+
+// SetAccountLookup replaces the account database this manager resolves homes and
+// owners through.
+//
+// It exists for tests, which cannot create real accounts on the machine running
+// the suite; see HomeRootLookup. Call it before the manager is used.
+func (akm *AuthorizedKeysManager) SetAccountLookup(lookup AccountLookup) {
+	if lookup != nil {
+		akm.lookupAccount = lookup
+	}
+}
+
+// SetKeyLifetime sets how long a broker-issued entry is honoured when the entry
+// itself does not say — that is, an entry written by an older broker, which
+// carries only the issue time in its comment.
+//
+// The broker passes the configured authentication.token_lifetime. Before #171 the
+// sweep used a hardcoded 24 hours regardless of configuration, so a site that had
+// deliberately configured a one-hour lifetime still left every key it issued
+// usable for a day.
+func (akm *AuthorizedKeysManager) SetKeyLifetime(d time.Duration) {
+	if d > 0 {
+		akm.keyLifetime = d
+	}
+}
+
+// userPaths resolves an account and returns it with the paths of its .ssh
+// directory and authorized_keys file.
+//
+// It refuses to proceed unless the home directory the account database names
+// already exists and belongs to that account or to root. In particular it will
+// not create a home: MkdirAll on <home>/.ssh used to create the home itself, as
+// root and mode 0700, which locks the user out of their own home directory for a
+// login that then cannot work anyway. A missing home means the account is not
+// provisioned on this host, and that is a fact to report, not to paper over.
+func (akm *AuthorizedKeysManager) userPaths(username string) (Account, string, string, error) {
+	if err := validateUsername(username); err != nil {
+		return Account{}, "", "", fmt.Errorf("invalid username: %w", err)
+	}
+	account, err := akm.lookupAccount(username)
+	if err != nil {
+		return Account{}, "", "", err
+	}
+
+	info, err := os.Lstat(account.Home)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Account{}, "", "", fmt.Errorf(
+				"home directory %q for %s does not exist; refusing to create it",
+				account.Home, username)
+		}
+		return Account{}, "", "", fmt.Errorf("failed to stat home directory %q: %w", account.Home, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return Account{}, "", "", fmt.Errorf("refusing to use home directory %q: it is a symlink", account.Home)
+	}
+	if !info.IsDir() {
+		return Account{}, "", "", fmt.Errorf("refusing to use home directory %q: it is not a directory", account.Home)
+	}
+	if err := checkOwner("home directory", account.Home, info, account); err != nil {
+		return Account{}, "", "", err
+	}
+
+	sshDir := filepath.Join(account.Home, ".ssh")
+	return account, sshDir, filepath.Join(sshDir, "authorized_keys"), nil
 }
 
 // LockPath returns the lock file serializing writes to one user's
@@ -293,79 +414,88 @@ func (akm *AuthorizedKeysManager) SetLockTimeout(d time.Duration) {
 	akm.lockTimeout = d
 }
 
-// AddPublicKey adds a public key to a user's authorized_keys file
-func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte) error {
-	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
-	}
+// AddPublicKey installs the broker's key in a user's authorized_keys, as the
+// user's only broker-issued key, carrying the expiry sshd will enforce on it.
+//
+// expiresAt must be in the future: an entry with no expiry, or one already expired,
+// is not something to write into a key list and hope something removes later.
+//
+// (#171) Two things changed here, and both were ways a stale key stayed usable:
+//
+//   - It appended. Every login left another `@oidc-pam-` entry behind, deduplicated
+//     only against a byte-identical line — and the comment carries the issue
+//     timestamp, so no two logins ever produced one. A user who logged in daily
+//     accumulated one permanently valid key per login, each independently
+//     sufficient to authenticate, and revoking the current session's key left all
+//     the others in place. Now every broker-issued entry for that user is dropped
+//     before the new one is written: one live key, so revoking it revokes access.
+//   - The expiry existed only in the broker's memory and in a comment nothing but
+//     this broker reads. sshd now enforces it itself, which is what makes a key
+//     survive neither a broker restart nor a broker that never gets around to
+//     sweeping.
+func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte, expiresAt time.Time) error {
 	// Reject embedded newlines/CR: a multi-line value would inject additional
 	// authorized_keys entries or options (e.g. command=) (M-8).
 	if err := validatePublicKeyLine(publicKey); err != nil {
 		return err
 	}
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	lockPath := akm.LockPath(username)
+	if expiresAt.IsZero() {
+		return fmt.Errorf("refusing to install an SSH key with no expiry time")
+	}
+	if !expiresAt.After(time.Now()) {
+		return fmt.Errorf("refusing to install an SSH key that expired at %s", expiresAt.UTC().Format(time.RFC3339))
+	}
 
-	// Create/verify .ssh directory, rejecting a symlinked .ssh (C-2).
-	if err := ensureSecureSSHDir(sshDir); err != nil {
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
 		return err
 	}
 
-	return withFileLock(lockPath, akm.lockTimeout, func() error {
-		// Read existing authorized_keys file
-		var existingKeys []string
-		// (#165) Whether the file needs a newline before this append. The rewrite
-		// paths now always leave one, but the file belongs to the user and can be
-		// edited by anything: appending to a file whose last line is unterminated
-		// fuses the comment below onto that line, producing an entry no remover can
-		// ever match again. Cheap to check here, and it is the last chance to.
-		needsSeparator := false
-		if data, err := os.ReadFile(authorizedKeysPath); err == nil {
-			existingKeys = strings.Split(string(data), "\n")
-			needsSeparator = len(data) > 0 && data[len(data)-1] != '\n'
-		}
+	// Create/verify .ssh directory, rejecting a symlinked .ssh (C-2).
+	if err := ensureSecureSSHDir(sshDir, account); err != nil {
+		return err
+	}
 
-		// Check if key already exists
-		newKeyLine := strings.TrimSpace(string(publicKey))
-		for _, existingKey := range existingKeys {
-			if strings.TrimSpace(existingKey) == newKeyLine {
-				log.Debug().
-					Str("username", username).
-					Msg("Public key already exists in authorized_keys")
-				return nil
-			}
-		}
+	newEntry, ok := parseKeyEntry(string(publicKey))
+	if !ok {
+		return fmt.Errorf("public key is not a valid authorized_keys entry")
+	}
 
-		// Add the new key (O_NOFOLLOW: never follow a planted symlink — C-2).
-		file, err := openAuthorizedKeysForAppend(authorizedKeysPath)
+	return withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+		existing, err := readAuthorizedKeysLines(authorizedKeysPath, account)
 		if err != nil {
-			return fmt.Errorf("failed to open authorized_keys file: %w", err)
+			return err
 		}
-		defer func() { _ = file.Close() }()
 
-		if needsSeparator {
-			if _, err := file.WriteString("\n"); err != nil {
-				return fmt.Errorf("failed to terminate the last authorized_keys line: %w", err)
+		// Keep everything that is not the broker's. A key the user put there
+		// themselves is none of the broker's business, whatever it authorizes; only
+		// entries carrying the broker's own marker, or a re-add of this very entry,
+		// are dropped.
+		kept := make([]string, 0, len(existing)+2)
+		superseded := 0
+		for _, line := range existing {
+			entry, isEntry := parseKeyEntry(line)
+			if isEntry && (entry.brokerIssued() || entry.isSameEntryAs(newEntry)) {
+				superseded++
+				continue
 			}
+			kept = append(kept, line)
 		}
+		kept = dropStrandedBrokerComments(kept)
 
-		// Add timestamp comment
-		timestamp := time.Now().Format("2006-01-02 15:04:05")
-		comment := fmt.Sprintf("# Added by OIDC PAM on %s\n", timestamp)
+		kept = append(kept,
+			fmt.Sprintf("%s %s", brokerCommentPrefix, time.Now().Format("2006-01-02 15:04:05")),
+			brokerEntryLine(publicKey, expiresAt))
 
-		if _, err := file.WriteString(comment); err != nil {
-			return fmt.Errorf("failed to write comment to authorized_keys: %w", err)
-		}
-
-		if _, err := file.WriteString(newKeyLine + "\n"); err != nil {
-			return fmt.Errorf("failed to write key to authorized_keys: %w", err)
+		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath, kept, account); err != nil {
+			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
 
 		log.Info().
 			Str("username", username).
 			Str("authorized_keys_path", authorizedKeysPath).
+			Int("superseded_keys", superseded).
+			Time("expires_at", expiresAt).
 			Msg("Public key added to authorized_keys")
 
 		return nil
@@ -381,40 +511,36 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 // nothing — the audit trail asserted a revocation that had not happened while the
 // credential stayed usable. Callers must distinguish the two: removed=false, err=nil
 // means the entry is still there, if it was ever there at all.
+// (#171) Matching is on the entry, not on the whole line: the installed line
+// carries an `expiry-time=` option in front of the key, so a broker holding the
+// bare key in its store would never again find the line it had itself written.
+// parseKeyEntry/isSameEntryAs compare the key and its comment and ignore options.
 func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []byte) (bool, error) {
-	if err := validateUsername(username); err != nil {
-		return false, fmt.Errorf("invalid username: %w", err)
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
+		return false, err
 	}
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	lockPath := akm.LockPath(username)
 
 	// Check if .ssh directory exists; if not, nothing to remove
-	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
+	if _, statErr := os.Stat(sshDir); os.IsNotExist(statErr) {
 		return false, nil
 	}
 
+	target, ok := parseKeyEntry(string(publicKey))
+	if !ok {
+		return false, fmt.Errorf("public key is not a valid authorized_keys entry")
+	}
+
 	removed := false
-	err := withFileLock(lockPath, akm.lockTimeout, func() error {
-		// Read existing authorized_keys file
-		data, err := os.ReadFile(authorizedKeysPath)
+	err = withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+		lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
 		if err != nil {
-			if os.IsNotExist(err) {
-				return nil // File doesn't exist, nothing to remove
-			}
-			return fmt.Errorf("failed to read authorized_keys file: %w", err)
+			return err
 		}
 
-		// Parse existing keys
-		lines := strings.Split(string(data), "\n")
-		keyToRemove := strings.TrimSpace(string(publicKey))
-
-		var filteredLines []string
-
+		filteredLines := make([]string, 0, len(lines))
 		for _, line := range lines {
-			trimmedLine := strings.TrimSpace(line)
-			if trimmedLine == keyToRemove {
+			if entry, isEntry := parseKeyEntry(line); isEntry && entry.isSameEntryAs(target) {
 				removed = true
 				continue
 			}
@@ -429,7 +555,8 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 		}
 
 		// Write filtered content back atomically, refusing to follow symlinks (C-2).
-		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath, filteredLines); err != nil {
+		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath,
+			dropStrandedBrokerComments(filteredLines), account); err != nil {
 			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
 
@@ -446,105 +573,163 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 	return removed, nil
 }
 
-// RemoveExpiredKeys removes broker-issued keys older than 24 hours from a user's
-// authorized_keys.
+// KeyIsAuthorized reports whether this key material still authorizes access to the
+// account, whatever entry or options carry it.
+//
+// (#171) The broker needs this to tell the two reasons a removal matched nothing
+// apart. "The entry is gone because a later login superseded it" is the system
+// working; "the entry is still there under some line this code could not match" is
+// a credential that outlived its session, and only the second is worth an alarm.
+// Without the distinction, one-live-key-per-user would make every revocation of a
+// superseded key look like a failed revocation.
+func (akm *AuthorizedKeysManager) KeyIsAuthorized(username string, publicKey []byte) (bool, error) {
+	account, _, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
+		return false, err
+	}
+	target, ok := parseKeyEntry(string(publicKey))
+	if !ok {
+		return false, fmt.Errorf("public key is not a valid authorized_keys entry")
+	}
+
+	lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range lines {
+		if entry, isEntry := parseKeyEntry(line); isEntry && entry.authorizesSameKeyAs(target) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// RemoveOIDCKeys removes every broker-issued entry from a user's authorized_keys
+// and reports how many it removed.
+//
+// This is what makes a broker restart safe. Sessions live in memory, so a broker
+// that restarts has no record of the keys it issued and nothing left that would
+// ever revoke them; the sweep only helped users who happened to have another
+// session expire afterwards. The broker now calls this at startup for every key it
+// finds in its own store (#171).
+func (akm *AuthorizedKeysManager) RemoveOIDCKeys(username string) (int, error) {
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
+		return 0, err
+	}
+
+	removed := 0
+	err = withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+		lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
+		if err != nil {
+			return err
+		}
+		kept := make([]string, 0, len(lines))
+		for _, line := range lines {
+			if entry, isEntry := parseKeyEntry(line); isEntry && entry.brokerIssued() {
+				removed++
+				continue
+			}
+			kept = append(kept, line)
+		}
+		if removed == 0 {
+			return nil
+		}
+		return writeAuthorizedKeysLines(sshDir, authorizedKeysPath, dropStrandedBrokerComments(kept), account)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return removed, nil
+}
+
+// RemoveExpiredKeys removes broker-issued keys whose expiry has passed from a
+// user's authorized_keys.
 //
 // Called from the broker's session-expiry pass. Its job is the keys no session
 // accounts for: sessions live only in the broker's memory, so a restart orphans
-// every key issued before it, leaving a working credential with nothing left to
-// revoke it.
+// every key issued before it. (Since #171 the broker also reconciles its key store
+// at startup, and every entry it writes carries an expiry sshd enforces by itself,
+// so this is no longer the only thing standing between a restart and a permanent
+// credential.)
 //
-// The 24-hour cutoff is fixed and is not the configured session lifetime. It is
-// read from the `@oidc-pam-<timestamp>` comment the broker writes, so a key whose
-// comment is missing or malformed is retained rather than removed — cleanup fails
-// safe, never early. Authoritative expiry is the broker session; this is
-// best-effort maintenance.
+// The expiry is taken from the entry's own `expiry-time=` option, and for entries
+// written by an older broker from the `@oidc-pam-<timestamp>` comment plus the
+// configured key lifetime (SetKeyLifetime). A key whose expiry cannot be
+// determined either way is retained rather than removed — cleanup fails safe,
+// never early.
+//
+// (#171) The cutoff used to be a hardcoded 24 hours whatever the site had
+// configured, and the timestamp was read out of `strings.Fields(line)[2]`, which is
+// the key data rather than the comment for any entry that carries options — so the
+// sweep would have silently stopped recognising the broker's own keys.
 func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
-	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
+		return err
 	}
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	lockPath := akm.LockPath(username)
 
 	// Check if .ssh directory exists; if not, nothing to clean
-	if _, err := os.Stat(sshDir); os.IsNotExist(err) {
+	if _, statErr := os.Stat(sshDir); os.IsNotExist(statErr) {
 		return nil
 	}
 
-	return withFileLock(lockPath, akm.lockTimeout, func() error {
-		// Read existing authorized_keys file (O_NOFOLLOW: never follow a symlink — C-2).
-		if err := rejectIfSymlink(authorizedKeysPath); err != nil {
+	return withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+		lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
+		if err != nil {
 			return err
 		}
-		// #nosec G304 -- validated username path; symlink-checked above and opened O_NOFOLLOW.
-		file, err := os.OpenFile(authorizedKeysPath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil // File doesn't exist, nothing to clean
+
+		now := time.Now()
+		filteredLines := make([]string, 0, len(lines))
+		removedCount := 0
+		for _, line := range lines {
+			if akm.entryHasExpired(line, now) {
+				removedCount++
+				continue
 			}
-			return fmt.Errorf("failed to open authorized_keys file: %w", err)
-		}
-		defer func() { _ = file.Close() }()
-
-		var filteredLines []string
-		var removedCount int
-		scanner := bufio.NewScanner(file)
-
-		for scanner.Scan() {
-			line := scanner.Text()
-
-			// L-14: expiry is read from the (broker-written) key comment. A
-			// malformed/forged comment simply causes the key to be retained
-			// (fail-safe for cleanup: it is never removed early), and the keys are
-			// broker-generated so the comment is not attacker-controlled in the
-			// supported flow. Authoritative expiry lives in the broker session;
-			// this cleanup is best-effort. See TODO(L-3) in keys.go for moving
-			// expiry to a separate metadata file.
-			if strings.Contains(line, "@oidc-pam-") {
-				// Extract timestamp from comment
-				parts := strings.Fields(line)
-				if len(parts) >= 3 {
-					comment := parts[2]
-					if strings.Contains(comment, "@oidc-pam-") {
-						// Extract timestamp
-						timestampStr := strings.Split(comment, "@oidc-pam-")[1]
-						if timestamp, err := strconv.ParseInt(timestampStr, 10, 64); err == nil {
-							keyTime := time.Unix(timestamp, 0)
-							// Check if key is older than 24 hours (default expiration)
-							if time.Since(keyTime) > 24*time.Hour {
-								removedCount++
-								continue // Skip this line (remove the key)
-							}
-						}
-					}
-				}
-			}
-
 			filteredLines = append(filteredLines, line)
 		}
 
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("failed to scan authorized_keys file: %w", err)
+		if removedCount == 0 {
+			return nil
 		}
 
-		if removedCount > 0 {
-			// Write filtered content back atomically, refusing to follow symlinks (C-2).
-			// The scanner has stripped every line's newline, so the shared writer is
-			// what puts the file's final one back (#165).
-			if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath, filteredLines); err != nil {
-				return fmt.Errorf("failed to write authorized_keys file: %w", err)
-			}
-
-			log.Info().
-				Str("username", username).
-				Int("removed_count", removedCount).
-				Msg("Removed expired OIDC PAM keys from authorized_keys")
+		// Write filtered content back atomically, refusing to follow symlinks (C-2).
+		// Line splitting has stripped every line's newline, so the shared writer is
+		// what puts the file's final one back (#165).
+		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath,
+			dropStrandedBrokerComments(filteredLines), account); err != nil {
+			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
+
+		log.Info().
+			Str("username", username).
+			Int("removed_count", removedCount).
+			Msg("Removed expired OIDC PAM keys from authorized_keys")
 
 		return nil
 	})
+}
+
+// entryHasExpired reports whether a line is a broker-issued entry that is past its
+// expiry. Anything else — a blank line, a comment, a key the user owns, or a broker
+// entry whose expiry cannot be read — is not expired as far as this is concerned.
+func (akm *AuthorizedKeysManager) entryHasExpired(line string, now time.Time) bool {
+	entry, ok := parseKeyEntry(line)
+	if !ok || !entry.brokerIssued() {
+		return false
+	}
+	// The option is what sshd itself honours, so it wins where both are present.
+	if expiry, ok := entry.expiryTime(); ok {
+		return now.After(expiry)
+	}
+	// An entry from a broker that predates expiry-time=: the comment records when it
+	// was issued, and the configured lifetime says how long that was good for.
+	if issued, ok := entry.issuedAt(); ok {
+		return now.After(issued.Add(akm.keyLifetime))
+	}
+	return false
 }
 
 // ListOIDCKeys lists all OIDC PAM keys in a user's authorized_keys file.
@@ -554,31 +739,23 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 // authorized_keys entries this broker is responsible for, distinguished from the
 // user's own keys by the `@oidc-pam-<timestamp>` comment.
 func (akm *AuthorizedKeysManager) ListOIDCKeys(username string) ([]string, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, fmt.Errorf("invalid username: %w", err)
-	}
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-
-	// Read existing authorized_keys file
-	data, err := os.ReadFile(authorizedKeysPath)
+	account, _, authorizedKeysPath, err := akm.userPaths(username)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return []string{}, nil
-		}
-		return nil, fmt.Errorf("failed to read authorized_keys file: %w", err)
+		return nil, err
 	}
 
-	var oidcKeys []string
-	lines := strings.Split(string(data), "\n")
+	lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
+	if err != nil {
+		return nil, err
+	}
 
+	oidcKeys := []string{}
 	for _, line := range lines {
-		trimmedLine := strings.TrimSpace(line)
-		if trimmedLine != "" && !strings.HasPrefix(trimmedLine, "#") {
-			if strings.Contains(trimmedLine, "@oidc-pam-") {
-				oidcKeys = append(oidcKeys, trimmedLine)
-			}
+		// Parsed rather than substring-matched so that an entry carrying options is
+		// still recognised, and so that "@oidc-pam-" appearing anywhere other than
+		// the comment does not make a line the broker's (#171).
+		if entry, ok := parseKeyEntry(line); ok && entry.brokerIssued() {
+			oidcKeys = append(oidcKeys, strings.TrimSpace(line))
 		}
 	}
 
@@ -592,26 +769,24 @@ func (akm *AuthorizedKeysManager) ListOIDCKeys(username string) ([]string, error
 // file the user also owns, so a copy taken before a manual intervention is worth
 // having.
 func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
-	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
+		return err
 	}
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
 	backupPath := filepath.Join(sshDir, "authorized_keys.backup")
 
 	// Check if original file exists
-	if _, err := os.Stat(authorizedKeysPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(authorizedKeysPath); os.IsNotExist(statErr) {
 		return nil // No file to backup
 	}
 
-	// Copy the file (refuse to read through a symlinked authorized_keys — C-2).
-	if err := rejectIfSymlink(authorizedKeysPath); err != nil {
+	lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
+	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(authorizedKeysPath)
-	if err != nil {
-		return fmt.Errorf("failed to read authorized_keys file: %w", err)
+	var data []byte
+	if len(lines) > 0 {
+		data = []byte(strings.Join(lines, "\n") + "\n")
 	}
 
 	// Write the backup without following a planted symlink at the backup path.
@@ -630,6 +805,10 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 	if err := bf.Close(); err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
+	// The backup sits in the user's own .ssh, so it is theirs, not root's (#171).
+	if err := chownToAccount(backupPath, account); err != nil {
+		return err
+	}
 
 	log.Info().
 		Str("username", username).
@@ -647,16 +826,14 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 // broker-issued keys that were present then — run the expiry sweep afterwards if
 // that matters.
 func (akm *AuthorizedKeysManager) RestoreAuthorizedKeys(username string) error {
-	if err := validateUsername(username); err != nil {
-		return fmt.Errorf("invalid username: %w", err)
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
+	if err != nil {
+		return err
 	}
-	userHomeDir := filepath.Join(akm.baseDir, username)
-	sshDir := filepath.Join(userHomeDir, ".ssh")
-	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
 	backupPath := filepath.Join(sshDir, "authorized_keys.backup")
 
 	// Check if backup exists
-	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
 		return fmt.Errorf("no backup file found")
 	}
 
@@ -664,15 +841,15 @@ func (akm *AuthorizedKeysManager) RestoreAuthorizedKeys(username string) error {
 	if err := rejectIfSymlink(backupPath); err != nil {
 		return err
 	}
-	data, err := os.ReadFile(backupPath)
+	data, err := os.ReadFile(backupPath) // #nosec G304 -- resolved home, symlink-checked above
 	if err != nil {
 		return fmt.Errorf("failed to read backup file: %w", err)
 	}
 
-	if err := ensureSecureSSHDir(sshDir); err != nil {
+	if err := ensureSecureSSHDir(sshDir, account); err != nil {
 		return err
 	}
-	if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, data); err != nil {
+	if err := writeAuthorizedKeysAtomic(sshDir, authorizedKeysPath, data, account); err != nil {
 		return fmt.Errorf("failed to restore authorized_keys: %w", err)
 	}
 

--- a/pkg/ssh/authorized_keys_test.go
+++ b/pkg/ssh/authorized_keys_test.go
@@ -10,36 +10,153 @@ import (
 	"time"
 )
 
-// newTestManager builds a manager whose home base is baseDir and whose lock
-// directory is a fresh temp dir.
+// newTestManager builds a manager that resolves homes under baseDir and whose lock
+// directory is a fresh temp dir, and creates the home directories of the named
+// accounts (defaulting to "testuser").
+//
+// The homes are created here because the manager refuses to create one itself
+// (#171): a missing home means the account is not provisioned on this host, and
+// creating it as root locks the user out of it. Tests that are *about* that refusal
+// resolve their own paths instead of using this helper.
 //
 // The lock directory is a separate argument in production too (#161): the locks
 // must not be reachable from the homes they protect. A test that pointed lockDir
 // at baseDir would still pass while reintroducing exactly the bug, so no test
 // shares the two.
-func newTestManager(t *testing.T, baseDir string) *AuthorizedKeysManager {
+func newTestManager(t *testing.T, baseDir string, usernames ...string) *AuthorizedKeysManager {
 	t.Helper()
-	return NewAuthorizedKeysManager(baseDir, t.TempDir())
+	if len(usernames) == 0 {
+		usernames = []string{"testuser"}
+	}
+	for _, username := range usernames {
+		if err := os.MkdirAll(filepath.Join(baseDir, username), 0700); err != nil {
+			t.Fatalf("MkdirAll home for %s: %v", username, err)
+		}
+	}
+	akm := NewAuthorizedKeysManager(t.TempDir())
+	akm.SetAccountLookup(HomeRootLookup(baseDir))
+	return akm
 }
 
+// testExpiry is the expiry every test that does not care about expiry passes to
+// AddPublicKey. It is far enough out that no sweep in these tests treats it as
+// stale, and AddPublicKey refuses a zero or past value outright (#171).
+func testExpiry() time.Time { return time.Now().Add(time.Hour) }
+
 func TestNewAuthorizedKeysManager(t *testing.T) {
-	baseDir := "/tmp/test-auth-keys"
 	lockDir := "/tmp/test-auth-locks"
-	akm := NewAuthorizedKeysManager(baseDir, lockDir)
+	akm := NewAuthorizedKeysManager(lockDir)
 
 	if akm == nil {
 		t.Fatal("Expected non-nil AuthorizedKeysManager")
 	}
-	if akm.baseDir != baseDir {
-		t.Errorf("Expected baseDir %s, got %s", baseDir, akm.baseDir)
-	}
 	if akm.lockDir != lockDir {
 		t.Errorf("Expected lockDir %s, got %s", lockDir, akm.lockDir)
 	}
+	// Homes come from the account database, never from a base directory the broker
+	// guessed (#171).
+	if akm.lookupAccount == nil {
+		t.Error("a manager built for production has no account lookup, so it cannot resolve a home")
+	}
 	// The lock must not live under the home directory it protects: a user who can
 	// write there can take the lock and wedge the broker (#161).
-	if got := akm.LockPath("alice"); strings.HasPrefix(got, filepath.Join(baseDir, "alice")) {
-		t.Errorf("lock path %s is inside the user's own home", got)
+	if got := akm.LockPath("alice"); !strings.HasPrefix(got, lockDir) {
+		t.Errorf("lock path %s is not in the lock directory %s", got, lockDir)
+	}
+}
+
+// The manager must not invent a home directory. Before #171 it joined "/home" with
+// the login name, so on a host whose homes are anywhere else the broker wrote a key
+// list sshd never reads — and reported success, letting a login through that could
+// not work.
+func TestPathsComeFromTheAccountDatabaseNotABaseDirectory(t *testing.T) {
+	realHomes := t.TempDir()
+	home := filepath.Join(realHomes, "ldap-domain", "alice")
+	if err := os.MkdirAll(home, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	akm := NewAuthorizedKeysManager(t.TempDir())
+	akm.SetAccountLookup(func(username string) (Account, error) {
+		if username != "alice" {
+			return Account{}, ErrUnknownAccount
+		}
+		return Account{Username: "alice", Home: home, UID: os.Geteuid(), GID: os.Getegid()}, nil
+	})
+
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDAP alice@oidc-pam-1700000000")
+	if err := akm.AddPublicKey("alice", key, testExpiry()); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".ssh", "authorized_keys"))
+	if err != nil {
+		t.Fatalf("the key was not written to the home the account database gave (%s): %v", home, err)
+	}
+	if !strings.Contains(string(data), "AAAAC3NzaC1lZDI1NTE5AAAAILDAP") {
+		t.Errorf("authorized_keys at the real home does not contain the key; content is %q", data)
+	}
+	// Nothing may have been created at the path the old code would have used.
+	if _, err := os.Stat(filepath.Join(realHomes, "alice")); err == nil {
+		t.Errorf("a directory was created at %s, which is not this account's home",
+			filepath.Join(realHomes, "alice"))
+	}
+}
+
+// A missing home means the account is not provisioned on this host. The broker must
+// say so, not create it: MkdirAll(<home>/.ssh) used to create the home as root with
+// mode 0700, locking the user out of their own home directory for a login that
+// could not work anyway (#171).
+func TestAddPublicKeyRefusesAMissingHomeAndDoesNotCreateIt(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := NewAuthorizedKeysManager(t.TempDir())
+	akm.SetAccountLookup(HomeRootLookup(baseDir))
+
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAANOHOME nohome@oidc-pam-1700000000")
+	err := akm.AddPublicKey("nohome", key, testExpiry())
+	if err == nil {
+		t.Fatal("AddPublicKey reported success for an account with no home directory")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error does not say the home is missing: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(baseDir, "nohome")); statErr == nil {
+		t.Errorf("the home directory %s was created; the broker must not create homes",
+			filepath.Join(baseDir, "nohome"))
+	}
+}
+
+// A home, .ssh or authorized_keys owned by some third account is not the target
+// user's, and writing a key into it neither authorizes them nor is safe: whoever
+// owns it can rewrite it. checkOwner is exercised directly because a test cannot
+// create a file owned by another uid without root.
+func TestForeignOwnershipIsRefused(t *testing.T) {
+	account := Account{Username: "alice", Home: "/home/alice", UID: 1000, GID: 1000}
+	dir := t.TempDir()
+	info, err := os.Lstat(dir)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+
+	if err := checkOwner("home directory", dir, info, Account{Username: "alice", UID: os.Geteuid()}); err != nil {
+		t.Errorf("a path owned by the account itself was refused: %v", err)
+	}
+	// Root-owned is accepted, because sshd's StrictModes accepts it: every component
+	// of the path to authorized_keys must belong to the user or to root.
+	rootInfo, err := os.Lstat("/")
+	if err != nil {
+		t.Fatalf(`Lstat("/"): %v`, err)
+	}
+	if uid, ok := statUID(rootInfo); !ok || uid != 0 {
+		t.Skip(`"/" is not owned by uid 0 on this host`)
+	}
+	if err := checkOwner("home directory", "/", rootInfo, account); err != nil {
+		t.Errorf("a root-owned path was refused: %v", err)
+	}
+	if os.Geteuid() != account.UID && os.Geteuid() != 0 {
+		if err := checkOwner("home directory", dir, info, account); err == nil {
+			t.Error("a path owned by a third account was accepted")
+		}
 	}
 }
 
@@ -56,7 +173,7 @@ func TestAddPublicKey(t *testing.T) {
 	publicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... testuser@example.com")
 
 	// Test adding a public key
-	err = akm.AddPublicKey(username, publicKey)
+	err = akm.AddPublicKey(username, publicKey, testExpiry())
 	if err != nil {
 		t.Errorf("Failed to add public key: %v", err)
 	}
@@ -77,7 +194,7 @@ func TestAddPublicKey(t *testing.T) {
 	}
 
 	// Test adding the same key again (should not duplicate)
-	err = akm.AddPublicKey(username, publicKey)
+	err = akm.AddPublicKey(username, publicKey, testExpiry())
 	if err != nil {
 		t.Errorf("Failed to add duplicate public key: %v", err)
 	}
@@ -121,7 +238,7 @@ func TestAddPublicKeyWithExistingFile(t *testing.T) {
 
 	// Add a new key
 	newKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... newkey@example.com")
-	err = akm.AddPublicKey(username, newKey)
+	err = akm.AddPublicKey(username, newKey, testExpiry())
 	if err != nil {
 		t.Errorf("Failed to add public key to existing file: %v", err)
 	}
@@ -154,7 +271,7 @@ func TestRemovePublicKey(t *testing.T) {
 	publicKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... testuser@example.com")
 
 	// Add a public key first
-	err = akm.AddPublicKey(username, publicKey)
+	err = akm.AddPublicKey(username, publicKey, testExpiry())
 	if err != nil {
 		t.Errorf("Failed to add public key: %v", err)
 	}
@@ -217,7 +334,7 @@ func TestRemovePublicKeyNotFound(t *testing.T) {
 	nonExistentKey := []byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... nonexistent@example.com")
 
 	// Add a public key
-	err = akm.AddPublicKey(username, existingKey)
+	err = akm.AddPublicKey(username, existingKey, testExpiry())
 	if err != nil {
 		t.Errorf("Failed to add public key: %v", err)
 	}
@@ -452,7 +569,7 @@ func TestRestoreAuthorizedKeysNoBackup(t *testing.T) {
 }
 
 func TestValidateKeyFormat(t *testing.T) {
-	akm := newTestManager(t, "/tmp")
+	akm := newTestManager(t, t.TempDir())
 
 	// Test valid keys
 	validKeys := [][]byte{
@@ -572,7 +689,7 @@ func TestAddPublicKeyConcurrent(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			if err := akm.AddPublicKey(username, key); err != nil {
+			if err := akm.AddPublicKey(username, key, testExpiry()); err != nil {
 				t.Errorf("AddPublicKey failed: %v", err)
 			}
 		}()
@@ -586,10 +703,15 @@ func TestAddPublicKeyConcurrent(t *testing.T) {
 		t.Fatalf("Failed to read authorized_keys: %v", err)
 	}
 
-	keyLine := strings.TrimSpace(string(key))
+	// Counted by entry rather than by exact line: the installed entry carries an
+	// expiry-time= option in front of the key (#171).
+	target, ok := parseKeyEntry(string(key))
+	if !ok {
+		t.Fatalf("test key is not a valid entry: %q", key)
+	}
 	count := 0
 	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == keyLine {
+		if entry, isEntry := parseKeyEntry(line); isEntry && entry.authorizesSameKeyAs(target) {
 			count++
 		}
 	}

--- a/pkg/ssh/docs_test.go
+++ b/pkg/ssh/docs_test.go
@@ -1,0 +1,120 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The entry this package installs carries an `expiry-time=` option, which is how
+// sshd — rather than a broker that may not be running — stops honouring a stale key
+// (#171). That option is not universally available: it arrived in OpenSSH
+// minOpenSSHVersion, and an sshd that does not recognise an authorized_keys option
+// refuses the entry carrying it. On an older host, therefore, every key this
+// package writes is rejected, the file looks correct, and the account is
+// authenticated and then told `Permission denied (publickey)`.
+//
+// That is a deployment requirement, and a requirement stated only in a Go comment
+// is one an operator learns from a login that does not work. These tests read the
+// operator-facing documents and hold them to the same version the code uses, so the
+// two cannot drift apart.
+
+// docsThatStateTheRequirement are the documents an operator reads before installing:
+// the deployment guide's prerequisites, and the platform table in the README that
+// says what is expected to work.
+var docsThatStateTheRequirement = []string{
+	filepath.Join("..", "..", "DEPLOYMENT.md"),
+	filepath.Join("..", "..", "README.md"),
+}
+
+func TestTheDocsStateTheMinimumOpenSSHVersion(t *testing.T) {
+	for _, doc := range docsThatStateTheRequirement {
+		content := readDoc(t, doc)
+
+		// The requirement phrasing, not merely the number: a document that mentions
+		// 7.7 somewhere in passing has not told anyone it is a minimum.
+		want := fmt.Sprintf("OpenSSH %s or newer", minOpenSSHVersion)
+		if !strings.Contains(content, want) {
+			t.Errorf("%s never says %q, so nothing tells an operator that a host with an "+
+				"older sshd rejects every key the broker installs", filepath.Base(doc), want)
+		}
+
+		// The version alone is a number with no reason attached; an operator deciding
+		// whether it applies to them needs to know it is the key option that requires
+		// it, not the module or the broker.
+		if !strings.Contains(content, expiryTimeOption) {
+			t.Errorf("%s states no reason for the OpenSSH requirement: it does not mention "+
+				"the %s= option the requirement comes from", filepath.Base(doc), expiryTimeOption)
+		}
+	}
+}
+
+// The requirement excludes platforms this project used to list as supported, and a
+// platform table that says "expected to work" about a host where no key can be
+// installed is worse than one that says nothing. Amazon Linux 2 and RHEL/CentOS 7
+// both ship OpenSSH 7.4p1.
+func TestTheDocsNameThePlatformsThatAreTooOld(t *testing.T) {
+	const tooOld = "7.4p1"
+
+	for _, doc := range docsThatStateTheRequirement {
+		content := readDoc(t, doc)
+		if !strings.Contains(content, tooOld) {
+			t.Errorf("%s does not name %s, the version Amazon Linux 2 and RHEL/CentOS 7 ship, "+
+				"so a reader cannot tell those platforms are excluded", filepath.Base(doc), tooOld)
+		}
+		if !strings.Contains(content, "Amazon Linux 2") {
+			t.Errorf("%s does not mention Amazon Linux 2, which cannot run this", filepath.Base(doc))
+		}
+	}
+}
+
+// A timespec suffixed with Z to mean UTC is OpenSSH 9.1 and newer. Every sshd before
+// that parses a timespec by its length and rejects the 15-character form, refusing
+// the entry with it — so writing UTC would restrict this to Debian 12-era hosts
+// while satisfying every other test in this package, including the e2e suite, which
+// runs on Debian 12. Hence a test about the shape of what is written.
+func TestTheExpiryTimespecIsTheFormEverySupportedSSHDParses(t *testing.T) {
+	// A fixed instant, so a host in any time zone gets a deterministic length and
+	// a value that must equal the same instant rendered locally.
+	expiresAt := time.Date(2031, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	timespec := formatExpiryTimespec(expiresAt)
+
+	if strings.ContainsAny(timespec, "Zz") {
+		t.Errorf("the expiry is written as %q: the Z suffix means UTC only from OpenSSH 9.1, "+
+			"and every sshd before that rejects the entry carrying it", timespec)
+	}
+	if !regexp.MustCompile(`^\d{14}$`).MatchString(timespec) {
+		t.Errorf("the expiry is written as %q, not the 14-digit YYYYMMDDHHMMSS sshd(8) "+
+			"documents", timespec)
+	}
+	if got, want := timespec, expiresAt.Local().Format("20060102150405"); got != want {
+		t.Errorf("the expiry is written as %q, want %q: sshd reads an unsuffixed timespec in "+
+			"the host's own time zone, so writing UTC digits would move the expiry by the "+
+			"host's offset", got, want)
+	}
+
+	// And what is written must be read back as the same instant, or the sweep and
+	// sshd disagree about when the key stopped working.
+	parsed, ok := parseExpiryTimespec(timespec)
+	if !ok {
+		t.Fatalf("the expiry this package writes, %q, cannot be read back", timespec)
+	}
+	if !parsed.Equal(expiresAt) {
+		t.Errorf("%q reads back as %s, want %s", timespec, parsed, expiresAt)
+	}
+}
+
+func readDoc(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}

--- a/pkg/ssh/entry.go
+++ b/pkg/ssh/entry.go
@@ -1,0 +1,290 @@
+package ssh
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// This file understands one authorized_keys line.
+//
+// (#171) Every function here exists because the entries the broker installs now
+// carry a per-key option — `expiry-time="..."`, so that sshd itself stops
+// honouring a key once it is stale rather than trusting the broker to still be
+// alive and still remember the session. An options prefix breaks every way this
+// package used to read a line: removal compared whole lines and would no longer
+// match the key it had just written, and the expiry sweep read the comment out of
+// `strings.Fields(line)[2]`, which is the key data once anything precedes the key
+// type. Both of those failures are silent and both leave a working credential
+// behind, so the parsing is in one place with its own tests.
+
+// oidcMarker is what makes an entry the broker's. KeyManager.GenerateKey stamps
+// every key it issues with a "<username>@oidc-pam-<unix>" comment, and that
+// marker is the only thing distinguishing a key the broker is responsible for
+// from a key the user put there themselves and which is none of the broker's
+// business.
+const oidcMarker = "@oidc-pam-"
+
+// brokerCommentPrefix is the provenance comment the broker writes above the entry
+// it installs. It is recognised so that the next write can drop the previous one
+// instead of leaving a comment line per login behind.
+const brokerCommentPrefix = "# Added by OIDC PAM on"
+
+// expiryTimeOption is sshd's per-key expiry option (OpenSSH 8.2+, sshd(8)
+// AUTHORIZED_KEYS FILE FORMAT). sshd refuses the key after the time given.
+const expiryTimeOption = "expiry-time"
+
+// keyEntry is one authorized_keys entry split into the parts that matter:
+//
+//	[options] <keyType> <blob> [comment]
+type keyEntry struct {
+	options string
+	keyType string
+	blob    string
+	comment string
+}
+
+// parseKeyEntry splits an authorized_keys line. It reports false for a line that
+// is blank, a comment, or otherwise not an entry — such a line is never matched,
+// never expired and never rewritten, only carried through untouched.
+//
+// It deliberately does not verify the key: the caller is deciding which lines to
+// keep, and a line whose base64 this package cannot decode still authorizes
+// whoever holds the private half as far as sshd is concerned.
+func parseKeyEntry(line string) (keyEntry, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return keyEntry{}, false
+	}
+
+	fields := splitOutsideQuotes(trimmed)
+	entry := keyEntry{}
+	if len(fields) > 0 && !looksLikeKeyType(fields[0]) {
+		entry.options = fields[0]
+		fields = fields[1:]
+	}
+	if len(fields) < 2 {
+		return keyEntry{}, false
+	}
+	entry.keyType = fields[0]
+	entry.blob = fields[1]
+	if len(fields) > 2 {
+		entry.comment = strings.Join(fields[2:], " ")
+	}
+	return entry, true
+}
+
+// splitOutsideQuotes splits on whitespace that is not inside a double-quoted
+// string. Option values are quoted and may contain spaces (sshd(8): "no spaces
+// are permitted, except within double quotes"), so a naive Fields() would tear
+// `from="10.0.0.1, 10.0.0.2"` into pieces and mistake the second half for the key
+// type.
+func splitOutsideQuotes(s string) []string {
+	var fields []string
+	var current strings.Builder
+	inQuotes := false
+	escaped := false
+
+	flush := func() {
+		if current.Len() > 0 {
+			fields = append(fields, current.String())
+			current.Reset()
+		}
+	}
+
+	for _, r := range s {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\' && inQuotes:
+			current.WriteRune(r)
+			escaped = true
+		case r == '"':
+			inQuotes = !inQuotes
+			current.WriteRune(r)
+		case (r == ' ' || r == '\t') && !inQuotes:
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	flush()
+	return fields
+}
+
+// looksLikeKeyType reports whether a field is an SSH public key algorithm name
+// rather than an options list. Every algorithm name OpenSSH accepts in
+// authorized_keys begins with one of these prefixes; an options list begins with
+// an option name, none of which do.
+func looksLikeKeyType(field string) bool {
+	for _, prefix := range []string{"ssh-", "ecdsa-", "sk-ecdsa-", "sk-ssh-", "rsa-sha2-", "webauthn-"} {
+		if strings.HasPrefix(field, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// authorizesSameKeyAs reports whether two entries authorize the same key
+// material, whatever options or comment they carry.
+//
+// This is "is this credential usable?", which is the question a revocation has to
+// answer honestly. It is deliberately weaker than sameEntry.
+func (e keyEntry) authorizesSameKeyAs(other keyEntry) bool {
+	return e.keyType == other.keyType && e.blob == other.blob
+}
+
+// isSameEntryAs reports whether two entries are the same authorized_keys entry:
+// same key, same comment, options ignored.
+//
+// Removal matches on this rather than on the whole line because the broker holds
+// the bare key in its store and writes the entry with an `expiry-time=` option in
+// front of it — comparing whole lines would never match again. It is deliberately
+// stronger than authorizesSameKeyAs: a line that carries the same key with a
+// different comment is not the entry the broker wrote, and quietly rewriting it
+// would be the broker editing something that is not its own.
+func (e keyEntry) isSameEntryAs(other keyEntry) bool {
+	return e.authorizesSameKeyAs(other) && e.comment == other.comment
+}
+
+// brokerIssued reports whether this entry is one the broker installed.
+func (e keyEntry) brokerIssued() bool {
+	return strings.Contains(e.comment, oidcMarker)
+}
+
+// issuedAt reads the issue time out of the "<username>@oidc-pam-<unix>" comment.
+// A comment in any other shape yields false, and every caller treats that as "do
+// not touch this entry" — cleanup fails safe, never early.
+func (e keyEntry) issuedAt() (time.Time, bool) {
+	fields := strings.Fields(e.comment)
+	if len(fields) == 0 {
+		return time.Time{}, false
+	}
+	_, stamp, found := strings.Cut(fields[0], oidcMarker)
+	if !found {
+		return time.Time{}, false
+	}
+	unix, err := strconv.ParseInt(stamp, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(unix, 0), true
+}
+
+// expiryTime reads the entry's expiry-time= option, which is the expiry sshd
+// itself enforces. Absent or unparseable yields false, and the caller falls back
+// to the issue time in the comment.
+func (e keyEntry) expiryTime() (time.Time, bool) {
+	if e.options == "" {
+		return time.Time{}, false
+	}
+	for _, option := range splitOptions(e.options) {
+		name, value, found := strings.Cut(option, "=")
+		if !found || !strings.EqualFold(strings.TrimSpace(name), expiryTimeOption) {
+			continue
+		}
+		if parsed, ok := parseExpiryTimespec(strings.Trim(strings.TrimSpace(value), `"`)); ok {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// splitOptions splits an options list on the commas that separate options,
+// ignoring commas inside a quoted value.
+func splitOptions(options string) []string {
+	var out []string
+	var current strings.Builder
+	inQuotes := false
+	escaped := false
+	for _, r := range options {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\' && inQuotes:
+			escaped = true
+			current.WriteRune(r)
+		case r == '"':
+			inQuotes = !inQuotes
+			current.WriteRune(r)
+		case r == ',' && !inQuotes:
+			out = append(out, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	out = append(out, current.String())
+	return out
+}
+
+// expiryTimespecLayout is the format the broker writes: sshd's YYYYMMDDHHMMSS
+// with the Z suffix that makes it UTC, so the entry means the same thing whatever
+// time zone the host is set to.
+const expiryTimespecLayout = "20060102150405Z"
+
+// parseExpiryTimespec reads any of the forms sshd(8) documents for a timespec:
+// YYYYMMDD or YYYYMMDDHHMM[SS], each optionally suffixed with Z for UTC and
+// otherwise in the host's own time zone.
+func parseExpiryTimespec(value string) (time.Time, bool) {
+	loc := time.Local
+	if strings.HasSuffix(value, "Z") || strings.HasSuffix(value, "z") {
+		value = value[:len(value)-1]
+		loc = time.UTC
+	}
+	for _, layout := range []string{"20060102150405", "200601021504", "20060102"} {
+		if parsed, err := time.ParseInLocation(layout, value, loc); err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// formatExpiryTimespec renders an expiry for sshd's expiry-time= option.
+func formatExpiryTimespec(t time.Time) string {
+	return t.UTC().Format(expiryTimespecLayout)
+}
+
+// brokerEntryLine renders the authorized_keys line the broker installs: the key
+// as generated, preceded by the expiry sshd will enforce on it.
+//
+// The expiry is on the line, and not only in the broker's memory and in the key
+// comment, because everything else that was supposed to remove a stale key
+// depended on this broker still running: sessions live in memory, so a restart
+// orphaned every key it had ever issued, and the sweep that was meant to catch
+// those only ran for users who happened to have a session expire afterwards
+// (#171). sshd reads this option on every authentication, whether the broker is
+// running or not.
+func brokerEntryLine(publicKey []byte, expiresAt time.Time) string {
+	return fmt.Sprintf("%s=%q %s", expiryTimeOption, formatExpiryTimespec(expiresAt),
+		strings.TrimSpace(string(publicKey)))
+}
+
+// isBrokerComment reports whether a line is the provenance comment the broker
+// writes above its entry.
+func isBrokerComment(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), brokerCommentPrefix)
+}
+
+// dropStrandedBrokerComments removes the broker's provenance comments from a set
+// of lines that no longer contains any broker-issued entry. A comment claiming
+// the broker added a key, sitting above the user's own keys because the key it
+// described has been revoked, misleads whoever reads the file next.
+func dropStrandedBrokerComments(lines []string) []string {
+	for _, line := range lines {
+		if entry, ok := parseKeyEntry(line); ok && entry.brokerIssued() {
+			return lines
+		}
+	}
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if isBrokerComment(line) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return kept
+}

--- a/pkg/ssh/entry.go
+++ b/pkg/ssh/entry.go
@@ -31,9 +31,23 @@ const oidcMarker = "@oidc-pam-"
 // instead of leaving a comment line per login behind.
 const brokerCommentPrefix = "# Added by OIDC PAM on"
 
-// expiryTimeOption is sshd's per-key expiry option (OpenSSH 8.2+, sshd(8)
-// AUTHORIZED_KEYS FILE FORMAT). sshd refuses the key after the time given.
+// expiryTimeOption is sshd's per-key expiry option (sshd(8), AUTHORIZED_KEYS FILE
+// FORMAT). sshd refuses the key after the time given.
+//
+// It needs OpenSSH minOpenSSHVersion or newer. An sshd that does not recognise an
+// option refuses the entry carrying it, so on anything older every key the broker
+// installs is rejected and the account is authenticated and then cannot log in —
+// the failure #171 is about, reached by a different route.
 const expiryTimeOption = "expiry-time"
+
+// minOpenSSHVersion is the oldest sshd that understands what this package writes.
+// OpenSSH 7.7 added expiry-time= for authorized_keys, and the timespec written
+// below is deliberately the form 7.7 accepts.
+//
+// It is a constant here so pkg/ssh/docs_test.go can hold DEPLOYMENT.md and
+// README.md to the same number: a version requirement only this file knows about
+// is one an operator discovers from a login that does not work.
+const minOpenSSHVersion = "7.7"
 
 // keyEntry is one authorized_keys entry split into the parts that matter:
 //
@@ -221,14 +235,27 @@ func splitOptions(options string) []string {
 	return out
 }
 
-// expiryTimespecLayout is the format the broker writes: sshd's YYYYMMDDHHMMSS
-// with the Z suffix that makes it UTC, so the entry means the same thing whatever
-// time zone the host is set to.
-const expiryTimespecLayout = "20060102150405Z"
+// expiryTimespecLayout is the format the broker writes: sshd's YYYYMMDDHHMMSS, in
+// the host's own time zone, which is how sshd reads a timespec with no suffix.
+//
+// Not the UTC form. Suffixing the timespec with Z to mean UTC was added in OpenSSH
+// 9.1; every sshd before that parses a timespec by its length (8, 12 or 14 digits)
+// and rejects the 15-character Z form outright, taking the whole entry with it. So
+// writing UTC would have limited this to Debian 12/Ubuntu 24.04-era hosts and
+// broken RHEL 8 and 9, Debian 11 and Ubuntu 20.04 and 22.04 — and broken them in
+// the way that is hardest to see, since the file looks correct and only sshd
+// disagrees. The two processes share a host and therefore a time zone, so the
+// local form is unambiguous in practice.
+const expiryTimespecLayout = "20060102150405"
 
 // parseExpiryTimespec reads any of the forms sshd(8) documents for a timespec:
 // YYYYMMDD or YYYYMMDDHHMM[SS], each optionally suffixed with Z for UTC and
 // otherwise in the host's own time zone.
+//
+// It reads more forms than formatExpiryTimespec writes on purpose. The sweep must
+// agree with sshd about when an entry stops working, and an entry it did not write
+// — an operator's own expiring key, or the Z form an sshd 9.1+ host accepts — is
+// still one whose expiry it should honour rather than guess at.
 func parseExpiryTimespec(value string) (time.Time, bool) {
 	loc := time.Local
 	if strings.HasSuffix(value, "Z") || strings.HasSuffix(value, "z") {
@@ -243,9 +270,10 @@ func parseExpiryTimespec(value string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// formatExpiryTimespec renders an expiry for sshd's expiry-time= option.
+// formatExpiryTimespec renders an expiry for sshd's expiry-time= option, in the
+// host's local time because that is what sshd reads an unsuffixed timespec as.
 func formatExpiryTimespec(t time.Time) string {
-	return t.UTC().Format(expiryTimespecLayout)
+	return t.Local().Format(expiryTimespecLayout)
 }
 
 // brokerEntryLine renders the authorized_keys line the broker installs: the key

--- a/pkg/ssh/lock_test.go
+++ b/pkg/ssh/lock_test.go
@@ -79,7 +79,7 @@ func runWithin(t *testing.T, limit time.Duration, fn func() error) error {
 // wait forever on a lock someone else holds.
 func TestRemoveExpiredKeysGivesUpWhenTheLockIsHeld(t *testing.T) {
 	base := t.TempDir()
-	akm := NewAuthorizedKeysManager(base, t.TempDir())
+	akm := newTestManager(t, base, "alice")
 	akm.SetLockTimeout(150 * time.Millisecond)
 
 	path := seedStaleKey(t, base, "alice")
@@ -106,13 +106,13 @@ func TestRemoveExpiredKeysGivesUpWhenTheLockIsHeld(t *testing.T) {
 // LoginGraceTime would kill the connection with no explanation logged.
 func TestAddPublicKeyGivesUpWhenTheLockIsHeld(t *testing.T) {
 	base := t.TempDir()
-	akm := NewAuthorizedKeysManager(base, t.TempDir())
+	akm := newTestManager(t, base, "alice")
 	akm.SetLockTimeout(150 * time.Millisecond)
 
 	holdLock(t, akm, "alice")
 
 	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ alice@oidc-pam")
-	err := runWithin(t, 5*time.Second, func() error { return akm.AddPublicKey("alice", key) })
+	err := runWithin(t, 5*time.Second, func() error { return akm.AddPublicKey("alice", key, testExpiry()) })
 	if !errors.Is(err, ErrLockUnavailable) {
 		t.Fatalf("expected ErrLockUnavailable, got %v", err)
 	}
@@ -123,7 +123,7 @@ func TestAddPublicKeyGivesUpWhenTheLockIsHeld(t *testing.T) {
 // for the whole host.
 func TestOneUsersLockDoesNotBlockAnother(t *testing.T) {
 	base := t.TempDir()
-	akm := NewAuthorizedKeysManager(base, t.TempDir())
+	akm := newTestManager(t, base, "alice", "bob")
 	akm.SetLockTimeout(150 * time.Millisecond)
 
 	bobPath := seedStaleKey(t, base, "bob")
@@ -148,10 +148,14 @@ func TestOneUsersLockDoesNotBlockAnother(t *testing.T) {
 func TestTheLockIsNotInTheUsersHome(t *testing.T) {
 	base := t.TempDir()
 	lockDir := t.TempDir()
-	akm := NewAuthorizedKeysManager(base, lockDir)
+	if err := os.MkdirAll(filepath.Join(base, "alice"), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	akm := NewAuthorizedKeysManager(lockDir)
+	akm.SetAccountLookup(HomeRootLookup(base))
 
 	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ alice@oidc-pam")
-	if err := akm.AddPublicKey("alice", key); err != nil {
+	if err := akm.AddPublicKey("alice", key, testExpiry()); err != nil {
 		t.Fatalf("AddPublicKey: %v", err)
 	}
 

--- a/pkg/ssh/security_hardening_test.go
+++ b/pkg/ssh/security_hardening_test.go
@@ -31,7 +31,7 @@ func TestAddPublicKeyRejectsSymlinkedAuthorizedKeys(t *testing.T) {
 	}
 
 	akm := newTestManager(t, base)
-	err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key"))
+	err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key"), testExpiry())
 	if err == nil {
 		t.Fatal("expected AddPublicKey to reject symlinked authorized_keys, got nil error")
 	}
@@ -64,7 +64,7 @@ func TestAddPublicKeyRejectsSymlinkedSSHDir(t *testing.T) {
 	}
 
 	akm := newTestManager(t, base)
-	if err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key")); err == nil {
+	if err := akm.AddPublicKey(username, []byte("ssh-ed25519 AAAAC3Nz key"), testExpiry()); err == nil {
 		t.Fatal("expected AddPublicKey to reject symlinked .ssh dir, got nil error")
 	}
 }
@@ -76,7 +76,7 @@ func TestAddPublicKeyRejectsEmbeddedNewline(t *testing.T) {
 	base := t.TempDir()
 	akm := newTestManager(t, base)
 	injected := []byte("ssh-ed25519 AAAAreal key\ncommand=\"evil\" ssh-ed25519 AAAAevil key2")
-	if err := akm.AddPublicKey("testuser", injected); err == nil {
+	if err := akm.AddPublicKey("testuser", injected, testExpiry()); err == nil {
 		t.Fatal("expected AddPublicKey to reject embedded newline, got nil error")
 	}
 }

--- a/pkg/ssh/trailing_newline_test.go
+++ b/pkg/ssh/trailing_newline_test.go
@@ -243,9 +243,13 @@ func TestInstalledEntryCarriesTheExpirySSHDEnforces(t *testing.T) {
 		t.Fatalf("AddPublicKey: %v", err)
 	}
 
+	// The timespec is the host-local form, which is what every sshd that knows the
+	// option accepts; TestTheExpiryTimespecIsTheFormEverySupportedSSHDParses covers
+	// why it is not the UTC one.
 	content := readKeys(t, baseDir, "testuser")
-	if !strings.Contains(content, `expiry-time="20310304050607Z"`) {
-		t.Errorf(`authorized_keys does not carry expiry-time="20310304050607Z"; file is %q`, content)
+	want := fmt.Sprintf(`expiry-time=%q`, expiresAt.Local().Format("20060102150405"))
+	if !strings.Contains(content, want) {
+		t.Errorf("authorized_keys does not carry %s; file is %q", want, content)
 	}
 
 	// And the option must be read back as the expiry it states, or the sweep cannot

--- a/pkg/ssh/trailing_newline_test.go
+++ b/pkg/ssh/trailing_newline_test.go
@@ -17,6 +17,25 @@ func brokerKeyLine(issuedAt time.Time, distinguisher string) []byte {
 		distinguisher, issuedAt.Unix()))
 }
 
+// plantLines writes authorized_keys directly, so a test can set up a state a
+// previous broker left behind.
+//
+// AddPublicKey cannot be used for this any more: it installs one live
+// broker-issued key per user and drops the rest (#171), which is the point of that
+// change and makes it useless for building a file that holds several at once.
+func plantLines(t *testing.T, baseDir, username string, lines ...string) {
+	t.Helper()
+
+	sshDir := filepath.Join(baseDir, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll %s: %v", sshDir, err)
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(sshDir, "authorized_keys"), []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
 // readKeys returns a user's authorized_keys contents verbatim — trailing newline
 // included, which is the whole subject of these tests.
 func readKeys(t *testing.T, baseDir, username string) string {
@@ -50,14 +69,9 @@ func TestExpirySweepLeavesATrailingNewline(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
 
-	for _, key := range [][]byte{
-		brokerKeyLine(time.Now().Add(-48*time.Hour), "STALE"),
-		brokerKeyLine(time.Now().Add(-time.Hour), "FRESH"),
-	} {
-		if err := akm.AddPublicKey("testuser", key); err != nil {
-			t.Fatalf("AddPublicKey: %v", err)
-		}
-	}
+	plantLines(t, baseDir, "testuser",
+		string(brokerKeyLine(time.Now().Add(-48*time.Hour), "STALE")),
+		string(brokerKeyLine(time.Now().Add(-time.Hour), "FRESH")))
 
 	if err := akm.RemoveExpiredKeys("testuser"); err != nil {
 		t.Fatalf("RemoveExpiredKeys: %v", err)
@@ -83,13 +97,12 @@ func TestTargetedRemovalLeavesATrailingNewline(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
 
+	// The survivor is the user's own key: since #171 a user has at most one
+	// broker-issued key, so what must be preserved around a targeted removal is the
+	// key the broker did not install.
 	doomed := brokerKeyLine(time.Now(), "DOOMED")
-	keeper := brokerKeyLine(time.Now(), "KEEPER")
-	for _, key := range [][]byte{doomed, keeper} {
-		if err := akm.AddPublicKey("testuser", key); err != nil {
-			t.Fatalf("AddPublicKey: %v", err)
-		}
-	}
+	keeper := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5KEEPER personal-laptop"
+	plantLines(t, baseDir, "testuser", string(doomed), keeper)
 
 	removed, err := akm.RemovePublicKey("testuser", doomed)
 	if err != nil {
@@ -114,21 +127,20 @@ func TestAddSweepAddRevokeRoundTrip(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
 
+	// The survivor is the user's own key. Since #171 the broker keeps at most one of
+	// its own per user, so the file the sweep leaves behind for the next login to
+	// write into is one holding a key that is not the broker's.
 	stale := brokerKeyLine(time.Now().Add(-48*time.Hour), "STALE")
-	surviving := brokerKeyLine(time.Now().Add(-time.Hour), "SURVIVING")
-	for _, key := range [][]byte{stale, surviving} {
-		if err := akm.AddPublicKey("testuser", key); err != nil {
-			t.Fatalf("AddPublicKey: %v", err)
-		}
-	}
+	surviving := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5SURVIVING personal-laptop"
+	plantLines(t, baseDir, "testuser", string(stale), surviving)
 
 	if err := akm.RemoveExpiredKeys("testuser"); err != nil {
 		t.Fatalf("RemoveExpiredKeys: %v", err)
 	}
 
-	// The next login, appending to whatever the sweep left behind.
+	// The next login, writing over whatever the sweep left behind.
 	nextLogin := brokerKeyLine(time.Now(), "NEXTLOGIN")
-	if err := akm.AddPublicKey("testuser", nextLogin); err != nil {
+	if err := akm.AddPublicKey("testuser", nextLogin, testExpiry()); err != nil {
 		t.Fatalf("AddPublicKey after the sweep: %v", err)
 	}
 
@@ -146,18 +158,262 @@ func TestAddSweepAddRevokeRoundTrip(t *testing.T) {
 		t.Error("the expired key survived the sweep")
 	}
 
-	// Both keys must still be revocable — the point of the whole exercise.
-	for _, key := range [][]byte{surviving, nextLogin} {
-		removed, err := akm.RemovePublicKey("testuser", key)
-		if err != nil {
-			t.Fatalf("RemovePublicKey: %v", err)
+	// The broker's key must still be revocable — the point of the whole exercise.
+	removed, err := akm.RemovePublicKey("testuser", nextLogin)
+	if err != nil {
+		t.Fatalf("RemovePublicKey: %v", err)
+	}
+	if !removed {
+		t.Errorf("no authorized_keys line matched %q, so revoking it is a no-op", nextLogin)
+	}
+	after := readKeys(t, baseDir, "testuser")
+	if strings.Contains(after, "NEXTLOGIN") {
+		t.Errorf("key %q still authorizes access after revocation", nextLogin)
+	}
+	if !strings.Contains(after, surviving) {
+		t.Errorf("revocation removed the user's own key; file is %q", after)
+	}
+}
+
+// Every login used to leave another `@oidc-pam-` entry behind, deduplicated only
+// against a byte-identical line — which the issue timestamp in the comment made
+// impossible. A user who logged in daily therefore accumulated one permanently
+// valid key per login, each on its own sufficient to authenticate, so revoking the
+// current session's key left all the earlier ones working (#171).
+func TestASecondLoginSupersedesTheFirstKey(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	own := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5MINE personal-laptop"
+	plantLines(t, baseDir, "testuser", own)
+
+	first := brokerKeyLine(time.Now().Add(-time.Minute), "FIRSTLOGIN")
+	second := brokerKeyLine(time.Now(), "SECONDLOGIN")
+	for _, key := range [][]byte{first, second} {
+		if err := akm.AddPublicKey("testuser", key, testExpiry()); err != nil {
+			t.Fatalf("AddPublicKey: %v", err)
 		}
-		if !removed {
-			t.Errorf("no authorized_keys line matched %q, so revoking it is a no-op", key)
+	}
+
+	oidcKeys, err := akm.ListOIDCKeys("testuser")
+	if err != nil {
+		t.Fatalf("ListOIDCKeys: %v", err)
+	}
+	if len(oidcKeys) != 1 {
+		t.Errorf("after two logins the user has %d broker-issued keys, not 1: %q", len(oidcKeys), oidcKeys)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if strings.Contains(content, "FIRSTLOGIN") {
+		t.Error("the first login's key is still in authorized_keys, so it still authenticates " +
+			"after the session that owned it ended")
+	}
+	if !strings.Contains(content, "SECONDLOGIN") {
+		t.Error("the second login's key is missing, so the login cannot be used")
+	}
+	if !strings.Contains(content, own) {
+		t.Errorf("the user's own key was removed; the broker only owns its own entries. file is %q", content)
+	}
+	// The superseded key must no longer authorize anything: that is what makes
+	// revoking the live one a revocation of access.
+	authorized, err := akm.KeyIsAuthorized("testuser", first)
+	if err != nil {
+		t.Fatalf("KeyIsAuthorized: %v", err)
+	}
+	if authorized {
+		t.Error("the first login's key still authorizes access")
+	}
+	// Exactly one provenance comment, not one per login.
+	if got := strings.Count(content, "# Added by OIDC PAM on"); got != 1 {
+		t.Errorf("authorized_keys carries %d broker comments, not 1; file is %q", got, content)
+	}
+}
+
+// sshd must be able to expire the key without the broker's help. Everything that
+// was supposed to remove a stale entry ran inside the broker — sessions in memory,
+// a sweep on a timer — so a restart, or simply a broker that never got round to it,
+// left a working credential (#171).
+func TestInstalledEntryCarriesTheExpirySSHDEnforces(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	expiresAt := time.Date(2031, 3, 4, 5, 6, 7, 0, time.UTC)
+	key := brokerKeyLine(time.Now(), "EXPIRY")
+	if err := akm.AddPublicKey("testuser", key, expiresAt); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if !strings.Contains(content, `expiry-time="20310304050607Z"`) {
+		t.Errorf(`authorized_keys does not carry expiry-time="20310304050607Z"; file is %q`, content)
+	}
+
+	// And the option must be read back as the expiry it states, or the sweep cannot
+	// act on it.
+	oidcKeys, err := akm.ListOIDCKeys("testuser")
+	if err != nil {
+		t.Fatalf("ListOIDCKeys: %v", err)
+	}
+	if len(oidcKeys) != 1 {
+		t.Fatalf("expected 1 broker key, got %d: %q", len(oidcKeys), oidcKeys)
+	}
+	entry, ok := parseKeyEntry(oidcKeys[0])
+	if !ok {
+		t.Fatalf("the installed entry does not parse: %q", oidcKeys[0])
+	}
+	parsed, ok := entry.expiryTime()
+	if !ok {
+		t.Fatalf("the installed entry's expiry-time cannot be read back: %q", oidcKeys[0])
+	}
+	if !parsed.Equal(expiresAt) {
+		t.Errorf("expiry read back as %s, want %s", parsed, expiresAt)
+	}
+}
+
+// An expiry that has already passed, or none at all, is not something to write into
+// a key list in the hope that something removes it later.
+func TestAddPublicKeyRefusesAnExpiryThatIsNotInTheFuture(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+	key := brokerKeyLine(time.Now(), "BADEXPIRY")
+
+	for name, expiry := range map[string]time.Time{
+		"zero": {},
+		"past": time.Now().Add(-time.Minute),
+	} {
+		if err := akm.AddPublicKey("testuser", key, expiry); err == nil {
+			t.Errorf("AddPublicKey accepted a %s expiry", name)
 		}
-		if got := readKeys(t, baseDir, "testuser"); strings.Contains(got, string(key)) {
-			t.Errorf("key %q still authorizes access after revocation", key)
+	}
+	if _, err := os.Stat(filepath.Join(baseDir, "testuser", ".ssh", "authorized_keys")); err == nil {
+		t.Error("a key was installed despite the expiry being refused")
+	}
+}
+
+// The sweep must honour the configured lifetime. It used to compare against a
+// hardcoded 24 hours whatever the site had configured, so a deployment that had
+// deliberately set token_lifetime: 1h still left every key it issued usable for a
+// day (#171).
+func TestSweepUsesTheConfiguredLifetimeForOlderEntries(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+	akm.SetKeyLifetime(time.Hour)
+
+	// Entries as an older broker wrote them: no expiry-time= option, only the issue
+	// time in the comment.
+	pastLifetime := brokerKeyLine(time.Now().Add(-2*time.Hour), "PASTLIFETIME")
+	withinLifetime := brokerKeyLine(time.Now().Add(-10*time.Minute), "WITHINLIFETIME")
+	plantLines(t, baseDir, "testuser", string(pastLifetime), string(withinLifetime))
+
+	if err := akm.RemoveExpiredKeys("testuser"); err != nil {
+		t.Fatalf("RemoveExpiredKeys: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if strings.Contains(content, "PASTLIFETIME") {
+		t.Error("a key issued two hours ago survived a sweep with a one-hour configured lifetime, " +
+			"so the configured lifetime is not what the sweep measures against")
+	}
+	if !strings.Contains(content, "WITHINLIFETIME") {
+		t.Error("a key issued ten minutes ago was swept under a one-hour lifetime")
+	}
+}
+
+// An entry carrying options must still be recognised by the sweep. The timestamp
+// used to be read out of strings.Fields(line)[2], which is the key data rather than
+// the comment once anything precedes the key type — so the sweep would silently
+// have stopped recognising the broker's own entries (#171).
+func TestSweepReadsEntriesThatCarryOptions(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	expired := fmt.Sprintf(`expiry-time="%s" %s`,
+		time.Now().Add(-time.Minute).UTC().Format("20060102150405Z"),
+		brokerKeyLine(time.Now(), "OPTIONEXPIRED"))
+	live := fmt.Sprintf(`expiry-time="%s" %s`,
+		time.Now().Add(time.Hour).UTC().Format("20060102150405Z"),
+		brokerKeyLine(time.Now(), "OPTIONLIVE"))
+	plantLines(t, baseDir, "testuser", expired, live)
+
+	if err := akm.RemoveExpiredKeys("testuser"); err != nil {
+		t.Fatalf("RemoveExpiredKeys: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if strings.Contains(content, "OPTIONEXPIRED") {
+		t.Error("an entry whose expiry-time= has passed survived the sweep")
+	}
+	if !strings.Contains(content, "OPTIONLIVE") {
+		t.Error("an entry whose expiry-time= is in the future was swept")
+	}
+}
+
+// Removal has to match the entry the broker itself wrote, which now carries an
+// expiry-time= option in front of the key while the broker holds only the bare key
+// in its store. Comparing whole lines would never match again (#171).
+func TestRemovalMatchesAnEntryThatCarriesOptions(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	key := brokerKeyLine(time.Now(), "OPTIONREMOVE")
+	if err := akm.AddPublicKey("testuser", key, testExpiry()); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	removed, err := akm.RemovePublicKey("testuser", key)
+	if err != nil {
+		t.Fatalf("RemovePublicKey: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemovePublicKey found no match for the entry it had just installed, " +
+			"so revoking a key is a no-op the broker reports as a success")
+	}
+	authorized, err := akm.KeyIsAuthorized("testuser", key)
+	if err != nil {
+		t.Fatalf("KeyIsAuthorized: %v", err)
+	}
+	if authorized {
+		t.Error("the key still authorizes access after removal")
+	}
+}
+
+// RemoveOIDCKeys is what makes a broker restart safe: the broker has no session for
+// the keys it issued before it stopped, so the only way to revoke them is to remove
+// every entry bearing its marker.
+func TestRemoveOIDCKeysClearsOrphansAndKeepsTheUsersOwn(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	own := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5OWN personal-laptop"
+	plantLines(t, baseDir, "testuser",
+		"# Added by OIDC PAM on 2025-01-01 00:00:00",
+		string(brokerKeyLine(time.Now().Add(-time.Hour), "ORPHANA")),
+		fmt.Sprintf(`expiry-time="%s" %s`,
+			time.Now().Add(time.Hour).UTC().Format("20060102150405Z"),
+			brokerKeyLine(time.Now(), "ORPHANB")),
+		own)
+
+	removed, err := akm.RemoveOIDCKeys("testuser")
+	if err != nil {
+		t.Fatalf("RemoveOIDCKeys: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("RemoveOIDCKeys removed %d entries, want 2", removed)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	for _, gone := range []string{"ORPHANA", "ORPHANB"} {
+		if strings.Contains(content, gone) {
+			t.Errorf("orphaned key %s still authorizes access; file is %q", gone, content)
 		}
+	}
+	if !strings.Contains(content, own) {
+		t.Errorf("the user's own key was removed; file is %q", content)
+	}
+	// A comment claiming the broker added a key it has just revoked misleads the next
+	// reader of the file.
+	if strings.Contains(content, "# Added by OIDC PAM on") {
+		t.Errorf("a stranded broker comment was left behind; file is %q", content)
 	}
 }
 
@@ -177,7 +433,7 @@ func TestAddPublicKeyTerminatesAnUnterminatedFile(t *testing.T) {
 	}
 
 	newKey := brokerKeyLine(time.Now(), "NEWKEY")
-	if err := akm.AddPublicKey("testuser", newKey); err != nil {
+	if err := akm.AddPublicKey("testuser", newKey, testExpiry()); err != nil {
 		t.Fatalf("AddPublicKey: %v", err)
 	}
 

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -22,6 +22,10 @@ PAM_DIR="/lib/security"
 CONFIG_DIR="/etc/oidc-auth"
 RUN_DIR="/var/run/oidc-auth"
 LOG_DIR="/var/log/oidc-auth"
+# The broker's own state: the SSH keys it issues (ssh-keys/) and the per-user locks
+# that serialize its authorized_keys writes (locks/). Root-only, and deliberately
+# not in any user's home (#161, #171).
+STATE_DIR="/var/lib/oidc-pam"
 SYSTEMD_DIR="/etc/systemd/system"
 
 CONFIGURE_PAM=0
@@ -60,6 +64,8 @@ check_root() {
 create_directories() {
     print_info "Creating required directories..."
     install -d -m 0755 "$CONFIG_DIR" "$RUN_DIR" "$LOG_DIR"
+    # 0700: these are private keys and lock files belonging to the root broker.
+    install -d -m 0700 "$STATE_DIR" "$STATE_DIR/ssh-keys" "$STATE_DIR/locks"
 }
 
 create_user() {

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -244,6 +244,37 @@ expect_no_oidc_key_for() {
     fi
 }
 
+# oidc_key_blob prints the base64 blob of the account's broker-issued key, which
+# is what identifies one issued key against another across logins.
+oidc_key_blob() {
+    awk '/@oidc-pam-/ { for (i = 1; i <= NF; i++) if ($i ~ /^AAAA/) { print $i; exit } }' \
+        "/home/$1/.ssh/authorized_keys" 2>/dev/null
+}
+
+# PERSONAL_KEY stands in for a key the user put in their own authorized_keys. The
+# broker manages its own entries and must leave this one alone, whether it is
+# installing, superseding or sweeping (#171). It is syntactically valid but
+# authorizes nothing, since nobody holds the private half.
+PERSONAL_KEY='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPL personal-laptop'
+
+plant_personal_key() {
+    local user="$1" dir="/home/$1/.ssh"
+    install -d -m 0700 -o "${user}" -g "${user}" "${dir}"
+    printf '%s\n' "${PERSONAL_KEY}" >>"${dir}/authorized_keys"
+    chown "${user}:${user}" "${dir}/authorized_keys"
+    chmod 0600 "${dir}/authorized_keys"
+    log "planted a user-owned key in ${dir}/authorized_keys"
+}
+
+expect_personal_key_for() {
+    if grep -qF "${PERSONAL_KEY}" "/home/$1/.ssh/authorized_keys" 2>/dev/null; then
+        log "$1's own key is still there, as required"
+    else
+        fail "the broker removed $1's own key from authorized_keys; it manages only its own entries"
+        sed 's/^/      authorized_keys: /' "/home/$1/.ssh/authorized_keys" 2>/dev/null
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # Cases
 # ---------------------------------------------------------------------------
@@ -297,6 +328,10 @@ case_waits_while_pending() {
 case_approved_login() {
     reset_state alice || return 1
 
+    # The account's own key is in place before the broker ever touches the file, so
+    # this case also shows that installing a login key preserves it (#171).
+    plant_personal_key alice
+
     start_login alice
     wait_for_polls 1 30 || { kill "${LOGIN_PID}" 2>/dev/null; return 1; }
 
@@ -305,7 +340,18 @@ case_approved_login() {
 
     expect_login_ok || return 1
     expect_oidc_key_for alice
+    expect_personal_key_for alice
     expect_audit authentication_successful
+
+    # sshd is what enforces the expiry, so the option it reads has to be on the
+    # entry. Without it the key stops being revoked the moment the broker forgets
+    # the session, which is what #171 is about.
+    if grep '@oidc-pam-' "/home/alice/.ssh/authorized_keys" | grep -q 'expiry-time="'; then
+        log "the installed entry carries the expiry-time option sshd enforces"
+    else
+        fail "the installed entry has no expiry-time option, so only the broker limits the key"
+        sed 's/^/      authorized_keys: /' "/home/alice/.ssh/authorized_keys"
+    fi
 
     # The user has to be told where to go, or the device flow is unusable by a
     # human even when it works.
@@ -700,6 +746,98 @@ case_long_verification_uri() {
     expect_no_module_log 'does not fit this module'
 }
 
+# One live broker-issued key per account, however many times the user logs in
+# (#171). The old code appended one on every login and only ever deduplicated
+# byte-identical lines, so an account that logged in daily accumulated a working
+# credential per login, each outliving the session it was issued for.
+case_second_login_supersedes_key() {
+    reset_state alice || return 1
+    plant_personal_key alice
+
+    start_login alice
+    wait_for_polls 1 30 || { kill "${LOGIN_PID}" 2>/dev/null; return 1; }
+    control approve >/dev/null
+    reap_login
+    expect_login_ok || return 1
+    expect_oidc_key_for alice || return 1
+
+    local first
+    first="$(oidc_key_blob alice)"
+
+    # A second login, from scratch: a new device flow, a new approval, a new key.
+    reset_state alice || return 1
+    start_login alice
+    wait_for_polls 1 30 || { kill "${LOGIN_PID}" 2>/dev/null; return 1; }
+    control approve >/dev/null
+    reap_login
+    expect_login_ok || return 1
+
+    # Exactly one, still.
+    expect_oidc_key_for alice
+    expect_personal_key_for alice
+
+    local second
+    second="$(oidc_key_blob alice)"
+    if [[ -z "${second}" ]]; then
+        fail "the second login installed no key"
+    elif [[ "${second}" == "${first}" ]]; then
+        fail "the second login reused the first login's key; each session must get its own"
+    else
+        log "the second login replaced the first login's key rather than adding to it"
+    fi
+    if grep -qF "${first}" "/home/alice/.ssh/authorized_keys"; then
+        fail "the first login's key is still authorized after a second login (#171)"
+        sed 's/^/      authorized_keys: /' "/home/alice/.ssh/authorized_keys"
+    fi
+}
+
+# A key outlives the broker that issued it, and nothing used to remove it:
+# sessions live in memory, so a restart forgot every key it had installed while
+# the authorized_keys entries kept authenticating for as long as the account
+# existed (#171). Startup must revoke them.
+#
+# run-tests.sh drives this in two phases with a broker restart in between, and
+# sets PHASE — there is no way for a case running inside the client container to
+# restart a service in another container.
+case_orphan_keys_swept() {
+    case "${PHASE:-}" in
+        setup)
+            reset_state alice || return 1
+            plant_personal_key alice
+
+            start_login alice
+            wait_for_polls 1 30 || { kill "${LOGIN_PID}" 2>/dev/null; return 1; }
+            control approve >/dev/null
+            reap_login
+
+            expect_login_ok || return 1
+            expect_oidc_key_for alice
+            ;;
+        check)
+            # No login here, and deliberately no reset of alice's home: what is on
+            # disk is what the previous phase left, minus whatever the restarted
+            # broker removed.
+            if [[ ! -f /home/alice/.ssh/authorized_keys ]]; then
+                fail "alice's authorized_keys is gone entirely; the sweep must remove entries, not files"
+                return 1
+            fi
+            local count
+            count="$(grep -c '@oidc-pam-' /home/alice/.ssh/authorized_keys)"
+            if [[ "${count}" -ne 0 ]]; then
+                fail "${count} key(s) issued before the restart are still authorized, and no session remains that would ever revoke them (#171)"
+                sed 's/^/      authorized_keys: /' /home/alice/.ssh/authorized_keys
+            else
+                log "the keys the previous broker issued are no longer authorized"
+            fi
+            expect_personal_key_for alice
+            ;;
+        *)
+            fail "orphan_keys_swept must be driven by run-tests.sh, which restarts the broker between its two phases (PHASE=setup then PHASE=check)"
+            return 1
+            ;;
+    esac
+}
+
 # With no broker there is no opinion to be had: the module must report that it
 # could not reach one (PAM_AUTHINFO_UNAVAIL) and the login must be refused, at
 # once rather than after the device-flow budget.
@@ -738,6 +876,8 @@ CASES=(
     nonroot_ipc_rejected
     rate_limit_is_per_account
     home_lock_does_not_block_login
+    second_login_supersedes_key
+    orphan_keys_swept
     broker_down
 )
 

--- a/test/e2e/run-tests.sh
+++ b/test/e2e/run-tests.sh
@@ -86,6 +86,24 @@ fi
 passed=0
 failed=()
 
+# run_orphan_case drives orphan_keys_swept, the one case whose subject is a broker
+# restart: a login installs a key, the broker restarts, and the key must be gone
+# because the session it belonged to no longer exists anywhere (#171). A case runs
+# inside the client container and cannot restart a service in another one, so the
+# restart happens here, between the case's two phases.
+#
+# /home is deliberately not reset in between — the key the first phase installed is
+# the whole subject of the second.
+run_orphan_case() {
+    "${COMPOSE[@]}" exec -T -e PHASE=setup client /harness/cases.sh orphan_keys_swept || return 1
+
+    say "case orphan_keys_swept (restarting the broker between its two phases)"
+    "${COMPOSE[@]}" restart broker >/dev/null 2>&1
+    wait_for_socket || return 1
+
+    "${COMPOSE[@]}" exec -T -e PHASE=check client /harness/cases.sh orphan_keys_swept
+}
+
 for name in "${cases[@]}"; do
     # Every case starts from a broker with no sessions and no in-flight device
     # flows. Otherwise a flow left polling by the previous case can be granted by
@@ -113,7 +131,13 @@ for name in "${cases[@]}"; do
     # removal final.
     reset_homes
 
-    if "${COMPOSE[@]}" exec -T client /harness/cases.sh "${name}"; then
+    if [[ "${name}" == "orphan_keys_swept" ]]; then
+        run_case=(run_orphan_case)
+    else
+        run_case=("${COMPOSE[@]}" exec -T client /harness/cases.sh "${name}")
+    fi
+
+    if "${run_case[@]}"; then
         echo "    PASS ${name}"
         passed=$((passed + 1))
     else


### PR DESCRIPTION
Fixes #171

## What was broken

The SSH key a successful login was granted was written to a directory guessed from the login name, was never removed when the session ended, and accumulated one working credential per login.

The broker joined `/home` with the login name and wrote `<that>/.ssh/authorized_keys`. On any site whose homes are not literally `/home/<user>` — SSSD/LDAP with `/home/<domain>/<user>`, autofs, NFS, a home moved by hand — it created that directory itself, as root and mode 0700, wrote a key list sshd would never read, and reported the login as successful. The user was told they were authenticated and then could not log in; on their next real login their own home was shadowed by a root-owned directory they could not write. The owning uid from the passwd database was never consulted, so nothing distinguished "this is the account's home" from "this is somebody else's directory".

Where the key *did* land it was appended on every login and deduplicated only against byte-identical lines, so an account that logged in daily accumulated one live credential per login. None of them carried an expiry sshd could see, so a key stopped being limited at all the moment the broker forgot the session that owned it — which happens on every restart, since sessions are held only in memory. And the shipped systemd unit set `ProtectHome=true`, which makes `/home` an empty tmpfs to the service, so on a host installed from it no key could be written at all.

Per the issue decision, the feature is kept and fixed; nothing is stubbed out.

## What changed

- **Homes come from the account database.** New `pkg/ssh/accounts.go`: `LookupAccount` asks `os/user`, then falls back to `getent passwd`. The fallback is not redundancy — the released broker is built `CGO_ENABLED=0`, and without cgo `os/user` parses `/etc/passwd` and never asks NSS, so every SSSD/LDAP account is invisible to it. `getent` asks NSS the way sshd and `login` do, bounded by `context.WithTimeout` **and** `cmd.WaitDelay` (the context alone does not bound it: `Output` waits on the pipe, and a killed `getent` can leave a forked child holding it). Nothing derives a home path any more, and a home that does not exist is refused rather than created.
- **Ownership is checked** on the home, on `.ssh`, and on `authorized_keys` through the open descriptor (`fstat`, not a second path lookup). The account or root is accepted — what sshd's own `StrictModes` accepts — anything else is refused rather than written through. Files the root broker creates in a home are handed to the account.
- **One live key per account, with an expiry sshd enforces.** A login drops every previous `@oidc-pam-` entry as it writes, leaves the account's own keys alone, and installs an entry carrying `expiry-time="…"`, so sshd enforces the lifetime whether or not the broker is running or remembers the session. That option needs **OpenSSH 7.7 or newer**, and the timespec is written in the host's own time zone because the UTC `Z` spelling is 9.1+ (see the review round below). Entry parsing is now options-aware (`pkg/ssh/entry.go`, quote-aware field split), so the sweep and removal recognise their own entries once they carry options.
- **The configured `token_lifetime` reaches both the key store and the sweep.** Both were hardcoded to 24h, so a site that set `token_lifetime: 1h` still handed out day-long keys.
- **Startup revokes what the previous run left behind.** The key store survives a restart even though sessions do not, so anything in it at startup belongs to no live session; `Start` reconciles it.
- **A login whose key could not be provisioned is denied,** not completed. It used to be activated and audited `authentication_successful` with no usable key anywhere. The failure is audited as `ssh_key_provisioning_failed`, the metric is recorded, and the session is dropped.
- **A superseded key is not a failed revocation.** Revoking a key a later login had already replaced no longer emits `ssh_key_revocation_incomplete`; that event means a credential is still live (#165), and firing it for the ordinary two-logins case would have trained operators to ignore it.
- **Packaging:** `configs/systemd/oidc-auth-broker.service` sets `ProtectHome=false` (with the reason inline), lists `/home` in `ReadWritePaths` (`ProtectSystem=strict` otherwise makes it read-only) and declares `StateDirectory=oidc-pam` / `StateDirectoryMode=0700`; `scripts/install-release.sh` creates `/var/lib/oidc-pam/{ssh-keys,locks}` at 0700; DEPLOYMENT.md's unit snippet now matches the shipped one and gained troubleshooting for the three ways provisioning fails.

## Wire contract

**No change to the broker↔module wire protocol,** so no decision is needed from `scttfrdmn/oauth2-pam` (which owns `docs/wire-protocol.md`). Denying a login whose key could not be provisioned uses the existing convention: the broker calls `removeSession`, and the module's next check gets the already-specified `SESSION_NOT_FOUND`. No new field, error code or changed meaning, and no local divergence left unregistered.

## Which test proves which claim

Every one of these was run **both ways**: passing on this branch, and with the corresponding defect mechanically reintroduced in the production file (a scripted patch per row, reverted afterwards). All 18 rows failed as required with the defect present — I ran the whole matrix twice, once before rebasing onto `origin/main` and again after.

| Claim | Test | Defect reintroduced to prove it |
|---|---|---|
| The home comes from the account database, not a base directory | `pkg/ssh TestPathsComeFromTheAccountDatabaseNotABaseDirectory` | `account.Home = filepath.Join("/home", username)` |
| A missing home is refused, never created as root 0700 | `pkg/ssh TestAddPublicKeyRefusesAMissingHomeAndDoesNotCreateIt` | `os.MkdirAll(account.Home, 0700)` on `IsNotExist` |
| A foreign-owned home/.ssh/authorized_keys is refused | `pkg/ssh TestForeignOwnershipIsRefused` | `checkOwner` returns nil |
| A second login supersedes the first key instead of accumulating | `pkg/ssh TestASecondLoginSupersedesTheFirstKey` | match only byte-identical entries |
| The installed entry carries the expiry sshd enforces | `pkg/ssh TestInstalledEntryCarriesTheExpirySSHDEnforces` | drop the `expiry-time=` option |
| The sweep measures against the configured lifetime | `pkg/ssh TestSweepUsesTheConfiguredLifetimeForOlderEntries` | use `DefaultKeyLifetime` |
| Entries carrying options are understood by sweep and removal | `pkg/ssh TestSweepReadsEntriesThatCarryOptions`, `TestRemovalMatchesAnEntryThatCarriesOptions` | `strings.Fields` instead of the options-aware split |
| An account only NSS knows about resolves | `pkg/ssh TestAnAccountKnownOnlyToNSSResolvesThroughGetent` | skip the `getent` fallback |
| A wedged account database cannot hold a login open | `pkg/ssh TestAWedgedAccountDatabaseDoesNotHangTheLookup` | remove `cmd.WaitDelay` (this one found a real bug in my own first cut) |
| A login whose key cannot be provisioned is denied and audited | `pkg/auth TestLoginIsDeniedWhenTheKeyCannotBeProvisioned`, `TestLoginIsDeniedWhenTheKeyStoreCannotBeWritten` | activate the session anyway |
| Startup revokes the previous run's keys | `pkg/auth TestStartupRevokesKeysLeftByAPreviousRun` (drives the real `Start`/`Stop`) | drop the `reconcileIssuedKeys` call |
| `token_lifetime` reaches the key manager | `pkg/auth TestConfiguredTokenLifetimeLimitsTheIssuedKey` (real `NewBroker`) | drop `SetExpiration`/`SetKeyLifetime` |
| A superseded revocation is not reported as incomplete | `pkg/auth TestRevokingASupersededKeyIsNotReportedAsIncomplete` | never consult `KeyIsAuthorized` |
| The shipped unit lets the broker write where it must | `cmd/broker TestShippedUnitLetsTheBrokerWriteWhereItMust` (reads the shipped file) | `ProtectHome=true`, drop `/home` and `StateDirectory` |
| The timespec is the form every sshd that knows the option parses | `pkg/ssh TestTheExpiryTimespecIsTheFormEverySupportedSSHDParses`, `TestInstalledEntryCarriesTheExpirySSHDEnforces` | write the UTC `Z` form |
| The docs state the minimum OpenSSH version, and why | `pkg/ssh TestTheDocsStateTheMinimumOpenSSHVersion` | drop the requirement from DEPLOYMENT.md / README.md (proven separately for each) |
| The docs name the platforms too old to run this | `pkg/ssh TestTheDocsNameThePlatformsThatAreTooOld` | remove the 7.4p1 row from the README table |
| A host with no `/home` can still start the broker | `cmd/broker TestShippedUnitLetsTheBrokerWriteWhereItMust` | `ReadWritePaths=… /home` without the `-` |

`pkg/ssh/accounts_test.go` also covers an unknown account (`getent` exit 2 → `ErrUnknownAccount`), a missing `getent`, passwd entries the broker refuses to act on (empty home, non-numeric uid/gid), an answer about the wrong account, non-login-name input, and that `HomeRootLookup` creates nothing.

## Verification

Run on the rebased branch (`origin/main` = b120357):

- `gofmt -l pkg internal cmd` — no output.
- `go build ./...` — clean.
- `go test -count=1 ./pkg/... ./internal/... ./cmd/broker/...` — `ok pkg/auth 7.026s`, `ok pkg/config 0.950s`, `ok pkg/metrics 1.740s`, `ok pkg/pam 0.701s`, `ok pkg/security 5.073s`, `ok pkg/ssh 7.642s`, `ok internal/brokerclient 1.568s`, `ok internal/ipc 2.108s`, `ok cmd/broker 1.384s`.
- Container gate — not strictly required (no C or cgo file is touched) but run anyway: `docker run --rm … golang:1.25 … go vet ./cmd/pam-module ./pkg/pam && go test ./cmd/pam-module/... ./pkg/pam/...` → exit 0, `ok cmd/pam-module 3.029s`, `ok pkg/pam 0.002s`.
- `bash -n` on `test/e2e/cases.sh`, `test/e2e/run-tests.sh`, `scripts/install-release.sh` — clean.
- Defect matrix: 14/14 reintroductions caught.

## e2e additions (not executed here)

`test/e2e/cases.sh` gains `case_second_login_supersedes_key` (two full device flows: still exactly one `@oidc-pam-` entry, a different key blob, the first blob gone) and `case_orphan_keys_swept` (driven in two phases across a broker restart by `run_orphan_case` in `run-tests.sh`), and `case_approved_login` now plants a personal key, asserts it survives provisioning, and asserts the installed entry carries `expiry-time="`. Both new cases are registered in `CASES`. These were **not run on this host** — the suite needs the full docker-compose stack — so they are best-effort until CI runs them; the Go suite is what proves the claims above.

## Deliberately out of scope

- Section 4 of the issue (how the *private* key is consumed, and whether this should be an SSH CA instead of authorized_keys). That is a design change to the login flow, not a defect in provisioning, and wants its own issue.
- Adding a `from=` restriction to the installed entry. Now that #169 makes the real source address available it is worth doing, but it is a policy addition rather than part of this fix.

## Review round 2 (commit `ca0e745`)

Two findings from review, plus one the first finding turned up.

1. **The `Z` was worse than the version note.** The reviewer flagged that `expiry-time=` is version-gated and only a Go comment said so. Checking the numbers rather than taking them: `expiry-time=` was added in **OpenSSH 7.7** (7.7 release notes, April 2018) — so RHEL 8's 8.0p1 does know the option — but the **`Z` suffix meaning UTC was only added in 9.1** (9.1 release notes). Every sshd before 9.1 parses a timespec by its length (8, 12 or 14 digits) and rejects the 15-character `Z` form, taking the whole entry with it. So the first commit worked on Debian 12 (9.2) — the one image `test/e2e` runs — and broke RHEL 8 *and 9*, Debian 11, and Ubuntu 20.04 and 22.04. The timespec is now the host-local 14-digit form; the parser still reads the UTC form, because the sweep has to agree with a 9.1+ sshd about entries it did not write.
2. **The requirement is documented.** DEPLOYMENT.md prerequisites state OpenSSH 7.7+ with the reason, the check (`ssh -V`), and the versions the common platforms ship; the supported-OS list drops Amazon Linux 2 and names RHEL/CentOS 7 as excluded (both `7.4p1`). README.md's platform table gains an OpenSSH column and a `❌ Not supported` row for those platforms, and its "expected to work" definition now includes "the platform's sshd is new enough for the `expiry-time=` option" — so #192's honesty is preserved rather than quietly falsified. Versions verified from primary sources: Debian/Ubuntu package pages, Red Hat's RHEL 9 release notes (8.7p1, and 8.0p1 in RHEL 8), Fedora's `openssh-8.7p1-2.fc35`, and the AL2 advisories (`openssh-7.4p1-22.amzn2`).
3. **`ReadWritePaths=-/home`.** systemd fails the unit's namespace setup when a listed path is missing, so the site told to add `/export/home` — the one with no `/home` — would have got a broker that refuses to start. The `-` prefix makes it non-fatal; the comment says why, and the test now requires the prefix rather than merely the path.

No sshd version detection, no config toggle: filed as **#199** with the three options (detect and omit, refuse to start, or make it configurable) and the caveat that a version probe is a heuristic, since the sshd binary found is not necessarily the sshd that will authenticate the session. Both documents link to it.

Verification re-run on `ca0e745`, rebased on `origin/main` (`b120357`): `gofmt -l pkg internal cmd` empty; `go build ./...` clean; `go test -count=1 ./pkg/... ./internal/... ./cmd/broker/...` all `ok`; the `pkg/ssh` suite also run under `TZ=America/New_York` and `TZ=Asia/Kolkata`, since the timespec is now local time; container gate exit 0 again (`ok cmd/pam-module`, `ok pkg/pam`). Defect matrix now **19/19** — the original 14 plus the four new rows above (the docs row proven once per document).
