### PR TITLE
fix(ssh): grant CAP_CHOWN and hand files over by descriptor (#202, #203)

### DIFF
--- a/cmd/broker/systemd_unit_test.go
+++ b/cmd/broker/systemd_unit_test.go
@@ -65,6 +65,22 @@ func TestShippedUnitLetsTheBrokerWriteWhereItMust(t *testing.T) {
 			"every issued key", got)
 	}
 
+	// CapabilityBoundingSet caps the effective set even for User=root, so a capability
+	// missing from this list is one the broker does not have. Handing a newly written
+	// authorized_keys to its owner needs CAP_CHOWN; without it every chown(2) to
+	// another uid returns EPERM, provisioning fails, and every login through
+	// configs/pam/ssh is denied (#202).
+	//
+	// This assertion exists because nothing else could catch it: the e2e harness runs
+	// in a container with Docker's default capability set, which includes CAP_CHOWN,
+	// so it is strictly more permissive than the host this unit describes.
+	caps := strings.Fields(settings["CapabilityBoundingSet"])
+	if !slices.Contains(caps, "CAP_CHOWN") {
+		t.Errorf("CapabilityBoundingSet=%q omits CAP_CHOWN, so the broker cannot give an "+
+			"account its own authorized_keys and every SSH login is denied (#202)",
+			settings["CapabilityBoundingSet"])
+	}
+
 	// The hardening that is not in the way stays on, so this test cannot be
 	// satisfied by simply removing the sandbox.
 	for setting, want := range map[string]string{

--- a/configs/systemd/oidc-auth-broker.service
+++ b/configs/systemd/oidc-auth-broker.service
@@ -43,7 +43,21 @@ ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oid
 # host installed by hand does not fail on a missing state directory.
 StateDirectory=oidc-pam
 StateDirectoryMode=0700
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
+# CAP_CHOWN is what lets the broker hand a newly written authorized_keys to the
+# account it belongs to. CapabilityBoundingSet caps the *effective* set even for
+# User=root, so without it every chown(2) to another uid returned EPERM, every SSH
+# key provisioning failed, and — on a host wired with configs/pam/ssh — every login
+# was denied (#202).
+#
+# CI never saw it: the containerized e2e harness runs with Docker's default
+# capability set, which includes CAP_CHOWN, so the harness was structurally more
+# permissive than the host this unit describes (see #189).
+#
+# Granting this is only safe because the handover goes through fchown(2) on an
+# already-open descriptor rather than chown(2) on a path the account can replace
+# with a symlink (#203). Do not grant it back without that; the two changes landed
+# in the same commit for this reason.
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
 
 # Logging
 StandardOutput=journal

--- a/pkg/ssh/accounts.go
+++ b/pkg/ssh/accounts.go
@@ -213,17 +213,50 @@ func checkOwner(what, path string, info fs.FileInfo, account Account) error {
 		what, path, uid, account.Username, account.UID)
 }
 
-// chownToAccount gives a path to the account, so that a file the root broker
-// created in someone's home stays theirs to manage.
+// chownFileToAccount gives an already-open descriptor to the account, so that a
+// file the root broker created in someone's home stays theirs to manage.
 //
 // Only root can hand a file to another user, so this is a no-op for an unprivileged
 // process — which is every test, and any development run.
-func chownToAccount(path string, account Account) error {
+//
+// (#203) The chown goes through the descriptor, never through a path. os.Chown
+// resolves the name it is handed and follows symlinks, and every path this package
+// chowns lives in a directory the target account can write. Between creating a file
+// and chowning it by name, the account can replace that name with a link to any file
+// on the host — /etc/shadow, a setuid binary, root's authorized_keys — and the root
+// broker hands them the target. fchown(2) acts on the object that was actually
+// opened, so there is no name left to race and no window to race it in.
+//
+// This is why the fix and CAP_CHOWN (#202) had to land together: until the
+// capability was granted every one of these calls failed with EPERM, which made the
+// path dead code. Granting the capability without fixing the chown would have
+// converted that dead code into a live local privilege escalation.
+func chownFileToAccount(f *os.File, account Account) error {
 	if os.Geteuid() != 0 {
 		return nil
 	}
-	if err := os.Chown(path, account.UID, account.GID); err != nil {
-		return fmt.Errorf("failed to give %q to %s (uid %d): %w", path, account.Username, account.UID, err)
+	if err := f.Chown(account.UID, account.GID); err != nil {
+		return fmt.Errorf("failed to give %q to %s (uid %d): %w", f.Name(), account.Username, account.UID, err)
 	}
 	return nil
+}
+
+// chownDirToAccount gives a directory to the account without ever following a
+// symlink at its path: it opens the directory O_NOFOLLOW|O_DIRECTORY and chowns the
+// descriptor. See chownFileToAccount for why the name is not safe to chown.
+//
+// O_NOFOLLOW constrains only the final path component, which is the component the
+// account controls here — the parent is their home directory, verified by the caller.
+func chownDirToAccount(path string, account Account) error {
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	// #nosec G304 -- path is <resolved home>/.ssh for a validated login name, and the
+	// descriptor is refused below unless it is a real directory rather than a link.
+	dir, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %q to give it to %s: %w", path, account.Username, err)
+	}
+	defer func() { _ = dir.Close() }()
+	return chownFileToAccount(dir, account)
 }

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -153,7 +153,7 @@ func ensureSecureSSHDir(sshDir string, account Account) error {
 			if mkErr := os.MkdirAll(sshDir, 0700); mkErr != nil {
 				return fmt.Errorf("failed to create .ssh directory: %w", mkErr)
 			}
-			return chownToAccount(sshDir, account)
+			return chownDirToAccount(sshDir, account)
 		}
 		return fmt.Errorf("failed to stat .ssh directory: %w", err)
 	}
@@ -252,13 +252,18 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte, account Acco
 		cleanup()
 		return fmt.Errorf("failed to write temp authorized_keys: %w", err)
 	}
+	// The handover goes through the still-open descriptor rather than through
+	// tmpPath (#203). The temp file sits in a directory the account can write, and
+	// its name was predictable, so a chown by name could be pointed at any file on
+	// the host. fchown(2) can only reach the file that was opened here.
+	if err := chownFileToAccount(tmp, account); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		cleanup()
 		return fmt.Errorf("failed to close temp authorized_keys: %w", err)
-	}
-	if err := chownToAccount(tmpPath, account); err != nil {
-		cleanup()
-		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		cleanup()
@@ -802,12 +807,14 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 		_ = bf.Close()
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
+	// The backup sits in the user's own .ssh, so it is theirs, not root's (#171) —
+	// handed over through the open descriptor, not by name (#203).
+	if err := chownFileToAccount(bf, account); err != nil {
+		_ = bf.Close()
+		return err
+	}
 	if err := bf.Close(); err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
-	}
-	// The backup sits in the user's own .ssh, so it is theirs, not root's (#171).
-	if err := chownToAccount(backupPath, account); err != nil {
-		return err
 	}
 
 	log.Info().

--- a/pkg/ssh/security_hardening_test.go
+++ b/pkg/ssh/security_hardening_test.go
@@ -197,3 +197,52 @@ func TestUsernameFromComment(t *testing.T) {
 		}
 	}
 }
+
+// TestNothingInThisPackageChownsByName pins the #203 fix: every handover of a file
+// to its account goes through fchown(2) on an open descriptor, never through
+// chown(2) on a path.
+//
+// The distinction is the whole vulnerability. os.Chown resolves the name it is given
+// and follows symlinks, and every path this package hands over lives in a directory
+// the target account can write — so a chown by name can be redirected at any file on
+// the host, and the root broker performs it. That was unreachable while the shipped
+// unit withheld CAP_CHOWN (#202); granting the capability is what made it live, which
+// is why the two landed together.
+//
+// This is a source guard rather than a behavioural test, deliberately and with a
+// known limit: chownFileToAccount is a no-op for a non-root process, so a test that
+// does not run as root cannot observe which file got chowned. What it does catch is
+// the reintroduction of os.Chown by someone who does not know the history — which is
+// the realistic regression. The behavioural half belongs in the e2e suite, which runs
+// as root in a container.
+func TestNothingInThisPackageChownsByName(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+
+	// os.Lchown is listed too. It does not follow symlinks, so it is not the
+	// escalation — but it still acts on a name, and a name in a user-writable
+	// directory can be a different inode by the time the call runs. The descriptor is
+	// the only thing this package should be chowning.
+	banned := []string{"os.Chown(", "os.Lchown(", "syscall.Chown(", "syscall.Lchown("}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		source, err := os.ReadFile(name) // #nosec G304 -- a .go file in this package's own directory
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, call := range banned {
+			if strings.Contains(string(source), call) {
+				t.Errorf("%s calls %s: hand the file over with chownFileToAccount on an open "+
+					"descriptor instead. Chowning a path the account can replace with a symlink "+
+					"lets it point the root broker's chown at any file on the host (#203).",
+					name, strings.TrimSuffix(call, "("))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #202. Closes #203.

**These must land together.** Either one alone is worse than neither:

- Granting `CAP_CHOWN` without fixing the chown converts dead code into a live local privilege escalation.
- Fixing the chown without granting the capability leaves the product unable to authenticate anyone.

## #202 — the shipped unit denied every login

`CapabilityBoundingSet` caps the *effective* set even for `User=root`. The unit listed `CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID` and no `CAP_CHOWN`, so every `chownToAccount` returned `EPERM`, every SSH key provisioning failed, and on a host wired with `configs/pam/ssh` (`auth sufficient pam_oidc.so` → `auth requisite pam_deny.so`) every login was denied.

CI could not see this. `test/e2e/docker-compose.yml` has no `cap_add`, so the harness runs with Docker's default capability set — which includes `CAP_CHOWN`. The harness was structurally more permissive than the host the unit describes. That is the generalized point in #189.

## #203 — the chown followed a user-controlled name

All three call sites chowned a *path* inside a directory the target account owns and can write:

| site | what it chowned |
|---|---|
| `authorized_keys.go:156` | a newly created `.ssh` |
| `authorized_keys.go:259` | every `authorized_keys` write, via a PID-predictable temp name |
| `authorized_keys.go:809` | backups |

`os.Chown` resolves the name it is given and follows symlinks. Between creating the file and chowning it by name, the account replaces the name with a link to anything on the host, and the root broker hands them the target.

## The fix

- `chownToAccount(path)` → `chownFileToAccount(*os.File)`, i.e. `fchown(2)` on the descriptor that was actually opened. Plus `chownDirToAccount`, which opens `O_NOFOLLOW|O_DIRECTORY` first for the `.ssh` case.
- All three sites hand over while the descriptor is still open — before the name exists to be swapped.
- The unit lists `CAP_CHOWN`, with a comment recording that it is only safe because of the above, so it does not get granted again without it.

## Tests

- `cmd/broker/systemd_unit_test.go` asserts `CAP_CHOWN` is present. This assertion exists because nothing else can catch it — the harness that would otherwise notice is the harness that masks it.
- A source guard in `pkg/ssh` fails on any reintroduced `os.Chown`/`os.Lchown`/`syscall.Chown`. Verified non-vacuous: reintroducing `os.Chown` fails it, removing it passes.

**Stated limit:** the guard is a source scan, not a behavioural test. `chownFileToAccount` is a no-op for a non-root process, so a non-root test cannot observe *which* file got chowned. The behavioural half belongs in the e2e suite, which runs as root in a container — and the same suite should gain a `cap_drop` matching the unit, or it will keep masking #202's class.

Refs #189