### PR TITLE
fix(pam): refuse a broker response whose fields are the wrong JSON type (#201)

### DIFF
--- a/cmd/pam-module/cgo_bridge_linux.c
+++ b/cmd/pam-module/cgo_bridge_linux.c
@@ -539,25 +539,25 @@ void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
 // value cannot collide with one.
 #define BROKER_PENDING (-1)
 
-// Read a string field, or NULL if it is absent or JSON null. The result points
-// into obj and is only valid while obj is alive.
+// Read a string field, or NULL if it is absent, JSON null, or not a JSON string.
+// The result points into obj and is only valid while obj is alive.
+//
+// The type is checked for the same reason it is checked on `success` (#201):
+// json_object_get_string does not read a string, it *renders* whatever it is
+// given, so `"session_id":{"a":1}` came back as the literal text `{ "a": 1 }` and
+// `"error_code":404` as `"404"`. A value of the wrong type is not a value the
+// broker's contract can express, and inventing one from it — then sending it back
+// as the session to poll — is worse than reporting that the field is missing.
+// json_object_is_type answers false for the NULL that json_object_object_get_ex
+// hands back for a JSON null, so that case needs no separate test.
 static const char *json_get_string(json_object *obj, const char *key) {
     json_object *field = NULL;
 
-    if (!json_object_object_get_ex(obj, key, &field) || field == NULL) {
+    if (!json_object_object_get_ex(obj, key, &field) ||
+        !json_object_is_type(field, json_type_string)) {
         return NULL;
     }
     return json_object_get_string(field);
-}
-
-// Read a boolean field, or fallback if it is absent.
-static int json_get_bool(json_object *obj, const char *key, int fallback) {
-    json_object *field = NULL;
-
-    if (!json_object_object_get_ex(obj, key, &field) || field == NULL) {
-        return fallback;
-    }
-    return json_object_get_boolean(field);
 }
 
 // Read the poll interval the broker asked for, clamped into a sane range. An
@@ -570,7 +570,16 @@ static int response_poll_interval(json_object *obj) {
     if (!json_object_object_get_ex(obj, "metadata", &metadata) || metadata == NULL) {
         return DEFAULT_POLL_INTERVAL;
     }
-    if (!json_object_object_get_ex(metadata, "polling_interval", &field) || field == NULL) {
+    if (!json_object_object_get_ex(metadata, "polling_interval", &field)) {
+        return DEFAULT_POLL_INTERVAL;
+    }
+    // A JSON number, and not something rendered into one: json_object_get_int
+    // parses a JSON *string* ("30"), and answers 1 for `true`. Both int and
+    // double are accepted, which is what internal/brokerclient's pollInterval
+    // accepts; the broker sends an int. json_object_is_type answers false for the
+    // NULL a JSON null produces, so that case needs no separate test.
+    if (!json_object_is_type(field, json_type_int) &&
+        !json_object_is_type(field, json_type_double)) {
         return DEFAULT_POLL_INTERVAL;
     }
 
@@ -613,6 +622,7 @@ static int map_error_code(const char *error_code) {
 // the device flow is still in progress.
 static int classify_response(json_object *obj) {
     json_object *success_obj = NULL;
+    json_object *requires_device_obj = NULL;
 
     // A response we cannot interpret is not a grant.
     //
@@ -643,8 +653,32 @@ static int classify_response(json_object *obj) {
     // requires_device must therefore be tested before success is honored, or
     // `auth sufficient pam_oidc.so` short-circuits the auth stack and grants
     // login to anyone who can reach the broker.
-    if (json_get_bool(obj, "requires_device", 0)) {
-        return BROKER_PENDING;
+    //
+    // This read used to go through json_object_get_boolean with no type check, so
+    // a `requires_device` that was not a boolean was silently read as false and
+    // the device step vanished: `{"success":true,"requires_device":null}` — or
+    // `{}`, `[]`, `""` — returned PAM_SUCCESS for an arbitrary user_id, with no
+    // device flow, no identity binding and no require_groups check (#201). It is
+    // the exact grant the paragraph above says must be impossible, so a
+    // requires_device that is present but not a boolean is treated as a response
+    // that cannot be interpreted, not as false. Fail closed, as with `success`.
+    //
+    // Absent is still read as "no device step": internal/ipc.Response declares
+    // `json:"requires_device"` with no omitempty, so the broker emits the field on
+    // every response and only a *different* producer can omit it.
+    if (json_object_object_get_ex(obj, "requires_device", &requires_device_obj)) {
+        // json_object_object_get_ex answers TRUE with a NULL object for a JSON
+        // null, which is how a null used to reach the "absent" path; here it is a
+        // present field of the wrong type, and json_object_is_type answers false
+        // for NULL unless the type asked for is json_type_null.
+        if (!json_object_is_type(requires_device_obj, json_type_boolean)) {
+            log_pam_message(LOG_ERR, "Broker response has a non-boolean requires_device field; "
+                                     "refusing to read it as 'no device authorization needed'");
+            return PAM_AUTHINFO_UNAVAIL;
+        }
+        if (json_object_get_boolean(requires_device_obj)) {
+            return BROKER_PENDING;
+        }
     }
 
     return PAM_SUCCESS;

--- a/cmd/pam-module/device_flow_linux_test.go
+++ b/cmd/pam-module/device_flow_linux_test.go
@@ -417,6 +417,169 @@ func TestPerformAuthenticationRequiresABooleanSuccess(t *testing.T) {
 	}
 }
 
+// The other half of the same trap, and the dangerous half: requires_device was
+// read with json_object_get_boolean and no type check, so anything that was not a
+// JSON boolean was silently read as *false* — "no device authorization needed" —
+// and success=true was then honored on its own (#201).
+//
+// That is the grant the comment in classify_response says must be impossible:
+// `{"success":true,"requires_device":null}` returned PAM_SUCCESS for an arbitrary
+// user_id with no device flow, no identity binding and no require_groups check,
+// and with the shipped `auth sufficient pam_oidc.so` a grant is a login. JSON null
+// is the worst of them, because json_object_object_get_ex answers TRUE with a NULL
+// object for it, so it took the "absent" path rather than looking like a value at
+// all.
+//
+// A requires_device that is present but not a boolean is therefore a response the
+// module cannot interpret, not a false. The real broker emits a JSON bool
+// (internal/ipc.Response, no omitempty), so nothing is given up by insisting on
+// one.
+func TestPerformAuthenticationRequiresABooleanRequiresDevice(t *testing.T) {
+	t.Parallel()
+
+	// success is a real JSON bool in every one of these: the point is what the
+	// module does *after* it has honored success, which is where the device step
+	// either survives or vanishes. Written verbatim, so the JSON type is the test.
+	replies := []struct {
+		name  string
+		reply string
+	}{
+		{"null", `{"success":true,"session_id":"s","requires_device":null}` + "\n"},
+		{"an empty object", `{"success":true,"session_id":"s","requires_device":{}}` + "\n"},
+		{"an empty array", `{"success":true,"session_id":"s","requires_device":[]}` + "\n"},
+		{"the empty string", `{"success":true,"session_id":"s","requires_device":""}` + "\n"},
+		{"the string false", `{"success":true,"session_id":"s","requires_device":"false"}` + "\n"},
+		{"the string true", `{"success":true,"session_id":"s","requires_device":"true"}` + "\n"},
+		{"the number 0", `{"success":true,"session_id":"s","requires_device":0}` + "\n"},
+		{"the number 1", `{"success":true,"session_id":"s","requires_device":1}` + "\n"},
+		{"the float 0.0", `{"success":true,"session_id":"s","requires_device":0.0}` + "\n"},
+	}
+
+	for _, tt := range replies {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return tt.reply
+			})
+
+			got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+			if got == pam.PAMSuccess {
+				t.Fatalf("requires_device=%s was read as 'no device step' and success=true was "+
+					"honored on its own: PAM_SUCCESS from `auth sufficient pam_oidc.so` is a "+
+					"login, with no device flow and no group check", tt.name)
+			}
+			if got != pam.PAMAuthInfoUnavail {
+				t.Fatalf("requires_device=%s: got PAM result %d, want pam.PAMAuthInfoUnavail (%d)",
+					tt.name, got, pam.PAMAuthInfoUnavail)
+			}
+			// An uninterpretable response is not something to keep polling on.
+			if n := len(broker.received()); n != 1 {
+				t.Errorf("expected exactly 1 request, got %d", n)
+			}
+		})
+	}
+}
+
+// json_object_get_string does not read a string, it renders whatever it is given:
+// a session_id of 12345 came back as the text "12345", and one of {"a":1} as
+// `{ "a": 1 }` — a session the module then sent back to the broker as the one to
+// poll. The broker's session ids are strings, so a session_id of another type is a
+// response that cannot be interpreted (#201).
+func TestPerformAuthenticationRequiresAStringSessionID(t *testing.T) {
+	t.Parallel()
+
+	replies := []struct {
+		name  string
+		reply string
+	}{
+		{"a number", `{"success":true,"requires_device":true,"session_id":12345}` + "\n"},
+		{"a bool", `{"success":true,"requires_device":true,"session_id":true}` + "\n"},
+		{"an object", `{"success":true,"requires_device":true,"session_id":{"id":"s"}}` + "\n"},
+		{"an array", `{"success":true,"requires_device":true,"session_id":["s"]}` + "\n"},
+		{"null", `{"success":true,"requires_device":true,"session_id":null}` + "\n"},
+	}
+
+	for _, tt := range replies {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return tt.reply
+			})
+
+			got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+			if got != pam.PAMAuthInfoUnavail {
+				t.Fatalf("session_id=%s: got PAM result %d, want pam.PAMAuthInfoUnavail (%d)",
+					tt.name, got, pam.PAMAuthInfoUnavail)
+			}
+			if n := len(broker.received()); n != 1 {
+				t.Errorf("a session_id the module cannot read must not be polled: got %d requests", n)
+			}
+		})
+	}
+}
+
+// error_code is read with the same strictness, and a refusal whose error_code is
+// not a string stays a refusal: it maps as an unrecognized code (PAM_AUTH_ERR)
+// rather than being rendered into text that map_error_code might match, and never
+// becomes "I could not reach an opinion".
+func TestPerformAuthenticationDeniesWithANonStringErrorCode(t *testing.T) {
+	t.Parallel()
+
+	replies := []struct {
+		name  string
+		reply string
+	}{
+		{"a number", `{"success":false,"error_code":404,"error_message":"nope"}` + "\n"},
+		{"an array", `{"success":false,"error_code":["POLICY_DENIED"],"error_message":{"m":1}}` + "\n"},
+		{"null", `{"success":false,"error_code":null,"error_message":null}` + "\n"},
+	}
+
+	for _, tt := range replies {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			broker := newFakeBroker(t, func(_ int, _ map[string]interface{}) interface{} {
+				return tt.reply
+			})
+
+			got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 30)
+			if got != pam.PAMAuthError {
+				t.Fatalf("error_code=%s: got PAM result %d, want pam.PAMAuthError (%d)",
+					tt.name, got, pam.PAMAuthError)
+			}
+		})
+	}
+}
+
+// metadata.polling_interval is read with json_object_get_int, which parses a JSON
+// *string* too, so a broker could set the module's poll rate with a value that is
+// not a number. It is now ignored unless it really is a JSON number, which leaves
+// DEFAULT_POLL_INTERVAL in force.
+//
+// The count is what shows it: a 2-second budget with the default 5-second interval
+// leaves time for exactly one poll, where a honored "1" would have allowed two.
+func TestPerformAuthenticationIgnoresANonNumericPollInterval(t *testing.T) {
+	t.Parallel()
+
+	broker := newFakeBroker(t, func(n int, _ map[string]interface{}) interface{} {
+		if n == 1 {
+			return `{"success":true,"session_id":"sess-pi","requires_device":true,` +
+				`"metadata":{"polling_interval":"1"}}` + "\n"
+		}
+		return devicePending("sess-pi")
+	})
+
+	if got := performAuthentication(broker.socketPath, "testuser", "sshd", "10.0.0.1", "ssh", 2); got != pam.PAMAuthError {
+		t.Fatalf("unfinished device flow: got PAM result %d, want pam.PAMAuthError (%d)", got, pam.PAMAuthError)
+	}
+	if n := len(broker.received()); n != 2 {
+		t.Errorf("expected authenticate + 1 poll in a 2s budget at the default 5s interval, got %d "+
+			"requests: a non-numeric polling_interval is being read as a number", n)
+	}
+}
+
 // A service can hand the module a PAM_CONV item with no conversation function in
 // it. display_message called through it without looking, so showing the device-flow
 // instructions dereferenced NULL and killed the process — and under sshd that


### PR DESCRIPTION
Closes #201.

`classify_response` read `requires_device` with `json_object_get_boolean` and no type check. json-c coerces rather than rejects there — `json_object_get_boolean` answers 0 for a JSON null, for `{}` and for `[]` — so

```json
{"success":true,"requires_device":null,"user_id":"anyone"}
```

was read as *authorized, and no device authorization needed*, and returned `PAM_SUCCESS`: no device flow, no identity binding, no `require_groups` check. The comment immediately above that read already said `requires_device` must be tested before `success` is honored, or `auth sufficient pam_oidc.so` short-circuits the auth stack and grants login to anyone who can reach the broker. The read did not hold up its end.

A present-but-not-boolean `requires_device` is now a response that cannot be interpreted (`PAM_AUTHINFO_UNAVAIL`), which is how `success` has been handled since the bypass that started this campaign. Absent is still "no device step" — `internal/ipc.Response` declares the field without `omitempty`, so the broker emits it on every response; the comment now records that dependency instead of leaving it implicit.

### The same coercion was on every other field, so all of them are typed now

| Field | What coercion did | Now |
|---|---|---|
| `session_id`, `instructions`, `error_code`, `error_message` | `json_object_get_string` *renders* what it is handed, so `"session_id":{"a":1}` became the literal text `{ "a": 1 }` — and was sent back to the broker as the session to poll | wrong type reads as absent, which the existing "no session_id" path already refuses |
| `metadata.polling_interval` | `json_object_get_int` parses a JSON string (`"30"` → 30) and answers 1 for `true`, letting a peer set the module poll rate with a non-number | only `json_type_int` / `json_type_double`, matching what `internal/brokerclient`s `pollInterval` accepts |

`json_get_bool` had no other caller and is deleted rather than left to be reached for again; `-Wall -Wextra` would have flagged it unused anyway.

### Verification

The Go tests need Linux-PAM, so CI's `PAM (cgo)` job is their first real run. Rather than ship read-verified C, the file was `#include`d into a harness linked against libpam and json-c on the development host and `perform_authentication` driven against a fake broker on a unix socket:

- **At the parent commit**, `requires_device` of `null`, `{}`, `""` and `0.0` each returned **`PAM_SUCCESS`** — the grant, reproduced live.
- **After the fix**, all nine wrong-typed cases return `PAM_AUTHINFO_UNAVAIL` with a single request; `true` still polls; `false` and absent still return `PAM_SUCCESS`.
- Non-string `session_id` → `PAM_AUTHINFO_UNAVAIL`, one request. `error_code:404` → `PAM_AUTH_ERR`; `"POLICY_DENIED"` still → `PAM_PERM_DENIED`. Poll interval `"1"` → 2 requests, `1` → 3, exactly as the new test asserts.
- `cc -fsyntax-only -Wall -Wextra` adds no new warning (the one that remains is the pre-existing `msg.msg = message` const discard, an OpenPAM-vs-Linux-PAM header difference).

Two things are **not** verified here: the assertions are pinned to harness numbers from the identical C path but the Go tests themselves have never executed, and the host json-c is 0.19 while the issue was found against 0.18 (the `is_type` / `get_ex`-NULL semantics relied on are long-standing).

No CHANGELOG entry: the v0.5.1 entries land in one commit at the end of the milestone so the parallel branches do not all conflict in the same `[Unreleased]` region.