### PR TITLE
ci: gate the release on CI and pin the last two actions (#214, #221)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # Called by release.yml so a tag publishes only what this workflow accepts.
+  # Reuse, not a copy: a second hand-maintained definition of the test set drifts
+  # from this one silently, and the release is the copy nobody watches (#214).
+  workflow_call:
 
 permissions:
   contents: read
@@ -228,3 +232,42 @@ jobs:
       # offending package instead of failing with a missing header.
       - name: Check the cgo quarantine
         run: ./scripts/check-cgo-quarantine.sh
+
+      # Every `uses:` in this directory must name a 40-hex commit SHA. A version
+      # tag is mutable: whoever controls the action's repository can retarget it,
+      # and the two references that were left unpinned sat between "build the PAM
+      # module" and "publish it" (#221). This check is here so that is a build
+      # failure rather than something an audit has to find again.
+      - name: Check every action is pinned to a commit SHA
+        run: |
+          # Local reusable workflows (`uses: ./...`) resolve to this repository at
+          # this commit, so there is no third-party tag to pin.
+          unpinned=$(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' .github/workflows/ \
+            | grep -vE 'uses:[[:space:]]*\./' \
+            | grep -vE 'uses:[[:space:]]*[^@]+@[0-9a-f]{40}([[:space:]]|$)' \
+            || true)
+          if [ -n "$unpinned" ]; then
+            echo "::error::unpinned action reference(s) — pin each to a 40-hex commit SHA with a '# vX.Y.Z' comment:"
+            echo "$unpinned"
+            exit 1
+          fi
+          echo "All action references in .github/workflows/ are pinned to commit SHAs."
+
+      # #214: `build` in release.yml needed only `verify-version`, which checks the
+      # README badge and a CHANGELOG header — so a tag published binaries no test
+      # had run against. Assert the gate is still wired, since removing one `needs`
+      # entry restores the hole silently.
+      - name: Check the release build stays gated on CI
+        run: |
+          uses=$(yq -r '.jobs.ci.uses // ""' .github/workflows/release.yml)
+          if [ "$uses" != "./.github/workflows/ci.yml" ]; then
+            echo "::error::release.yml has no 'ci' job calling ./.github/workflows/ci.yml (found: '${uses}')"
+            exit 1
+          fi
+          # `needs` may be a string or a sequence; compare as JSON either way.
+          needs=$(yq -o=json -I=0 '.jobs.build.needs' .github/workflows/release.yml)
+          if ! printf '%s' "$needs" | grep -q '"ci"'; then
+            echo "::error::release.yml's build job does not need the 'ci' job (needs: ${needs}). A tag would publish untested binaries."
+            exit 1
+          fi
+          echo "release.yml's build job is gated on the CI workflow."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,26 @@ jobs:
           fi
           echo "Version $VERSION is consistent across the tag, README badge, and CHANGELOG."
 
+  # A tag push used to publish a release with no test, lint or e2e job having run:
+  # `build` needed only `verify-version`, which reads two files (#214). This calls
+  # the CI workflow rather than restating its jobs, because two hand-maintained
+  # copies of the test set drift and the drift is silent — the release would keep
+  # passing a weaker gate than every pull request has to clear.
+  #
+  # `contents: read` is deliberately narrower than this workflow's `contents:
+  # write`: nothing CI does needs to write, and a called workflow may only be
+  # granted permissions the caller already has.
+  ci:
+    name: CI
+    needs: verify-version
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
   build:
     name: Build (${{ matrix.arch }})
     runs-on: ${{ matrix.runs_on }}
-    needs: verify-version
+    needs: [verify-version, ci]
 
     strategy:
       fail-fast: false
@@ -145,7 +161,7 @@ jobs:
           sha256sum ${DIR}.tar.gz > ${DIR}.tar.gz.sha256
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-linux-${{ matrix.arch }}
           path: |
@@ -163,11 +179,34 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-linux-*
           merge-multiple: true
           path: dist/
+
+      # The .sha256 files are computed in the build job, before the upload, but
+      # until now nothing re-checked them after the download — so anything that
+      # substituted an artifact between the two steps went undetected (#221). The
+      # checksums are only evidence if something compares them.
+      - name: Verify artifact checksums
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          sums=(*.tar.gz.sha256)
+          tars=(*.tar.gz)
+          # `sha256sum -c` over an empty file list exits 0, so an upload that
+          # produced nothing would otherwise verify clean. Count first.
+          if [ "${#sums[@]}" -eq 0 ] || [ "${#tars[@]}" -eq 0 ]; then
+            echo "::error::dist/ has ${#tars[@]} tarball(s) and ${#sums[@]} checksum file(s); expected at least one of each"
+            exit 1
+          fi
+          if [ "${#sums[@]}" -ne "${#tars[@]}" ]; then
+            echo "::error::${#tars[@]} tarball(s) but ${#sums[@]} checksum file(s) in dist/ — an artifact is unaccounted for"
+            exit 1
+          fi
+          sha256sum -c "${sums[@]}"
+          echo "Verified ${#tars[@]} artifact(s) against their checksums."
 
       - name: Create release
         env:


### PR DESCRIPTION
Closes #214 (code half). Closes #221.

## #214 — a tag published untested binaries

`build` needed only `verify-version`, which checks the README badge and that CHANGELOG has a matching header. That was the entire gate: nothing ran `go test`, `golangci-lint`, or the e2e suite before `gh release create`.

`release.yml` now calls `ci.yml` as a **reusable workflow** and `build` needs it. Reuse rather than a copied test step, because a second hand-maintained definition of the test set drifts from the first silently — and the release is the copy nobody watches. `ci.yml` gains a `workflow_call` trigger, which is additive: PR-side context names are unchanged, so branch protection's existing `Test`/`Lint`/`Validate`/`Build` contexts still match.

## #221 — the last two unpinned actions

`upload-artifact@v7` and `download-artifact@v8` were the only unpinned `uses:` in the repository, and both sat between "build the PAM module and broker" and "publish them". Pinned to the commits those tags resolve to *today* (independently re-resolved via `gh api`), so this cannot change current behaviour — it only removes the future retarget.

The release job also now verifies the `.sha256` files it downloads. They were generated at build time and uploaded, but nothing ever checked them.

## Guards, so neither hole reopens quietly

Two new steps in `Validate`:

1. Every `uses:` must name a 40-hex SHA — local `./` reusable workflows excepted, since they resolve to this repo at this commit.
2. `release.yml` must have a `ci` job calling `ci.yml`, and `build` must need it. Removing one `needs` entry would otherwise restore the hole invisibly.

Both were verified to **fail** on a tree with the bug reintroduced, not merely to pass on the fixed one. The checksum step was tested against a swapped tarball, an empty `dist/`, and a missing `.sha256` — `sha256sum -c` over an empty file list exits 0, so the count check ahead of it is load-bearing.

`actionlint` passes clean on both files.

## Two things this does NOT do

**#214's repository-settings half remains open** and is the load-bearing part. This PR guarantees a tag *builds* only code that passed CI; it does not restrict **who can push `v9.9.9` at an arbitrary commit**. Still outstanding, and not doable from a PR:

- a tag protection ruleset for `v*` (`rulesets` is currently length 0)
- `enforce_admins: true` on `main`
- adding `End-to-end (SSH + PAM)`, `PAM (cgo)`, `macOS (no PAM headers)` and the security jobs to the required contexts

**Cost note:** the reused CI set includes a `macos-latest` job, billed at 10×, which now runs on every tag as well as every PR. If that is unwanted, the fix is a `workflow_call` input that skips it for tags — but skipping it would mean the release gate is not the same gate as the PR gate, which is the drift this PR exists to prevent.