### PR TITLE
fix(auth): fail closed on policy, sessions and every refusal

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -323,19 +323,20 @@ authentication:
   require_groups: ["employees"]
   max_concurrent_sessions: 3
 
+  # A policy sets require_groups, max_session_duration, require_device_trust and
+  # ip_whitelist. Those four are enforced; anything else is a startup error (#212).
   policies:
     default:
       require_groups: ["employees", "contractors"]
       max_session_duration: "8h"
-      audit_level: "standard"
 
     # Applies only on hosts named "admin", e.g. admin.example.com.
     admin:
       require_groups: ["administrators", "sysadmins"]
       max_session_duration: "4h"
-      require_additional_mfa: true
+      # Denies any identity whose amr claim carries no hwk/fido authenticator.
+      # Confirm your provider emits amr first — one that does not denies every login.
       require_device_trust: true
-      audit_level: "detailed"
 
 # Security settings
 security:

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -143,7 +143,6 @@ authentication:
     default:
       require_groups: ["users"]
       max_session_duration: "8h"
-      audit_level: "standard"
 
 server:
   log_level: "info"

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -583,6 +583,58 @@ Every matching policy applies. `require_groups` is the union of the global
 `max_session_duration` is the smallest — so an additional matching policy can
 only further restrict access.
 
+### What a policy can set
+
+A policy has exactly four settings, and the broker enforces all four:
+
+| Key | What it does |
+|---|---|
+| `require_groups` | Denies any identity that is in none of the named groups. |
+| `max_session_duration` | Hard ceiling on the session's life from the moment it was created. Reached, the session ends and the user re-authenticates — which is when policy is evaluated again from scratch. Refreshing does not extend past it. |
+| `require_device_trust` | Denies any identity whose `amr` claim does not include `hwk` or `fido` (RFC 8176). **Check your provider emits `amr` before enabling this**: against one that does not, it denies every login on the host. |
+| `ip_whitelist` | CIDRs the login's **source** address must fall in. A login reporting no source address is governed by `authentication.network_requirements.unknown_source_ip`. |
+
+Ten other keys used to be accepted here. They parsed, they appeared in the loaded
+configuration, and **nothing read any of them** — so a policy that set
+`require_additional_mfa` or `session_recording` announced a control that did not
+exist and the login proceeded exactly as if it had not. Since v0.5.1 the broker
+**refuses to start** on any of them, naming each one and why (#212):
+
+`require_reauth_for_new_hosts`, `require_institutional_affiliation`,
+`require_allocation_verification`, `require_project_membership`, `audit_level`,
+`allow_untrusted_devices`, `require_additional_mfa`, `no_data_export`,
+`session_recording`, `require_approval_for`.
+
+Refusing to start, rather than warning, is deliberate: a warning in a log nobody
+reads is how these settings survived eleven releases. **Upgrading to v0.5.1 with
+any of them set will stop the broker**, so remove them before you upgrade. Most
+have somewhere real to go — an affiliation or project requirement is a
+`require_groups` against a group the IdP issues; a second factor belongs in the
+IdP's own sign-on policy, where it can be enforced.
+
+### Risk policies
+
+`authentication.risk_policies` matches a condition against the risk score and
+signals the broker computes, and its `action` is `DENY` or `LOG` — those two.
+`REQUIRE_ADDITIONAL_MFA` and `REQUIRE_APPROVAL` were accepted until v0.5.1, set a
+field nothing read, and let the login proceed unchanged; they are now a startup
+error for the same reason as the keys above.
+
+A condition is either a comparison against `risk_score` (`>=`, `>`, `<=`, `<`,
+`==`) or one or more signal names joined by `AND`:
+
+| Signal | True when |
+|---|---|
+| `unusual_location` | The source address is outside the user's recorded location history. |
+| `after_hours` | The login is outside 07:00–19:00 in the broker's local time. |
+| `untrusted_network` | The source address is not private — **including when there is no source address at all**, since an unknown origin is not evidence of a safe one. |
+| `unknown_device` (alias `new_device`) | The request carries no device identifier. |
+| `unknown_network_origin` (alias `unknown_network`) | The request carries no source address. |
+
+Anything else is a startup error. There is deliberately no device-trust signal:
+risk policies are evaluated before the device flow begins, so no `amr` claim
+exists yet — `require_device_trust` covers that, after the identity is known.
+
 ## Environment-Specific Configurations
 
 Deploy one configuration per environment and name its policy `default`, so that
@@ -596,8 +648,6 @@ authentication:
     default:
       require_groups: ["developers"]
       max_session_duration: "8h"
-      allow_untrusted_devices: true
-      audit_level: "basic"
 
 security:
   tls_verification:
@@ -613,7 +663,6 @@ authentication:
       require_groups: ["developers", "qa-team"]
       max_session_duration: "4h"
       require_device_trust: true
-      audit_level: "standard"
 ```
 
 ### Production Environment
@@ -625,9 +674,7 @@ authentication:
       require_groups: ["production-access"]
       max_session_duration: "2h"
       require_device_trust: true
-      require_additional_mfa: true
-      session_recording: true
-      audit_level: "detailed"
+      ip_whitelist: ["10.0.0.0/8"]
 ```
 
 ## Troubleshooting

--- a/configs/examples/broker.yaml
+++ b/configs/examples/broker.yaml
@@ -104,32 +104,41 @@ authentication:
   # naming it at startup. Rename the tier that applies to these hosts to
   # "default", or name your hosts to match. Every matching policy applies:
   # require_groups is the union of all matches and the global setting.
+  #
+  # A policy has four settings the broker enforces: require_groups,
+  # max_session_duration, require_device_trust and ip_whitelist. (#212) This example
+  # also set require_reauth_for_new_hosts, allow_untrusted_devices and audit_level,
+  # none of which anything read — writing any of them is now a startup error rather
+  # than a control that appears to exist.
   policies:
     production:
       require_groups: ["production-access", "senior-engineers"]
+      # Denies any login whose identity does not present a hardware or FIDO
+      # authenticator in its amr claim. Against a provider that does not emit amr,
+      # this denies every login — check yours before enabling it.
       require_device_trust: true
       max_session_duration: "4h"
-      require_reauth_for_new_hosts: true
-      audit_level: "detailed"
-      
+
     staging:
       require_groups: ["developers", "qa-team"]
       max_session_duration: "8h"
-      audit_level: "standard"
-      
+
     development:
       require_groups: ["developers", "contractors"]
       max_session_duration: "12h"
-      allow_untrusted_devices: true
-      audit_level: "basic"
 
   # Risk-based policies
+  #
+  # The action is DENY or LOG, and nothing else. (#212) REQUIRE_ADDITIONAL_MFA and
+  # REQUIRE_APPROVAL were accepted and then did nothing at all — the login went
+  # ahead as if the policy had not matched — so this example described a step-up
+  # flow the broker has never had. Writing either is now a startup error.
   risk_policies:
     - condition: "risk_score >= 70"
-      action: "REQUIRE_ADDITIONAL_MFA"
-      recommendation: "High risk detected, additional authentication required"
+      action: "LOG"
+      recommendation: "High risk login permitted; review the audit trail"
     - condition: "unusual_location AND after_hours"
-      action: "REQUIRE_APPROVAL"
+      action: "LOG"
       recommendation: "Unusual access pattern detected"
 
 # Security configuration

--- a/configs/production/broker-enterprise.yaml
+++ b/configs/production/broker-enterprise.yaml
@@ -131,57 +131,63 @@ authentication:
   # naming it at startup. Rename the tier that applies to these hosts to
   # "default", or name your hosts to match. Every matching policy applies:
   # require_groups is the union of all matches and the global setting.
+  #
+  # (#212) This file used to set require_reauth_for_new_hosts,
+  # require_institutional_affiliation, require_additional_mfa, no_data_export,
+  # session_recording, audit_level, require_approval_for and
+  # allow_untrusted_devices. Nothing read any of them: they parsed, they appeared
+  # in the loaded configuration, and they controlled nothing. The broker now
+  # refuses to start on any of them rather than let a tier called "maximum
+  # security" be four settings weaker than it reads. They are left here as
+  # comments because what they were reaching for is real — it is just not built.
   policies:
     # Production environment - maximum security
     production:
       require_groups: ["production-access", "senior-engineers"]
+      # Denies any login whose identity does not present a hardware or FIDO
+      # authenticator in its amr claim. Enable this only against a provider that
+      # emits amr: an IdP that never sends "hwk" or "fido" denies every login here.
       require_device_trust: true
       max_session_duration: "2h"
-      require_reauth_for_new_hosts: true
-      require_institutional_affiliation: true
-      require_additional_mfa: true
-      no_data_export: true
-      session_recording: true
-      audit_level: "detailed"
-      require_approval_for: ["database-access", "admin-actions"]
       ip_whitelist: ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-    
+      # Not enforceable — see the note above (#212):
+      #   require_reauth_for_new_hosts: true
+      #   require_institutional_affiliation: true
+      #   require_additional_mfa: true
+      #   no_data_export: true
+      #   session_recording: true
+      #   audit_level: "detailed"
+      #   require_approval_for: ["database-access", "admin-actions"]
+
     # Staging environment - high security
     staging:
       require_groups: ["staging-access", "developers", "qa-team"]
       require_device_trust: true
       max_session_duration: "4h"
-      require_reauth_for_new_hosts: false
-      require_additional_mfa: false
-      audit_level: "standard"
       ip_whitelist: ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-    
+
     # Development environment - balanced security
     development:
       require_groups: ["developers", "contractors"]
       require_device_trust: false
       max_session_duration: "8h"
-      allow_untrusted_devices: true
-      audit_level: "basic"
-    
+
     # Service accounts - automated access
     service:
       require_groups: ["service-accounts"]
       require_device_trust: true
       max_session_duration: "1h"
-      require_reauth_for_new_hosts: true
-      audit_level: "detailed"
-      no_data_export: true
-    
+
     # Emergency access - break-glass
+    #
+    # require_device_trust is deliberately false: a break-glass account is used
+    # when the usual path is unavailable, which includes the case where the
+    # authenticator is what is unavailable. The short max_session_duration is what
+    # bounds it, and every use is on the audit trail.
     emergency:
       require_groups: ["emergency-access", "security-team"]
       require_device_trust: false
       max_session_duration: "30m"
-      require_additional_mfa: true
-      session_recording: true
-      audit_level: "detailed"
-      require_approval_for: ["all-actions"]
 
   # Network security requirements
   network_requirements:
@@ -209,34 +215,57 @@ authentication:
       maintenance_windows: ["Sunday 02:00-06:00", "Wednesday 01:00-03:00"]
       holiday_restrictions: ["2024-12-25", "2024-01-01", "2024-07-04"]
     
-    time_restrictions:
-      - providers: ["contractors"]
-        allowed_hours: "08:00-18:00"
-        timezone: "America/New_York"
-        exceptions: ["emergency-access"]
-    
-    geo_restrictions:
-      - providers: ["contractors"]
-        allowed_countries: ["US", "CA"]
-        blocked_countries: ["CN", "RU", "IR", "KP"]
+    # providers names the OIDC providers a restriction applies to, by the name
+    # under oidc.providers, or "all". An empty list matches no provider, so the
+    # restriction applies to nothing — the broker refuses to start on it rather
+    # than let a time window look like it is in force (#212).
+    #
+    # "contractors" below must therefore be the name of a provider in this file's
+    # oidc.providers list. It is not — these restrictions are examples, so they are
+    # commented out. Uncomment them against a provider you actually have.
+    #
+    # exceptions is not implemented: it parsed and was never read, so a listed
+    # group was still refused outside the window. Starting on it is refused.
+    time_restrictions: []
+    #   - providers: ["contractors"]
+    #     allowed_hours: "08:00-18:00"   # local to timezone; may cross midnight
+    #     timezone: "America/New_York"
+
+    # Country restrictions need authentication.geoip_database_path. Without it
+    # every address resolves to no country, an allowed_countries list matches
+    # nothing, and every login the restriction covers is denied — so the broker
+    # refuses to start on a country restriction with no database (#212). The path
+    # must exist at startup: set it to a MaxMind GeoLite2-Country.mmdb you have
+    # installed on these hosts.
+    geo_restrictions: []
+    #   - providers: ["contractors"]
+    #     allowed_countries: ["US", "CA"]
+    #     blocked_countries: ["CN", "RU", "IR", "KP"]
 
   # Advanced risk-based policies
+  #
+  # (#212, #213) The action is DENY or LOG. REQUIRE_ADDITIONAL_MFA and
+  # REQUIRE_APPROVAL were accepted, set a field nothing read, and left the login to
+  # proceed exactly as if the policy had not matched — so a config full of them
+  # described an approval workflow that did not exist. There is no step-up or
+  # approval mechanism in the broker; DENY is the only thing it can do about risk,
+  # and LOG is the honest way to record a condition without acting on it.
+  #
+  # The condition vocabulary is a risk_score comparison, or one or more of
+  # unusual_location, after_hours, untrusted_network, unknown_device and
+  # unknown_network_origin joined by AND. Anything else is a startup error: the old
+  # "new_device AND production_access" and "contractor AND sensitive_data" named
+  # four flags that have never existed, so both policies matched nothing.
   risk_policies:
     - condition: "risk_score >= 80"
       action: "DENY"
       recommendation: "Critical risk detected, access denied"
     - condition: "risk_score >= 60"
-      action: "REQUIRE_ADDITIONAL_MFA"
-      recommendation: "High risk detected, additional authentication required"
+      action: "LOG"
+      recommendation: "High risk login permitted; review the audit trail"
     - condition: "unusual_location AND after_hours"
-      action: "REQUIRE_APPROVAL"
+      action: "LOG"
       recommendation: "Unusual access pattern detected"
-    - condition: "new_device AND production_access"
-      action: "REQUIRE_APPROVAL"
-      recommendation: "New device accessing production systems"
-    - condition: "contractor AND sensitive_data"
-      action: "REQUIRE_APPROVAL"
-      recommendation: "Contractor accessing sensitive resources"
 
 # Enhanced Security Configuration
 security:
@@ -339,11 +368,12 @@ audit:
 # loaded: this file is now checked by TestShippedConfigsLoad, and an unknown key
 # is a startup error rather than silence. What is enforced lives above:
 #
-#   * require_groups, max_session_duration, require_device_trust,
-#     require_additional_mfa and ip_whitelist under authentication.policies.<name>
-#     (see the note on policy names there — ip_whitelist matches the SOURCE
-#     address of the login, which is the network allowlist this file wanted)
-#   * risk thresholds under authentication.risk_policies
+#   * require_groups, max_session_duration, require_device_trust and
+#     ip_whitelist under authentication.policies.<name> — those four, and nothing
+#     else (#212). See the note on policy names there; ip_whitelist matches the
+#     SOURCE address of the login, which is the network allowlist this file wanted.
+#   * risk thresholds under authentication.risk_policies, whose only actions are
+#     DENY and LOG
 #   * network requirements under authentication.network_requirements
 #   * log verbosity under server.log_level, and the audit trail under audit:
 #

--- a/configs/providers/azure-ad.yaml
+++ b/configs/providers/azure-ad.yaml
@@ -75,18 +75,23 @@ authentication:
   # naming it at startup. Rename the tier that applies to these hosts to
   # "default", or name your hosts to match. Every matching policy applies:
   # require_groups is the union of all matches and the global setting.
+  #
+  # (#212) require_institutional_affiliation and audit_level were set here and read
+  # by nothing. Setting either is now a startup error rather than a control that
+  # appears to exist. An affiliation requirement is expressible as require_groups
+  # against a group the tenant actually issues, which is enforced.
   policies:
     production:
       require_groups: ["production-access", "azuread-admin"]
+      # Requires a hardware or FIDO authenticator in the identity's amr claim.
+      # Entra ID sends amr when the sign-in used one; against a Conditional Access
+      # policy that permits password-only sign-in, this denies those logins.
       require_device_trust: true
       max_session_duration: "4h"
-      require_institutional_affiliation: true
-      audit_level: "detailed"
-      
+
     development:
       require_groups: ["developers", "azuread-dev"]
       max_session_duration: "8h"
-      audit_level: "basic"
 
 # Security configuration
 security:

--- a/configs/providers/keycloak.yaml
+++ b/configs/providers/keycloak.yaml
@@ -73,17 +73,22 @@ authentication:
   # naming it at startup. Rename the tier that applies to these hosts to
   # "default", or name your hosts to match. Every matching policy applies:
   # require_groups is the union of all matches and the global setting.
+  #
+  # (#212) audit_level was set on both tiers and read by nothing — the audit trail
+  # records the same fields either way. Setting it is now a startup error rather
+  # than a control that appears to exist, so it is gone from here.
   policies:
     production:
       require_groups: ["production-access", "keycloak-admin"]
+      # Requires a hardware or FIDO authenticator in the identity's amr claim.
+      # Keycloak sends amr only when the authentication flow is configured to;
+      # against a realm that does not, this denies every login.
       require_device_trust: true
       max_session_duration: "4h"
-      audit_level: "detailed"
-      
+
     development:
       require_groups: ["developers", "keycloak-dev"]
       max_session_duration: "8h"
-      audit_level: "basic"
 
 # Security configuration
 security:

--- a/configs/providers/okta.yaml
+++ b/configs/providers/okta.yaml
@@ -75,18 +75,24 @@ authentication:
   # naming it at startup. Rename the tier that applies to these hosts to
   # "default", or name your hosts to match. Every matching policy applies:
   # require_groups is the union of all matches and the global setting.
+  #
+  # (#212) require_additional_mfa and audit_level were set here and read by
+  # nothing. The broker has no step-up mechanism: the policy said "additional MFA"
+  # and the login proceeded unchanged. Setting either is now a startup error rather
+  # than a control that appears to exist. Require the second factor in Okta's own
+  # sign-on policy for the application, which is where it can actually be enforced.
   policies:
     production:
       require_groups: ["production-access", "okta-admin"]
+      # Requires a hardware or FIDO authenticator in the identity's amr claim.
+      # Okta emits amr on the ID token; against a policy that permits password-only
+      # sign-in, this denies those logins, which is the point.
       require_device_trust: true
       max_session_duration: "4h"
-      require_additional_mfa: true
-      audit_level: "detailed"
-      
+
     development:
       require_groups: ["developers", "okta-dev"]
       max_session_duration: "8h"
-      audit_level: "basic"
 
 # Security configuration
 security:

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -100,7 +100,24 @@ type Session struct {
 	IsActive      bool
 	RiskScore     int
 	DeviceTrusted bool
-	Metadata      map[string]interface{}
+
+	// MaxDuration is the longest this session may live, from CreatedAt, as the
+	// policy that admitted it required. Zero means the policies set no limit and
+	// token_lifetime alone bounds the session.
+	//
+	// (#212) It is stored on the session rather than looked up again on refresh
+	// because a refresh must be bounded by the policy that admitted the login, and
+	// re-deriving it would silently extend every live session when an operator
+	// relaxed max_session_duration.
+	MaxDuration time.Duration
+
+	// RequireDeviceTrust records that a matching policy required a trusted device,
+	// so the check can be made once the identity — and with it the amr claim
+	// DeviceTrusted comes from — is actually known. Policy is evaluated before the
+	// device flow starts, when it is not.
+	RequireDeviceTrust bool
+
+	Metadata map[string]interface{}
 }
 
 // AuthRequest represents an authentication request
@@ -377,11 +394,86 @@ func (b *Broker) Stop() error {
 	return nil
 }
 
+// denialEvent is the audit record for a login this broker refused.
+//
+// (#218) Every branch of Authenticate that answers with a failure records one, and
+// records the same error_code it puts on the wire. A refusal used to be reported to
+// the client and then forgotten: a user with a valid IdP account but no group
+// membership could be denied on every host on the network and leave nothing behind
+// to count, because sshd's log does not know which OIDC identity was refused. It is
+// also what an operator debugging a policy lockout reads instead of reproducing the
+// denial with debug logging on.
+//
+// The caller adds whatever else it knows — provider, risk, the policy that decided
+// — before logging it.
+func (b *Broker) denialEvent(req *AuthRequest, errorCode, reason string) security.AuditEvent {
+	return security.AuditEvent{
+		EventType:    "authentication_denied",
+		UserID:       req.UserID,
+		SourceIP:     req.SourceIP,
+		UserAgent:    req.UserAgent,
+		TargetHost:   req.TargetHost,
+		DeviceID:     req.DeviceID,
+		Success:      false,
+		ErrorCode:    errorCode,
+		ErrorMessage: reason,
+		Metadata:     map[string]interface{}{"login_type": req.LoginType},
+		Timestamp:    time.Now(),
+	}
+}
+
+// auditCrossUserAttempt records an attempt to check, refresh or revoke a session
+// that belongs to somebody else.
+//
+// (#218) The three verbs already refuse this, and refused it silently: a caller
+// probing session IDs against another account got FORBIDDEN and left no trace at
+// all, so the one thing here that is unambiguously an attack — nobody reaches
+// another user's session ID by accident — was the least visible thing the broker
+// did. The record names both accounts, since "who asked" and "whose session" are
+// the two halves an investigation needs.
+func (b *Broker) auditCrossUserAttempt(verb, sessionID, requestedBy, owner string) {
+	log.Warn().
+		Str("verb", verb).
+		Str("session_id", sessionID).
+		Str("requested_by", requestedBy).
+		Msg("Refusing a session operation requested by someone other than the session's owner")
+
+	b.auditLogger.LogAuthEvent(security.AuditEvent{
+		EventType:    "session_access_denied",
+		UserID:       requestedBy,
+		SessionID:    sessionID,
+		Success:      false,
+		ErrorCode:    "FORBIDDEN",
+		ErrorMessage: "session does not belong to requesting user",
+		Metadata: map[string]interface{}{
+			"request_type":  verb,
+			"session_owner": owner,
+		},
+		Timestamp: time.Now(),
+	})
+}
+
 // Authenticate handles authentication requests
 func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 	// Validate field lengths to prevent log flooding and memory exhaustion.
 	if len(req.UserID) > 256 || len(req.SourceIP) > 45 ||
 		len(req.TargetHost) > 253 || len(req.LoginType) > 16 {
+		// Audited by length rather than by value: this branch exists to stop a
+		// client flooding the log with megabyte fields, so writing them into the
+		// audit trail would hand it the same amplification through another file.
+		b.auditLogger.LogAuthEvent(security.AuditEvent{
+			EventType:    "authentication_denied",
+			Success:      false,
+			ErrorCode:    "INVALID_REQUEST",
+			ErrorMessage: "request field exceeds maximum length",
+			Metadata: map[string]interface{}{
+				"user_id_len":     len(req.UserID),
+				"source_ip_len":   len(req.SourceIP),
+				"target_host_len": len(req.TargetHost),
+				"login_type_len":  len(req.LoginType),
+			},
+			Timestamp: time.Now(),
+		})
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "INVALID_REQUEST",
@@ -409,6 +501,12 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 			Str("user_id", req.UserID).
 			Int("max_sessions", maxSessions).
 			Msg("Maximum concurrent sessions reached for user")
+		// A capacity refusal is still a login that did not happen, and one an
+		// operator has to be able to tell apart from a policy denial — this is the
+		// host being full, not a decision about the identity.
+		event := b.denialEvent(req, "TOO_MANY_SESSIONS", "maximum concurrent sessions reached for this user")
+		event.Metadata["max_sessions"] = maxSessions
+		b.auditLogger.LogAuthEvent(event)
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "TOO_MANY_SESSIONS",
@@ -416,8 +514,31 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		}, nil
 	}
 
+	// Select the provider before evaluating policy: a provider-scoped time or
+	// geographic restriction cannot be applied without knowing which provider will
+	// serve the login, and taking the name from the request instead would let a
+	// client scope itself out of its own restrictions (#213). Selection depends on
+	// nothing in the policy result, so the order is free.
+	provider := b.selectProvider()
+	if provider == nil {
+		// Every login on the host fails this way, so the operator needs it in the
+		// trail alongside the refusals it looks nothing like: no provider is
+		// enabled_for_login, which is a configuration fault and not anything the
+		// user did.
+		log.Error().
+			Str("user_id", req.UserID).
+			Msg("No provider is enabled for login; refusing every authentication request")
+		b.auditLogger.LogAuthEvent(b.denialEvent(req, "NO_PROVIDER",
+			"no provider is enabled_for_login"))
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "NO_PROVIDER",
+			ErrorMessage: "No suitable authentication provider found",
+		}, nil
+	}
+
 	// Apply policy checks
-	policyResult, err := b.policyEngine.EvaluateRequest(req)
+	policyResult, err := b.policyEngine.EvaluateRequest(req, provider.Name)
 	if err != nil {
 		return nil, fmt.Errorf("policy evaluation failed: %w", err)
 	}
@@ -426,15 +547,17 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		if b.metrics != nil {
 			b.metrics.RecordAuth("", "policy_denied", "POLICY_DENIED")
 		}
-		b.auditLogger.LogAuthEvent(security.AuditEvent{
-			EventType:    "authentication_denied",
-			UserID:       req.UserID,
-			SourceIP:     req.SourceIP,
-			TargetHost:   req.TargetHost,
-			Success:      false,
-			ErrorMessage: policyResult.Reason,
-			Timestamp:    time.Now(),
-		})
+		// (#218) The record carries the code the client was given, the reason the
+		// engine gave, and the risk the decision was made on. The client is told
+		// only "Access denied by policy" — deliberately, since the reason names
+		// configuration — so this event is the only place the answer to "why was
+		// this login refused" exists.
+		event := b.denialEvent(req, "POLICY_DENIED", policyResult.Reason)
+		event.Provider = provider.Name
+		event.RiskScore = policyResult.RiskScore
+		event.RiskFactors = policyResult.RiskFactors
+		event.PolicyViolations = []string{policyResult.Reason}
+		b.auditLogger.LogAuthEvent(event)
 
 		log.Warn().
 			Str("user_id", req.UserID).
@@ -465,16 +588,6 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 			Metadata:     map[string]interface{}{"login_type": req.LoginType},
 			Timestamp:    time.Now(),
 		})
-	}
-
-	// Select appropriate provider
-	provider := b.selectProvider()
-	if provider == nil {
-		return &AuthResponse{
-			Success:      false,
-			ErrorCode:    "NO_PROVIDER",
-			ErrorMessage: "No suitable authentication provider found",
-		}, nil
 	}
 
 	// Initiate device flow
@@ -510,21 +623,28 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate session ID: %w", err)
 	}
+	createdAt := time.Now()
 	session := &Session{
-		ID:               sessionID,
-		UserID:           req.UserID,
-		Provider:         provider.Name,
-		LoginType:        req.LoginType,
-		DeviceID:         req.DeviceID,
-		CreatedAt:        time.Now(),
-		ExpiresAt:        time.Now().Add(b.config.Authentication.TokenLifetime),
-		LastAccessed:     time.Now(),
-		SourceIP:         req.SourceIP,
-		UserAgent:        req.UserAgent,
-		TokenFingerprint: deviceFlow.DeviceCode,
-		IsActive:         false,
-		RiskScore:        policyResult.RiskScore,
-		Metadata:         req.Metadata,
+		ID:        sessionID,
+		UserID:    req.UserID,
+		Provider:  provider.Name,
+		LoginType: req.LoginType,
+		DeviceID:  req.DeviceID,
+		CreatedAt: createdAt,
+		// (#212) sessionExpiry applies policyResult.MaxDuration — the minimum
+		// max_session_duration across every matching policy. It was computed on
+		// every login and then discarded, so `max_session_duration: 30m` on a sudo
+		// policy produced a session that lived for the full token_lifetime.
+		ExpiresAt:          b.sessionExpiry(createdAt, createdAt, policyResult.MaxDuration),
+		MaxDuration:        policyResult.MaxDuration,
+		LastAccessed:       createdAt,
+		SourceIP:           req.SourceIP,
+		UserAgent:          req.UserAgent,
+		TokenFingerprint:   deviceFlow.DeviceCode,
+		IsActive:           false,
+		RequireDeviceTrust: policyResult.Metadata[MetadataRequireDeviceTrust] == true,
+		RiskScore:          policyResult.RiskScore,
+		Metadata:           req.Metadata,
 	}
 
 	b.setSession(session)
@@ -534,6 +654,14 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 	if atomic.AddInt64(&b.pendingFlows, 1) > maxPendingFlows {
 		atomic.AddInt64(&b.pendingFlows, -1)
 		b.removeSession(session.ID)
+		// The host, not this user: without the record there is nothing to alert on
+		// when a flood of unfinished flows starts refusing everyone's logins, which
+		// is the condition this cap exists to survive (#163).
+		event := b.denialEvent(req, "RATE_LIMITED", "too many pending device authorization flows on this host")
+		event.SessionID = session.ID
+		event.Provider = provider.Name
+		event.Metadata["max_pending_flows"] = maxPendingFlows
+		b.auditLogger.LogAuthEvent(event)
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "RATE_LIMITED",
@@ -579,6 +707,7 @@ func (b *Broker) CheckSession(sessionID, userID string) (*AuthResponse, error) {
 	}
 
 	if session.UserID != userID {
+		b.auditCrossUserAttempt("check_session", sessionID, userID, session.UserID)
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "FORBIDDEN",
@@ -611,11 +740,25 @@ func (b *Broker) CheckSession(sessionID, userID string) (*AuthResponse, error) {
 	// Clone before mutation to avoid a data race: getSession returns the raw
 	// pointer stored in the map, so writing to it without a lock races with
 	// any concurrent reader that also holds that pointer.
+	//
+	// The store is conditional. If the session was revoked or swept between the
+	// checks above and here, replaceSession refuses the write rather than putting
+	// a revoked session back into the map (#217).
 	updated := *session
 	updated.LastAccessed = time.Now()
-	b.setSession(&updated)
+	if !b.replaceSession(session, &updated) {
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "SESSION_NOT_FOUND",
+			ErrorMessage: "Session not found",
+		}, nil
+	}
 
-	return b.createSuccessResponse(session), nil
+	// The response is built from the clone, not from the pointer that was read.
+	// Reading `session` here handed the caller a last_accessed from before this
+	// check, and would read whatever a future in-place mutation happened to leave
+	// there (#215).
+	return b.createSuccessResponse(&updated), nil
 }
 
 // RefreshSession refreshes an authentication session.
@@ -631,11 +774,65 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 	}
 
 	if session.UserID != userID {
+		b.auditCrossUserAttempt("refresh_session", sessionID, userID, session.UserID)
 		return &AuthResponse{
 			Success:      false,
 			ErrorCode:    "FORBIDDEN",
 			ErrorMessage: "session does not belong to requesting user",
 		}, nil
+	}
+
+	// (#215) A session that was never authorized is not refreshable, and this is
+	// checked before anything else that could answer with a success response.
+	//
+	// A device-flow session is stored with IsActive: false and an ExpiresAt one
+	// token lifetime out, and is only flipped active when the flow completes. Every
+	// check this function used to make was satisfied by such a session, so the
+	// "close to expiry" branch below returned createSuccessResponse for a login
+	// nobody had approved — a `success: true` for an identity that had not
+	// authenticated. CheckSession has always reported these as pending; refresh
+	// reported them as authorized.
+	if !session.IsActive {
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "SESSION_NOT_ACTIVE",
+			ErrorMessage: "session has not completed authentication",
+		}, nil
+	}
+
+	// An expired session is not refreshed back to life. Without this, ExpiresAt in
+	// the past made time.Until negative, the early return below was skipped, and
+	// the session was renewed — so expiry bounded nothing for a client that kept
+	// calling, and neither did max_session_duration.
+	if session.ExpiresAt.Before(time.Now()) {
+		b.removeSession(sessionID)
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "SESSION_EXPIRED",
+			ErrorMessage: "Session has expired",
+		}, nil
+	}
+
+	// (#212) The session may not outlive the max_session_duration of the policy that
+	// admitted it. Once that point is reached the session ends; the user
+	// re-authenticates, which is the moment policy — group membership, network
+	// requirements, risk — is evaluated again from scratch.
+	if session.MaxDuration > 0 && !time.Now().Before(session.CreatedAt.Add(session.MaxDuration)) {
+		b.removeSession(sessionID)
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "SESSION_EXPIRED",
+			ErrorMessage: "Session has reached its maximum duration and must be re-authenticated",
+		}, nil
+	}
+
+	// (#215) Re-evaluate policy before extending. Policy used to be evaluated only
+	// when a login started, so removing a user from a required group, tightening an
+	// IP whitelist or adding a deny policy had no effect on a live session for as
+	// long as its client kept refreshing — and the SSH key's expiry-time= is derived
+	// from the same ExpiresAt, so the credential was extended too.
+	if response := b.denyIfPolicyNoLongerAllows(session); response != nil {
+		return response, nil
 	}
 
 	// Check if session is close to expiry
@@ -722,13 +919,35 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 
 	previousTokenID := session.TokenID
 
-	// Update session with new token data
-	session.TokenFingerprint = newToken.Fingerprint
-	session.TokenID = newTokenID
-	session.ExpiresAt = time.Now().Add(b.config.Authentication.TokenLifetime)
-	session.LastAccessed = time.Now()
+	// Clone before mutation, and store conditionally. Writing through the stored
+	// pointer raced every concurrent reader holding it, and an unconditional store
+	// would resurrect a session revoked while the provider round-trip above was in
+	// flight — the refresh takes up to 30 seconds, which is ample (#217).
+	now := time.Now()
+	updated := *session
+	updated.TokenFingerprint = newToken.Fingerprint
+	updated.TokenID = newTokenID
+	updated.ExpiresAt = b.sessionExpiry(session.CreatedAt, now, session.MaxDuration)
+	updated.LastAccessed = now
 
-	b.setSession(session)
+	if !b.replaceSession(session, &updated) {
+		// The session went away or was replaced while the provider was being called.
+		// The token that was just stored belongs to a session that no longer exists,
+		// so it is revoked rather than left in the store as usable credential
+		// material for a session nobody can reach.
+		if err := b.tokenManager.RevokeToken(newTokenID); err != nil {
+			log.Warn().
+				Err(err).
+				Str("session_id", sessionID).
+				Msg("Could not revoke the token stored for a session that was revoked mid-refresh")
+		}
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "SESSION_NOT_FOUND",
+			ErrorMessage: "Session not found",
+		}, nil
+	}
+	session = &updated
 
 	if previousTokenID != "" && previousTokenID != newTokenID {
 		if err := b.tokenManager.RevokeToken(previousTokenID); err != nil {
@@ -750,6 +969,108 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 	return b.createSuccessResponse(session), nil
 }
 
+// denyIfPolicyNoLongerAllows re-runs policy against a live session and returns a
+// denial response if the session would not be admitted today. It returns nil when
+// the session may continue.
+//
+// (#215) Policy used to be evaluated exactly once, when a login started. Every
+// control an operator can change afterwards — group membership, ip_whitelist,
+// allowed_hours, a country list, a risk denial — therefore had no effect on a
+// session already running, and a client that kept refreshing kept the session and
+// its SSH key alive indefinitely. Revocation worked only by an operator finding and
+// revoking the session by hand.
+//
+// The request is reconstructed from what the session recorded at login, because
+// that is what the broker knows: the same account, source address, device and
+// login type. What has changed since is the configuration, and that is the point.
+func (b *Broker) denyIfPolicyNoLongerAllows(session *Session) *AuthResponse {
+	if b.policyEngine == nil {
+		// NewBroker always builds an engine, so this is unreachable in a running
+		// broker. It is still a denial rather than a pass: "there is nothing to
+		// check against" and "the checks passed" are different answers, and only
+		// one of them is safe to give a caller asking to extend live access.
+		log.Error().
+			Str("session_id", session.ID).
+			Msg("Refresh requested on a broker with no policy engine; refusing")
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "POLICY_DENIED",
+			ErrorMessage: "Access denied by policy",
+		}
+	}
+
+	req := &AuthRequest{
+		UserID:    session.UserID,
+		SourceIP:  session.SourceIP,
+		UserAgent: session.UserAgent,
+		LoginType: session.LoginType,
+		DeviceID:  session.DeviceID,
+		SessionID: session.ID,
+		Timestamp: time.Now(),
+		Metadata:  session.Metadata,
+	}
+
+	policyResult, err := b.policyEngine.EvaluateRequest(req, session.Provider)
+	if err != nil {
+		// A policy engine that cannot answer is not permission to continue.
+		log.Error().
+			Err(err).
+			Str("session_id", session.ID).
+			Msg("Could not re-evaluate policy for a session being refreshed; refusing the refresh")
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    "POLICY_DENIED",
+			ErrorMessage: "Access denied by policy",
+		}
+	}
+
+	denial := ""
+	switch {
+	case !policyResult.Allowed:
+		denial = policyResult.Reason
+	default:
+		// Group membership is checked against the groups the identity had at login:
+		// re-reading them would need a fresh token exchange, which is what the next
+		// login does. A group *requirement* added since the login is enforced here
+		// and now, which is the case an operator tightening access is relying on.
+		if err := b.verifyRequiredGroups(policyResult.RequiredGroups, session.Groups); err != nil {
+			denial = err.Error()
+		}
+	}
+	if denial == "" {
+		return nil
+	}
+
+	b.auditLogger.LogAuthEvent(security.AuditEvent{
+		EventType:    "session_refresh_denied",
+		UserID:       session.UserID,
+		SessionID:    session.ID,
+		SourceIP:     session.SourceIP,
+		Success:      false,
+		ErrorCode:    "POLICY_DENIED",
+		ErrorMessage: denial,
+		RiskScore:    policyResult.RiskScore,
+		RiskFactors:  policyResult.RiskFactors,
+		Timestamp:    time.Now(),
+	})
+	log.Warn().
+		Str("user_id", session.UserID).
+		Str("session_id", session.ID).
+		Str("reason", denial).
+		Msg("Refusing to refresh a session that policy no longer allows")
+
+	// The session is dropped, not merely refused a renewal: policy says this
+	// identity may not have this access, and leaving the session live until its own
+	// expiry would leave the SSH key installed for that whole window.
+	b.removeSession(session.ID)
+
+	return &AuthResponse{
+		Success:      false,
+		ErrorCode:    "POLICY_DENIED",
+		ErrorMessage: "Access denied by policy",
+	}
+}
+
 // RevokeSession revokes an authentication session.
 // userID must match the session owner — cross-user revocation is rejected.
 func (b *Broker) RevokeSession(sessionID, userID string) error {
@@ -759,6 +1080,7 @@ func (b *Broker) RevokeSession(sessionID, userID string) error {
 	}
 
 	if session.UserID != userID {
+		b.auditCrossUserAttempt("revoke_session", sessionID, userID, session.UserID)
 		return fmt.Errorf("session does not belong to requesting user")
 	}
 
@@ -832,6 +1154,55 @@ func (b *Broker) setSession(session *Session) {
 	b.sessionMutex.Lock()
 	defer b.sessionMutex.Unlock()
 	b.sessions[session.ID] = session
+}
+
+// replaceSession stores updated only if sessionID still maps to the exact session
+// that was read, and reports whether it did.
+//
+// (#217) Pointer identity is the comparison, deliberately. Every path that
+// invalidates a session either deletes it from the map — RevokeSession,
+// removeSession, expireSessions — or replaces it with a fresh copy, because no
+// path mutates a stored session in place any more. So "the pointer I read is still
+// the pointer stored" is exactly "nothing has happened to this session since I
+// read it", which is the condition a read-modify-write needs and which re-reading
+// the fields cannot establish.
+//
+// The device-flow completion path is why this exists. It read the session when the
+// login started, worked for up to the whole device-flow lifetime, and then wrote
+// IsActive: true unconditionally — so a session an operator had revoked, or one the
+// sweep had expired, came back as a fully active session, and the SSH key was
+// installed for it. Last writer won, and the late writer was the one asserting
+// authorization.
+func (b *Broker) replaceSession(previous, updated *Session) bool {
+	b.sessionMutex.Lock()
+	defer b.sessionMutex.Unlock()
+	if b.sessions[updated.ID] != previous {
+		return false
+	}
+	b.sessions[updated.ID] = updated
+	return true
+}
+
+// sessionExpiry is when a session created at createdAt and being (re)issued at now
+// must expire.
+//
+// It is the earlier of one token lifetime from now and maxDuration from the
+// session's creation. The second term is what makes max_session_duration a limit
+// rather than a suggestion (#212): without it a client that keeps refreshing
+// extends a session forever, so a 30-minute cap on a sudo policy bounded nothing,
+// and neither did the removal of a user from a group — the session simply never
+// reached an expiry at which the removal could take effect.
+//
+// A zero maxDuration means the policies set no limit.
+func (b *Broker) sessionExpiry(createdAt, now time.Time, maxDuration time.Duration) time.Time {
+	expiry := now.Add(b.config.Authentication.TokenLifetime)
+	if maxDuration <= 0 {
+		return expiry
+	}
+	if hardLimit := createdAt.Add(maxDuration); hardLimit.Before(expiry) {
+		return hardLimit
+	}
+	return expiry
 }
 
 func (b *Broker) removeSession(sessionID string) {
@@ -1119,6 +1490,38 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 				return
 			}
 
+			// (#212) require_device_trust, enforced. A matching policy asked for a
+			// trusted device; DeviceTrusted is set from the token's amr claim
+			// containing a hardware-key or FIDO method, and this is the first point in
+			// the login where that claim exists. The setting used to write a metadata
+			// key nothing read, so `require_device_trust: true` — present in every
+			// shipped provider configuration — admitted any device.
+			if session.RequireDeviceTrust && !userInfo.DeviceTrusted {
+				log.Warn().
+					Str("session_id", session.ID).
+					Str("requested_user", session.UserID).
+					Msg("Rejected authentication: a matching policy requires a trusted device and this " +
+						"identity did not authenticate with a hardware-backed method")
+				if b.metrics != nil {
+					b.metrics.RecordAuth(provider.Name, "failure", "DEVICE_NOT_TRUSTED")
+				}
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType: "authentication_denied",
+					UserID:    session.UserID,
+					Email:     userInfo.Email,
+					Groups:    userInfo.Groups,
+					SessionID: session.ID,
+					Provider:  provider.Name,
+					Success:   false,
+					ErrorCode: "DEVICE_NOT_TRUSTED",
+					ErrorMessage: "require_device_trust is set for this host and the token's amr claim " +
+						"reports no hardware-backed or FIDO authentication method",
+					Timestamp: time.Now(),
+				})
+				b.removeSession(session.ID)
+				return
+			}
+
 			// Hand the tokens to the token manager, which encrypts them with
 			// AES-256-GCM, and keep only its ID on the session. The session must
 			// never carry the refresh token itself: it is a long-lived credential,
@@ -1200,7 +1603,55 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 				updated.SSHPublicKey = sshKey.PublicKey
 			}
 
-			b.setSession(&updated)
+			// (#217) Store only if this session is still the session that was read.
+			// The device flow can run for its whole lifetime before reaching here, and
+			// during that time the session can be revoked by an operator or swept for
+			// expiry — after which writing IsActive: true unconditionally brought it
+			// back as a fully active session, with an SSH key installed for it, and
+			// the operator who revoked it had no way to know.
+			if !b.replaceSession(session, &updated) {
+				log.Warn().
+					Str("session_id", updated.ID).
+					Str("user_id", updated.UserID).
+					Msg("Device authorization completed for a session that was revoked or expired " +
+						"in the meantime; refusing to activate it")
+				if b.metrics != nil {
+					b.metrics.RecordAuth(provider.Name, "failure", "SESSION_GONE")
+				}
+				// Undo what completing the flow just created. The SSH key was installed
+				// in the account's authorized_keys a few lines above, so leaving it would
+				// leave a usable credential for a session that will never exist — the
+				// exact shape of #171.
+				if updated.SSHKeyID != "" {
+					if err := b.revokeSSHKey(&updated); err != nil {
+						log.Error().
+							Err(err).
+							Str("session_id", updated.ID).
+							Str("ssh_key_id", updated.SSHKeyID).
+							Msg("Failed to revoke the SSH key issued to a session that was revoked mid-flow")
+					}
+				}
+				if err := b.tokenManager.RevokeSessionTokens(updated.ID); err != nil {
+					log.Error().
+						Err(err).
+						Str("session_id", updated.ID).
+						Msg("Failed to revoke tokens stored for a session that was revoked mid-flow")
+				}
+				b.auditLogger.LogAuthEvent(security.AuditEvent{
+					EventType: "authentication_denied",
+					UserID:    updated.UserID,
+					Email:     updated.Email,
+					Groups:    updated.Groups,
+					SessionID: updated.ID,
+					Provider:  provider.Name,
+					Success:   false,
+					ErrorCode: "SESSION_GONE",
+					ErrorMessage: "the session was revoked or expired before device authorization " +
+						"completed; the issued key and tokens were withdrawn",
+					Timestamp: time.Now(),
+				})
+				return
+			}
 
 			if b.metrics != nil {
 				b.metrics.RecordAuth(provider.Name, "success", "")

--- a/pkg/auth/broker_core_test.go
+++ b/pkg/auth/broker_core_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
 )
 
 // Test core broker functionality with minimal mocking
@@ -38,11 +39,20 @@ func TestBrokerCoreAuthenticate(t *testing.T) {
 		t.Fatalf("Failed to create policy engine: %v", err)
 	}
 
+	// An audit logger, because every branch that refuses a login now records it
+	// (#218) and NewBroker always builds one — a hand-assembled broker without one
+	// only tests a shape the running broker never has.
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{Enabled: false})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
 	broker := &Broker{
 		config:       cfg,
 		providers:    make(map[string]*OIDCProvider),
 		sessions:     make(map[string]*Session),
 		policyEngine: policyEngine,
+		auditLogger:  auditLogger,
 	}
 
 	// Skip nil test - function doesn't handle nil requests gracefully
@@ -105,7 +115,7 @@ func TestPolicyEngineEvaluateCore(t *testing.T) {
 	}
 
 	// Test evaluation with nil request
-	result, err := policyEngine.EvaluateRequest(nil)
+	result, err := policyEngine.EvaluateRequest(nil, "")
 	if err != nil {
 		t.Logf("EvaluateRequest returned error for nil request: %v", err)
 	}
@@ -115,7 +125,7 @@ func TestPolicyEngineEvaluateCore(t *testing.T) {
 
 	// Test evaluation with empty request
 	emptyRequest := &AuthRequest{}
-	result, err = policyEngine.EvaluateRequest(emptyRequest)
+	result, err = policyEngine.EvaluateRequest(emptyRequest, "")
 	if err != nil {
 		t.Logf("EvaluateRequest returned error for empty request: %v", err)
 	}
@@ -131,7 +141,7 @@ func TestPolicyEngineEvaluateCore(t *testing.T) {
 		LoginType:  "ssh",
 		Timestamp:  time.Now(),
 	}
-	result, err = policyEngine.EvaluateRequest(validRequest)
+	result, err = policyEngine.EvaluateRequest(validRequest, "")
 	if err != nil {
 		t.Logf("EvaluateRequest returned error for valid request: %v", err)
 	}

--- a/pkg/auth/broker_session_test.go
+++ b/pkg/auth/broker_session_test.go
@@ -437,15 +437,18 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 
 	tokenManager := newTestTokenManager(t)
 
-	broker := &Broker{
-		config: &config.Config{
-			Authentication: config.AuthenticationConfig{
-				TokenLifetime:    time.Hour,
-				RefreshThreshold: 15 * time.Minute,
-			},
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:    time.Hour,
+			RefreshThreshold: 15 * time.Minute,
 		},
+	}
+
+	broker := &Broker{
+		config:       cfg,
 		sessions:     make(map[string]*Session),
 		sessionMutex: sync.RWMutex{},
+		policyEngine: newTestPolicyEngine(t, cfg),
 		providers:    map[string]*OIDCProvider{"test-provider": provider},
 		auditLogger:  auditLogger,
 		tokenManager: tokenManager,
@@ -518,15 +521,18 @@ func TestBrokerRefreshSessionNoRefreshToken(t *testing.T) {
 		t.Fatalf("Failed to create audit logger: %v", err)
 	}
 
-	broker := &Broker{
-		config: &config.Config{
-			Authentication: config.AuthenticationConfig{
-				TokenLifetime:    time.Hour,
-				RefreshThreshold: 15 * time.Minute,
-			},
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:    time.Hour,
+			RefreshThreshold: 15 * time.Minute,
 		},
+	}
+
+	broker := &Broker{
+		config:       cfg,
 		sessions:     make(map[string]*Session),
 		sessionMutex: sync.RWMutex{},
+		policyEngine: newTestPolicyEngine(t, cfg),
 		providers:    map[string]*OIDCProvider{"test-provider": {}},
 		auditLogger:  auditLogger,
 	}
@@ -557,15 +563,18 @@ func TestBrokerRefreshSessionNoRefreshToken(t *testing.T) {
 func TestBrokerRefreshSessionNotCloseToExpiry(t *testing.T) {
 	// Session not yet within the refresh threshold — RefreshSession should return success
 	// without hitting the token endpoint.
-	broker := &Broker{
-		config: &config.Config{
-			Authentication: config.AuthenticationConfig{
-				TokenLifetime:    time.Hour,
-				RefreshThreshold: 15 * time.Minute,
-			},
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:    time.Hour,
+			RefreshThreshold: 15 * time.Minute,
 		},
+	}
+
+	broker := &Broker{
+		config:       cfg,
 		sessions:     make(map[string]*Session),
 		sessionMutex: sync.RWMutex{},
+		policyEngine: newTestPolicyEngine(t, cfg),
 		providers:    map[string]*OIDCProvider{},
 	}
 
@@ -610,6 +619,21 @@ func TestAuthenticateSessionIDUniqueness(t *testing.T) {
 		}
 		seen[resp.SessionID] = true
 	}
+}
+
+// newTestPolicyEngine builds an engine through the real constructor, so tests that
+// hand-assemble a Broker get the same startup validation and policy compilation a
+// running broker has. RefreshSession re-evaluates policy (#215), so a broker
+// without an engine is refused rather than passed — meaning these tests need a
+// real one to reach the paths they are about.
+func newTestPolicyEngine(t *testing.T, cfg *config.Config) *PolicyEngine {
+	t.Helper()
+
+	pe, err := NewPolicyEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	return pe
 }
 
 // newTestTokenManager returns a TokenManager with a valid AES-256 key, for tests

--- a/pkg/auth/denial_audit_test.go
+++ b/pkg/auth/denial_audit_test.go
@@ -1,0 +1,342 @@
+package auth
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/testoidc"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+)
+
+// TestEveryRefusedLoginIsAuditedWithItsErrorCode is the acceptance gate for #218.
+//
+// Every branch of Authenticate that answers with a failure has to leave a record
+// carrying the same error_code the client was given. Before this, a policy denial
+// was audited without its code and the four other refusals were not audited at all,
+// so the events an incident responder most needs — who was refused, and why — were
+// the ones the broker did not keep. A user with a valid IdP account but no group
+// membership could be denied on every host on the network and leave nothing behind
+// to count: sshd's log does not record which OIDC identity was refused, and the
+// broker's log is not the audit trail.
+//
+// Driven through Authenticate rather than by asserting on the helpers, because the
+// defect was branches that never reached a helper at all.
+func TestEveryRefusedLoginIsAuditedWithItsErrorCode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// wantCode is asserted on both the response and the audit record: a record
+		// with a different code than the client got is a trail that cannot be joined
+		// to the failure the user reported.
+		wantCode string
+		// wantReasonHas is what the record has to say about why, since the client is
+		// told only that it was refused.
+		wantReasonHas string
+		setup         func(t *testing.T, env *denialTestEnv)
+		req           *AuthRequest
+	}{
+		{
+			name:          "a field longer than the broker will read",
+			wantCode:      "INVALID_REQUEST",
+			wantReasonHas: "maximum length",
+			req:           &AuthRequest{UserID: strings.Repeat("u", 257), LoginType: "ssh"},
+		},
+		{
+			name:          "no provider is enabled for login",
+			wantCode:      "NO_PROVIDER",
+			wantReasonHas: "enabled_for_login",
+			setup: func(_ *testing.T, env *denialTestEnv) {
+				env.broker.providers = map[string]*OIDCProvider{}
+			},
+			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
+		},
+		{
+			name:          "the user is at their concurrent session limit",
+			wantCode:      "TOO_MANY_SESSIONS",
+			wantReasonHas: "concurrent sessions",
+			setup: func(_ *testing.T, env *denialTestEnv) {
+				env.broker.config.Authentication.MaxConcurrentSessions = 1
+				env.broker.setSession(&Session{
+					ID:        "already-logged-in",
+					UserID:    "testuser",
+					IsActive:  true,
+					CreatedAt: time.Now(),
+					ExpiresAt: time.Now().Add(time.Hour),
+				})
+			},
+			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
+		},
+		{
+			name:          "policy no longer allows this identity",
+			wantCode:      "POLICY_DENIED",
+			wantReasonHas: "ip_whitelist",
+			setup: func(t *testing.T, env *denialTestEnv) {
+				env.broker.config.Authentication.Policies = map[string]config.AuthenticationPolicy{
+					"default": {IPWhitelist: []string{"10.0.0.0/8"}},
+				}
+				env.broker.policyEngine = newTestPolicyEngine(t, env.broker.config)
+			},
+			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
+		},
+		{
+			name:          "the host is at its device-flow cap",
+			wantCode:      "RATE_LIMITED",
+			wantReasonHas: "pending device authorization flows",
+			setup: func(_ *testing.T, env *denialTestEnv) {
+				// The cap is checked after the flow is started, so this is the state a
+				// host under a flood of unfinished logins is in.
+				atomic.StoreInt64(&env.broker.pendingFlows, 100)
+			},
+			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newDenialTestEnv(t)
+			if tc.setup != nil {
+				tc.setup(t, env)
+			}
+
+			resp, err := env.broker.Authenticate(tc.req)
+			if err != nil {
+				t.Fatalf("Authenticate: %v", err)
+			}
+			if resp.Success {
+				t.Fatalf("the request was not refused: %+v", resp)
+			}
+			if resp.ErrorCode != tc.wantCode {
+				t.Fatalf("response error_code = %q, want %q", resp.ErrorCode, tc.wantCode)
+			}
+
+			events := auditEventsAt(t, env.auditPath)
+			var denial *security.AuditEvent
+			for i := range events {
+				if events[i].EventType == "authentication_denied" {
+					denial = &events[i]
+				}
+			}
+			if denial == nil {
+				var seen []string
+				for _, e := range events {
+					seen = append(seen, e.EventType)
+				}
+				t.Fatalf("a refused login left no authentication_denied record; the trail holds %v (#218)", seen)
+			}
+			if denial.ErrorCode != tc.wantCode {
+				t.Errorf("audited error_code = %q, want the %q the client was given: a record that does "+
+					"not carry the client's code cannot be joined to the failure the user reported",
+					denial.ErrorCode, tc.wantCode)
+			}
+			if denial.Success {
+				t.Error("the refusal is recorded with success=true")
+			}
+			if !strings.Contains(denial.ErrorMessage, tc.wantReasonHas) {
+				t.Errorf("audited reason %q does not mention %q, so the record does not say why the "+
+					"login was refused", denial.ErrorMessage, tc.wantReasonHas)
+			}
+		})
+	}
+}
+
+// TestPolicyDenialRecordsWhatItWasDecidedOn covers the rest of what #218 asks the
+// policy record to carry. The reason alone does not let an operator tell a
+// deliberate denial from a risk-scoring surprise, and the risk score is not
+// recoverable afterwards — it is computed from the request and the time of day.
+func TestPolicyDenialRecordsWhatItWasDecidedOn(t *testing.T) {
+	env := newDenialTestEnv(t)
+	env.broker.config.Authentication.RiskPolicies = []config.RiskPolicy{
+		// No recommendation: the reason has to name the rule that fired anyway.
+		{Condition: "risk_score >= 0", Action: "DENY"},
+	}
+	env.broker.policyEngine = newTestPolicyEngine(t, env.broker.config)
+
+	resp, err := env.broker.Authenticate(&AuthRequest{
+		UserID:    "testuser",
+		SourceIP:  "192.0.2.10",
+		LoginType: "ssh",
+	})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.ErrorCode != "POLICY_DENIED" {
+		t.Fatalf("error_code = %q, want POLICY_DENIED", resp.ErrorCode)
+	}
+	// The reason names configuration, so it stays out of the reply and lives only in
+	// the trail.
+	if strings.Contains(resp.ErrorMessage, "risk_score") {
+		t.Errorf("the reply repeats the policy that refused it (%q); the reason is for the audit log, "+
+			"not the client", resp.ErrorMessage)
+	}
+
+	var denial *security.AuditEvent
+	for _, event := range auditEventsAt(t, env.auditPath) {
+		if event.EventType == "authentication_denied" {
+			e := event
+			denial = &e
+		}
+	}
+	if denial == nil {
+		t.Fatal("the policy denial was not audited")
+	}
+	if !strings.Contains(denial.ErrorMessage, "risk_score >= 0") {
+		t.Errorf("audited reason %q does not name the risk policy that fired, so an operator cannot "+
+			"tell which rule refused the login", denial.ErrorMessage)
+	}
+	if denial.Provider != "testidp" {
+		t.Errorf("audited provider = %q, want testidp", denial.Provider)
+	}
+	if len(denial.PolicyViolations) == 0 {
+		t.Error("the record carries no policy_violations, so a search for denials by rule finds nothing")
+	}
+	if got := denial.Metadata["login_type"]; got != "ssh" {
+		t.Errorf("audited login_type = %v, want ssh", got)
+	}
+}
+
+// TestReachingForSomeoneElsesSessionIsAudited covers the three session verbs. Each
+// already refused a caller asking about an account other than its own, and refused
+// it silently — so the one thing here that is unambiguously an attack, since nobody
+// reaches another user's 64-hex session ID by accident, was the least visible thing
+// the broker did (#218).
+func TestReachingForSomeoneElsesSessionIsAudited(t *testing.T) {
+	const (
+		sessionID = "3f0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8"
+		owner     = "alice"
+		attacker  = "bob"
+	)
+
+	for _, tc := range []struct {
+		verb string
+		// refuse asserts the verb refused the caller, in whatever way that verb
+		// answers: two return an AuthResponse, RevokeSession returns an error.
+		refuse func(t *testing.T, b *Broker)
+	}{
+		{
+			verb: "check_session",
+			refuse: func(t *testing.T, b *Broker) {
+				resp, err := b.CheckSession(sessionID, attacker)
+				if err != nil {
+					t.Fatalf("CheckSession: %v", err)
+				}
+				if resp.Success || resp.ErrorCode != "FORBIDDEN" {
+					t.Fatalf("CheckSession answered another user's session: %+v", resp)
+				}
+			},
+		},
+		{
+			verb: "refresh_session",
+			refuse: func(t *testing.T, b *Broker) {
+				resp, err := b.RefreshSession(sessionID, attacker)
+				if err != nil {
+					t.Fatalf("RefreshSession: %v", err)
+				}
+				if resp.Success || resp.ErrorCode != "FORBIDDEN" {
+					t.Fatalf("RefreshSession extended another user's session: %+v", resp)
+				}
+			},
+		},
+		{
+			verb: "revoke_session",
+			refuse: func(t *testing.T, b *Broker) {
+				if err := b.RevokeSession(sessionID, attacker); err == nil {
+					t.Fatal("RevokeSession let a caller revoke another user's session")
+				}
+			},
+		},
+	} {
+		t.Run(tc.verb, func(t *testing.T) {
+			session := &Session{
+				ID:        sessionID,
+				UserID:    owner,
+				IsActive:  true,
+				CreatedAt: time.Now(),
+				ExpiresAt: time.Now().Add(time.Hour),
+			}
+			broker, auditPath := refreshTestBroker(t, refreshTestConfig(), session)
+
+			tc.refuse(t, broker)
+
+			// Refused, and the owner's session untouched.
+			if got := broker.getSession(sessionID); got == nil {
+				t.Fatalf("%s by a caller who does not own the session removed it", tc.verb)
+			}
+
+			var denial *security.AuditEvent
+			for _, event := range auditEventsAt(t, auditPath) {
+				if event.EventType == "session_access_denied" {
+					e := event
+					denial = &e
+				}
+			}
+			if denial == nil {
+				t.Fatalf("%s refused a caller reaching for another user's session and recorded nothing "+
+					"(#218)", tc.verb)
+			}
+			if denial.UserID != attacker {
+				t.Errorf("audited user_id = %q, want the caller %q", denial.UserID, attacker)
+			}
+			if denial.SessionID != sessionID {
+				t.Errorf("audited session_id = %q, want %q", denial.SessionID, sessionID)
+			}
+			if got := denial.Metadata["session_owner"]; got != owner {
+				t.Errorf("audited session_owner = %v, want %q: without it the record does not say whose "+
+					"account was reached for", got, owner)
+			}
+			if got := denial.Metadata["request_type"]; got != tc.verb {
+				t.Errorf("audited request_type = %v, want %q", got, tc.verb)
+			}
+			if denial.ErrorCode != "FORBIDDEN" {
+				t.Errorf("audited error_code = %q, want FORBIDDEN", denial.ErrorCode)
+			}
+		})
+	}
+}
+
+// denialTestEnv is a broker that can reach every deny branch of Authenticate: a real
+// provider (so provider selection succeeds), a real policy engine, and a file-backed
+// audit logger to read the record back out of.
+type denialTestEnv struct {
+	broker    *Broker
+	auditPath string
+}
+
+func newDenialTestEnv(t *testing.T) *denialTestEnv {
+	t.Helper()
+
+	const clientID = "oidc-pam-test-client"
+	idp := testoidc.New(t, clientID)
+
+	secCfg := config.SecurityConfig{
+		TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+	}
+	provider, err := NewOIDCProvider(config.OIDCProvider{
+		Name:            "testidp",
+		Issuer:          idp.Issuer(),
+		ClientID:        clientID,
+		Scopes:          []string{"openid", "profile", "email"},
+		EnabledForLogin: true,
+		UserMapping:     config.UserMapping{UsernameClaim: "preferred_username"},
+	}, secCfg)
+	if err != nil {
+		t.Fatalf("NewOIDCProvider: %v", err)
+	}
+
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:    time.Hour,
+			RefreshThreshold: 15 * time.Minute,
+		},
+		Security: secCfg,
+	}
+
+	broker, auditPath := refreshTestBroker(t, cfg, &Session{
+		ID:     "unrelated-session",
+		UserID: "someone-else",
+	})
+	broker.providers = map[string]*OIDCProvider{"testidp": provider}
+	broker.stopChan = make(chan struct{})
+	t.Cleanup(func() { broker.wg.Wait() })
+
+	return &denialTestEnv{broker: broker, auditPath: auditPath}
+}

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -579,7 +579,7 @@ func TestPerPolicyRequireGroupsIsEnforced(t *testing.T) {
 		LoginType:  "ssh",
 		SourceIP:   "192.0.2.10",
 		TargetHost: "some-client.example.net", // what a client actually sends
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("EvaluateRequest: %v", err)
 	}
@@ -649,7 +649,7 @@ func TestResourcePolicyMatchesTheResourceNotTheClient(t *testing.T) {
 			engine := &PolicyEngine{config: policyCfg, resourceHost: tc.resourceHost}
 			result, err := engine.EvaluateRequest(&AuthRequest{
 				UserID: "testuser", LoginType: "ssh", TargetHost: tc.targetHost,
-			})
+			}, "")
 			if err != nil {
 				t.Fatalf("EvaluateRequest: %v", err)
 			}
@@ -679,6 +679,9 @@ func TestQuickStartConfigEnforcesItsRequiredGroups(t *testing.T) {
 	// (#170) It said `session_duration`, which is not a field of a policy; the
 	// loader dropped it in silence then and refuses it now, so the doc says
 	// max_session_duration.
+	// (#212) It also said `audit_level: "standard"`, which nothing has ever read.
+	// The broker now refuses to start on it rather than reporting an audit level it
+	// does not apply, so the doc no longer offers it.
 	const quickStartAuth = `
 authentication:
   token_lifetime: "8h"
@@ -686,7 +689,6 @@ authentication:
     default:
       require_groups: ["users"]
       max_session_duration: "8h"
-      audit_level: "standard"
 `
 	configPath := filepath.Join(t.TempDir(), "broker.yaml")
 	if err := os.WriteFile(configPath, []byte(quickStartAuth), 0o600); err != nil {
@@ -719,7 +721,7 @@ authentication:
 		LoginType:  "ssh",
 		SourceIP:   "192.0.2.10",
 		TargetHost: "some-client.example.net",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("EvaluateRequest: %v", err)
 	}

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -25,6 +25,41 @@ type PolicyEngine struct {
 	// machine, the resource being logged into. It is deliberately not taken from
 	// the request — see applyResourcePolicies (#158).
 	resourceHost string
+
+	// riskPolicies are the configured risk policies with their conditions already
+	// parsed. Parsing at startup rather than per login is what makes a
+	// misconfigured condition a startup failure instead of a policy that silently
+	// never matches (#213).
+	riskPolicies []parsedRiskPolicy
+
+	// timeRestrictions and geoRestrictions are the configured restrictions with
+	// their windows parsed and their provider scopes resolved, for the same reason.
+	timeRestrictions []parsedTimeRestriction
+	geoRestrictions  []parsedGeoRestriction
+}
+
+// parsedRiskPolicy is a risk policy the engine has fully understood.
+type parsedRiskPolicy struct {
+	condition      riskCondition
+	action         string
+	recommendation string
+}
+
+// parsedTimeRestriction is a time restriction with its window parsed and its
+// timezone resolved.
+type parsedTimeRestriction struct {
+	providers []string
+	window    hourWindow
+	location  *time.Location
+	raw       string
+}
+
+// parsedGeoRestriction is a geographic restriction with its provider scope kept
+// alongside its country lists.
+type parsedGeoRestriction struct {
+	providers        []string
+	allowedCountries []string
+	blockedCountries []string
 }
 
 // SetMetrics attaches a Metrics instance to the policy engine.
@@ -34,9 +69,12 @@ func (pe *PolicyEngine) SetMetrics(m *oidcmetrics.Metrics) {
 
 // PolicyResult represents the result of policy evaluation
 type PolicyResult struct {
-	Allowed        bool
-	Reason         string
-	RequiredMFA    bool
+	Allowed bool
+	Reason  string
+	// (#212) There is no RequiredMFA field. It had no reader, and the two settings
+	// that wrote it — a policy's require_additional_mfa and a risk policy's
+	// REQUIRE_ADDITIONAL_MFA action — are now refused at startup rather than
+	// silently doing nothing. Reinstate it together with the code that acts on it.
 	RequiredGroups []string
 	MaxDuration    time.Duration
 	RiskScore      int
@@ -47,6 +85,19 @@ type PolicyResult struct {
 // NewPolicyEngine creates a new policy engine
 func NewPolicyEngine(cfg *config.Config) (*PolicyEngine, error) {
 	pe := &PolicyEngine{config: cfg}
+
+	// (#212) Before anything else: refuse a configuration whose access controls
+	// this broker cannot enforce. Every check below is only worth running if the
+	// operator's stated policy and the code's behaviour are the same thing.
+	if err := validatePolicySupport(cfg); err != nil {
+		return nil, err
+	}
+	if err := pe.compilePolicies(); err != nil {
+		// Unreachable if validatePolicySupport is complete; returned rather than
+		// ignored so that a gap between the two is a startup failure and not a
+		// policy that silently never matches.
+		return nil, err
+	}
 
 	if cfg != nil && cfg.Authentication.GeoIPDatabasePath != "" {
 		db, err := geoip2.Open(cfg.Authentication.GeoIPDatabasePath)
@@ -139,8 +190,15 @@ func (pe *PolicyEngine) Close() {
 	}
 }
 
-// EvaluateRequest evaluates an authentication request against policies
-func (pe *PolicyEngine) EvaluateRequest(req *AuthRequest) (*PolicyResult, error) {
+// EvaluateRequest evaluates an authentication request against policies.
+//
+// providerName is the provider that will serve this login, chosen by the broker
+// before evaluation. It is a parameter rather than a field on AuthRequest because
+// AuthRequest is built from what the client sent: a provider-scoped restriction
+// that a client could opt out of by naming a different provider would be no
+// restriction at all (#213). An empty providerName scopes out every restriction
+// that names a provider, and leaves those scoped "all" in force.
+func (pe *PolicyEngine) EvaluateRequest(req *AuthRequest, providerName string) (*PolicyResult, error) {
 	if req == nil {
 		return nil, fmt.Errorf("authentication request cannot be nil")
 	}
@@ -170,7 +228,7 @@ func (pe *PolicyEngine) EvaluateRequest(req *AuthRequest) (*PolicyResult, error)
 	}
 
 	// Apply time-based policies
-	if err := pe.applyTimeBasedPolicies(req, result); err != nil {
+	if err := pe.applyTimeBasedPolicies(req, providerName, result); err != nil {
 		return nil, fmt.Errorf("failed to apply time-based policies: %w", err)
 	}
 
@@ -215,6 +273,12 @@ func (pe *PolicyEngine) applyGlobalPolicies(req *AuthRequest, result *PolicyResu
 // only because the operator chose unknown_source_ip: allow. The broker audits
 // it: a waived requirement is a security-relevant event, not a detail.
 const MetadataSourceIPUnknown = "source_ip_unknown"
+
+// MetadataRequireDeviceTrust marks a result whose matching policies required a
+// trusted device. The broker carries it onto the session and enforces it once the
+// identity is known — policy is evaluated before the device flow starts, so at
+// evaluation time there is no amr claim to judge the device by (#212).
+const MetadataRequireDeviceTrust = "require_device_trust"
 
 // applyNetworkPolicies applies network-related policies
 func (pe *PolicyEngine) applyNetworkPolicies(req *AuthRequest, result *PolicyResult) error {
@@ -266,49 +330,60 @@ func (pe *PolicyEngine) applyNetworkPolicies(req *AuthRequest, result *PolicyRes
 	return nil
 }
 
-// applyTimeBasedPolicies applies time-based access policies
-func (pe *PolicyEngine) applyTimeBasedPolicies(req *AuthRequest, result *PolicyResult) error {
+// applyTimeBasedPolicies applies the configured time and geographic restrictions
+// that govern a login served by providerName.
+func (pe *PolicyEngine) applyTimeBasedPolicies(req *AuthRequest, providerName string, result *PolicyResult) error {
 	now := time.Now()
 
-	// Check time restrictions
-	for _, restriction := range pe.config.Authentication.TimeBasedPolicies.TimeRestrictions {
-		if pe.matchesTimeRestriction(req, restriction, now) {
-			if !pe.isWithinAllowedHours(restriction.AllowedHours, now, restriction.Timezone) {
-				result.Allowed = false
-				result.Reason = fmt.Sprintf("Access not allowed at this time: %s", restriction.AllowedHours)
-				return nil
-			}
+	for _, restriction := range pe.timeRestrictions {
+		if !restrictionApplies(restriction.providers, providerName) {
+			continue
+		}
+		if !restriction.window.contains(now.In(restriction.location)) {
+			result.Allowed = false
+			result.Reason = fmt.Sprintf("Access not allowed at this time: %s", restriction.raw)
+			return nil
 		}
 	}
 
-	// Check geographic restrictions
-	for _, restriction := range pe.config.Authentication.TimeBasedPolicies.GeoRestrictions {
-		if pe.matchesGeoRestriction(req, restriction) {
-			country := pe.getCountryFromIP(req.SourceIP)
+	for _, restriction := range pe.geoRestrictions {
+		if !restrictionApplies(restriction.providers, providerName) {
+			continue
+		}
+		country := pe.getCountryFromIP(req.SourceIP)
 
-			// Check blocked countries
-			for _, blocked := range restriction.BlockedCountries {
-				if country == blocked {
-					result.Allowed = false
-					result.Reason = fmt.Sprintf("Access blocked from country: %s", country)
-					return nil
+		for _, blocked := range restriction.blockedCountries {
+			if country == blocked {
+				result.Allowed = false
+				result.Reason = fmt.Sprintf("Access blocked from country: %s", country)
+				return nil
+			}
+		}
+
+		if len(restriction.allowedCountries) > 0 {
+			allowed := false
+			for _, allowedCountry := range restriction.allowedCountries {
+				if country == allowedCountry {
+					allowed = true
+					break
 				}
 			}
-
-			// Check allowed countries
-			if len(restriction.AllowedCountries) > 0 {
-				allowed := false
-				for _, allowedCountry := range restriction.AllowedCountries {
-					if country == allowedCountry {
-						allowed = true
-						break
-					}
-				}
-				if !allowed {
+			if !allowed {
+				// The reason names what the broker concluded rather than only what it
+				// wanted, because "" here means the login could not be placed at all —
+				// a private or loopback source address, or an address the GeoIP
+				// database does not cover — and that is a different conversation with
+				// the operator than "this login came from a country you excluded".
+				if country == "" {
 					result.Allowed = false
-					result.Reason = fmt.Sprintf("Access not allowed from country: %s", country)
+					result.Reason = fmt.Sprintf("Access is restricted to %s and this login's country "+
+						"could not be determined from %q", strings.Join(restriction.allowedCountries, ", "),
+						req.SourceIP)
 					return nil
 				}
+				result.Allowed = false
+				result.Reason = fmt.Sprintf("Access not allowed from country: %s", country)
+				return nil
 			}
 		}
 	}
@@ -322,19 +397,35 @@ func (pe *PolicyEngine) applyRiskPolicies(req *AuthRequest, result *PolicyResult
 	riskScore := pe.calculateRiskScore(req, result)
 	result.RiskScore = riskScore
 
-	// Apply risk policies
-	for _, policy := range pe.config.Authentication.RiskPolicies {
-		if pe.evaluateRiskCondition(policy.Condition, req, result) {
-			switch policy.Action {
-			case "DENY":
-				result.Allowed = false
-				result.Reason = policy.Recommendation
-				return nil
-			case "REQUIRE_ADDITIONAL_MFA":
-				result.RequiredMFA = true
-			case "REQUIRE_APPROVAL":
-				result.Metadata["requires_approval"] = true
+	// Apply risk policies. Conditions and actions were parsed and checked at
+	// startup (#213), so there is no unrecognized case to skip over here.
+	now := time.Now()
+	for _, policy := range pe.riskPolicies {
+		if !policy.condition.holds(pe, req, result, now) {
+			continue
+		}
+		switch policy.action {
+		case "DENY":
+			result.Allowed = false
+			// The condition is always named, even when the operator wrote a
+			// recommendation: the recommendation says what the user should do, and
+			// the audit trail has to say which rule fired (#218). A blank
+			// recommendation used to make the reason blank, which is
+			// indistinguishable from a bug.
+			result.Reason = fmt.Sprintf("denied by risk policy %q (risk score %d)",
+				policy.condition.raw, result.RiskScore)
+			if policy.recommendation != "" {
+				result.Reason += ": " + policy.recommendation
 			}
+			return nil
+		case "LOG":
+			log.Info().
+				Str("user_id", req.UserID).
+				Str("condition", policy.condition.raw).
+				Int("risk_score", result.RiskScore).
+				Strs("risk_factors", result.RiskFactors).
+				Str("recommendation", policy.recommendation).
+				Msg("Risk policy matched")
 		}
 	}
 
@@ -382,11 +473,7 @@ func (pe *PolicyEngine) applyResourcePolicies(req *AuthRequest, result *PolicyRe
 			}
 
 			if policy.RequireDeviceTrust {
-				result.Metadata["require_device_trust"] = true
-			}
-
-			if policy.RequireAdditionalMFA {
-				result.RequiredMFA = true
+				result.Metadata[MetadataRequireDeviceTrust] = true
 			}
 
 			// Check IP whitelist
@@ -400,7 +487,13 @@ func (pe *PolicyEngine) applyResourcePolicies(req *AuthRequest, result *PolicyRe
 				}
 				if !allowed {
 					result.Allowed = false
-					result.Reason = "Source IP not in whitelist"
+					// Named, because the reason is what the audit trail carries and
+					// what an operator debugging a lockout reads (#218). "Source IP
+					// not in whitelist" does not say which of several matching
+					// policies refused, nor what address was compared, so it left
+					// the operator to guess both.
+					result.Reason = fmt.Sprintf("source IP %q is not in the ip_whitelist of policy %q",
+						req.SourceIP, policyName)
 					return nil
 				}
 			}
@@ -444,68 +537,6 @@ func (pe *PolicyEngine) isPrivateIP(ip string) bool {
 	}
 
 	return false
-}
-
-func (pe *PolicyEngine) matchesTimeRestriction(req *AuthRequest, restriction config.TimeRestriction, now time.Time) bool {
-	// "all" applies to every user. Provider-scoped matching requires a ProviderName
-	// field on AuthRequest (TODO: add when provider selection moves earlier in the flow).
-	for _, provider := range restriction.Providers {
-		if provider == "all" {
-			return true
-		}
-	}
-	return false
-}
-
-func (pe *PolicyEngine) matchesGeoRestriction(req *AuthRequest, restriction config.GeoRestriction) bool {
-	// "all" applies to every user. Provider-scoped matching requires a ProviderName
-	// field on AuthRequest (TODO: add when provider selection moves earlier in the flow).
-	for _, provider := range restriction.Providers {
-		if provider == "all" {
-			return true
-		}
-	}
-	return false
-}
-
-func (pe *PolicyEngine) isWithinAllowedHours(allowedHours string, now time.Time, timezone string) bool {
-	if allowedHours == "" {
-		return true
-	}
-
-	// Parse timezone
-	loc, err := time.LoadLocation(timezone)
-	if err != nil {
-		log.Warn().Err(err).Str("timezone", timezone).Msg("Failed to load timezone")
-		loc = time.UTC
-	}
-
-	// Convert to specified timezone
-	localTime := now.In(loc)
-
-	// Parse allowed hours (e.g., "09:00-17:00")
-	parts := strings.Split(allowedHours, "-")
-	if len(parts) != 2 {
-		return true
-	}
-
-	startTime, err := time.ParseInLocation("15:04", parts[0], loc)
-	if err != nil {
-		return true
-	}
-
-	endTime, err := time.ParseInLocation("15:04", parts[1], loc)
-	if err != nil {
-		return true
-	}
-
-	// Adjust for current date
-	startTime = time.Date(localTime.Year(), localTime.Month(), localTime.Day(),
-		startTime.Hour(), startTime.Minute(), 0, 0, loc)
-	endTime = time.Date(localTime.Year(), localTime.Month(), localTime.Day(),
-		endTime.Hour(), endTime.Minute(), 0, 0, loc)
-
-	return localTime.After(startTime) && localTime.Before(endTime)
 }
 
 // getCountryFromIP returns the ISO 3166-1 alpha-2 country code for the given IP
@@ -572,27 +603,6 @@ func (pe *PolicyEngine) calculateRiskScore(req *AuthRequest, result *PolicyResul
 	}
 
 	return score
-}
-
-func (pe *PolicyEngine) evaluateRiskCondition(condition string, req *AuthRequest, result *PolicyResult) bool {
-	// Simple condition evaluation
-	// In a real implementation, this would be more sophisticated
-	switch condition {
-	case "risk_score >= 70":
-		return result.RiskScore >= 70
-	case "unusual_location AND after_hours":
-		return pe.isUnusualLocation(req.UserID, req.SourceIP) && pe.isAfterHours(time.Now())
-	case "untrusted_network":
-		return !pe.isPrivateIP(req.SourceIP)
-	default:
-		// L-7: an unrecognized condition silently evaluates to "does not fire",
-		// which means a misconfigured DENY policy would never apply. Log loudly so
-		// the misconfiguration is visible rather than failing open silently.
-		log.Warn().
-			Str("condition", condition).
-			Msg("Unknown risk policy condition; it will not match. Check policy configuration")
-		return false
-	}
 }
 
 func (pe *PolicyEngine) matchesResourcePolicy(targetHost, policyName string) bool {

--- a/pkg/auth/policy_geoip_test.go
+++ b/pkg/auth/policy_geoip_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
@@ -129,42 +130,69 @@ func TestNewPolicyEngineNoGeoIPPath(t *testing.T) {
 	pe.Close() // must not panic
 }
 
-// TestGeoRestrictionWithoutDatabase verifies that geographic restrictions do
-// not block access when no GeoIP database is configured (country resolves to
-// ""), so that a missing database does not lock out all users.
-func TestGeoRestrictionWithoutDatabase(t *testing.T) {
+// TestGeoRestrictionWithoutDatabaseIsRefusedAtStartup pins the fix for what this
+// test used to accept. A geo_restriction with no geoip_database_path resolves every
+// country to "", so the restriction matched nothing and denied every login it
+// applied to — an operator who names allowed_countries and forgets the database
+// locks out the host. The old test observed that outcome, logged it, and asserted
+// nothing.
+//
+// A missing database is now a startup error (#212): the broker refuses to run a
+// restriction it cannot evaluate, which the operator sees at install time instead
+// of at the first login.
+func TestGeoRestrictionWithoutDatabaseIsRefusedAtStartup(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		restrictor config.GeoRestriction
+	}{
+		{"allowed countries", config.GeoRestriction{Providers: []string{"all"}, AllowedCountries: []string{"US", "CA"}}},
+		{"blocked countries", config.GeoRestriction{Providers: []string{"all"}, BlockedCountries: []string{"XX"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Authentication: config.AuthenticationConfig{
+					TimeBasedPolicies: config.TimeBasedPolicies{
+						GeoRestrictions: []config.GeoRestriction{tc.restrictor},
+					},
+				},
+			}
+
+			pe, err := NewPolicyEngine(cfg)
+			if err == nil {
+				pe.Close()
+				t.Fatal("NewPolicyEngine accepted a geo restriction with no GeoIP database; " +
+					"every login it applies to would be denied for a country it cannot resolve (#212)")
+			}
+			if !strings.Contains(err.Error(), "geoip_database_path") {
+				t.Errorf("startup error does not name the setting the operator has to add: %v", err)
+			}
+		})
+	}
+}
+
+// TestGeoRestrictionNeedsAProviderScope covers the other half: a restriction with
+// no providers list matched no provider, so it was inert. Silently applying to
+// nothing is the failure mode this whole change is about.
+func TestGeoRestrictionNeedsAProviderScope(t *testing.T) {
 	cfg := &config.Config{
 		Authentication: config.AuthenticationConfig{
 			TimeBasedPolicies: config.TimeBasedPolicies{
 				GeoRestrictions: []config.GeoRestriction{
-					{
-						AllowedCountries: []string{"US", "CA"},
-					},
+					{AllowedCountries: []string{"US"}},
 				},
 			},
 		},
 	}
 
 	pe, err := NewPolicyEngine(cfg)
-	if err != nil {
-		t.Fatalf("NewPolicyEngine failed: %v", err)
+	if err == nil {
+		pe.Close()
+		t.Fatal("NewPolicyEngine accepted a geo restriction with an empty providers list, " +
+			"which applies to no provider and therefore restricts nothing (#212)")
 	}
-
-	req := &AuthRequest{
-		UserID:   "testuser",
-		SourceIP: "8.8.8.8",
+	if !strings.Contains(err.Error(), "providers") {
+		t.Errorf("startup error does not name the empty providers list: %v", err)
 	}
-
-	result := &PolicyResult{Allowed: true}
-	if err := pe.applyTimeBasedPolicies(req, result); err != nil {
-		t.Fatalf("applyTimeBasedPolicies returned error: %v", err)
-	}
-
-	// With no database, country is "" which is not in the allowed list, so
-	// the restriction will block access. This is intentional: operators who
-	// configure geo restrictions MUST provide a GeoIP database.
-	// The test simply asserts the behaviour is deterministic (not a panic).
-	t.Logf("access allowed=%v reason=%q (no GeoIP DB)", result.Allowed, result.Reason)
 }
 
 // TestPolicyEngineClose verifies that Close is idempotent and safe to call

--- a/pkg/auth/policy_source_ip_test.go
+++ b/pkg/auth/policy_source_ip_test.go
@@ -28,7 +28,7 @@ func networkPolicyEngine(t *testing.T, nr config.NetworkRequirements) *PolicyEng
 func evaluate(t *testing.T, pe *PolicyEngine, req *AuthRequest) *PolicyResult {
 	t.Helper()
 
-	result, err := pe.EvaluateRequest(req)
+	result, err := pe.EvaluateRequest(req, "")
 	if err != nil {
 		t.Fatalf("EvaluateRequest: %v", err)
 	}

--- a/pkg/auth/policy_support.go
+++ b/pkg/auth/policy_support.go
@@ -1,0 +1,662 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// This file decides what the broker will admit it can enforce.
+//
+// (#212) Ten settings under authentication.policies were parsed, documented, and
+// shipped in the example configurations, and did nothing at all. Eight had no
+// reader anywhere in the product. The other two — require_additional_mfa and
+// require_approval_for — reached a PolicyResult field that nothing read, which is
+// the same outcome by a longer route. So did max_session_duration, whose
+// per-policy minimum was computed on every login and then discarded, and
+// require_device_trust, which set a metadata key no code looked at.
+//
+// An operator who writes `require_additional_mfa: true` has stated a requirement.
+// A broker that starts anyway is answering "yes, that is in force" to a question
+// it cannot answer, and the answer is wrong for as long as the deployment lives.
+// The two that can be enforced now are; the rest make startup fail with the key
+// named. Failing at startup is loud, is in the journal, happens on upgrade rather
+// than during an incident, and cannot be mistaken for protection.
+//
+// The alternative — a warning — is what the previous release used for policies
+// that could not match a host (#158), and it is the wrong instrument here.
+// A warning leaves a running broker whose configuration claims a control it does
+// not have.
+
+// compilePolicies turns the configured risk policies and restrictions into the
+// forms the engine evaluates, once, at startup.
+//
+// (#213) The parsing used to happen per login, and every parse failure took the
+// permissive branch: an unrecognized risk condition never matched, an unparseable
+// allowed_hours permitted every hour, an unloadable timezone became UTC. Doing it
+// here means those are startup errors, and the evaluation path has no failure mode
+// left to fall open through. validatePolicySupport reports all of them together
+// with their configuration paths, so this returning an error at all means the two
+// have drifted.
+func (pe *PolicyEngine) compilePolicies() error {
+	if pe.config == nil {
+		return nil
+	}
+
+	for i, rp := range pe.config.Authentication.RiskPolicies {
+		condition, err := parseRiskCondition(rp.Condition)
+		if err != nil {
+			return fmt.Errorf("authentication.risk_policies[%d].condition: %w", i, err)
+		}
+		if !riskPolicyActions[rp.Action] {
+			return fmt.Errorf("authentication.risk_policies[%d].action: %q is not an action this broker "+
+				"performs", i, rp.Action)
+		}
+		pe.riskPolicies = append(pe.riskPolicies, parsedRiskPolicy{
+			condition:      condition,
+			action:         rp.Action,
+			recommendation: rp.Recommendation,
+		})
+	}
+
+	for i, r := range pe.config.Authentication.TimeBasedPolicies.TimeRestrictions {
+		window, err := parseAllowedHours(r.AllowedHours)
+		if err != nil {
+			return fmt.Errorf("authentication.time_based_policies.time_restrictions[%d].allowed_hours: %w", i, err)
+		}
+		location := time.UTC
+		if r.Timezone != "" {
+			loaded, err := time.LoadLocation(r.Timezone)
+			if err != nil {
+				return fmt.Errorf("authentication.time_based_policies.time_restrictions[%d].timezone: %w", i, err)
+			}
+			location = loaded
+		}
+		pe.timeRestrictions = append(pe.timeRestrictions, parsedTimeRestriction{
+			providers: r.Providers,
+			window:    window,
+			location:  location,
+			raw:       r.AllowedHours,
+		})
+	}
+
+	for _, r := range pe.config.Authentication.TimeBasedPolicies.GeoRestrictions {
+		pe.geoRestrictions = append(pe.geoRestrictions, parsedGeoRestriction{
+			providers:        r.Providers,
+			allowedCountries: r.AllowedCountries,
+			blockedCountries: r.BlockedCountries,
+		})
+	}
+
+	return nil
+}
+
+// restrictionApplies reports whether a restriction scoped to these providers
+// governs a login being served by providerName.
+//
+// (#213) A restriction used to apply only if its provider list contained the
+// literal "all"; a restriction naming a provider matched nothing, so its
+// allowed_hours and its country lists were skipped and the login was allowed. The
+// provider name is now known before policy is evaluated, so scoping works and
+// "all" is one case of it rather than the only one.
+//
+// An empty provider list matches nothing, as before — but it can no longer be
+// configured, because validatePolicySupport refuses it.
+func restrictionApplies(providers []string, providerName string) bool {
+	for _, p := range providers {
+		if p == "all" {
+			return true
+		}
+		if providerName != "" && strings.EqualFold(p, providerName) {
+			return true
+		}
+	}
+	return false
+}
+
+// unsupportedPolicySetting names one configured setting the broker cannot
+// enforce, and says what to do about it.
+type unsupportedPolicySetting struct {
+	// key is the dotted configuration path, so the message can be pasted into a
+	// search of the operator's own config file.
+	key string
+	// why says what the broker does with the setting today, in terms of effect on
+	// access rather than in terms of code.
+	why string
+}
+
+// unenforceablePolicySettings returns every setting in one authentication.policies
+// entry that the broker does not act on.
+//
+// Adding enforcement for one of these means deleting its case here, in the same
+// change. That is deliberate: the two lists cannot drift, because there is only
+// one list.
+func unenforceablePolicySettings(policyPath string, p config.AuthenticationPolicy) []unsupportedPolicySetting {
+	var found []unsupportedPolicySetting
+	add := func(key, why string) {
+		found = append(found, unsupportedPolicySetting{key: policyPath + "." + key, why: why})
+	}
+
+	if p.RequireReauthForNewHosts {
+		add("require_reauth_for_new_hosts",
+			"the broker does not track which hosts an identity has logged into, so no login is ever "+
+				"asked to re-authenticate")
+	}
+	if p.RequireInstitutionalAffiliation {
+		add("require_institutional_affiliation",
+			"nothing checks the institution claim; a login from an identity with no affiliation is allowed. "+
+				"Use require_groups, which is enforced")
+	}
+	if p.RequireAllocationVerification {
+		add("require_allocation_verification",
+			"the broker has no allocation system to verify against; every login is allowed regardless of "+
+				"allocation")
+	}
+	if p.RequireProjectMembership != "" {
+		add("require_project_membership",
+			"project membership is not checked; every login is allowed regardless of project. "+
+				"Use require_groups, which is enforced")
+	}
+	if p.AuditLevel != "" {
+		add("audit_level",
+			"the audit trail has one verbosity and this does not change it; set audit.log_level instead")
+	}
+	if p.AllowUnstrustedDevices {
+		add("allow_untrusted_devices",
+			"device trust is only ever required by require_device_trust, so this grants nothing that is "+
+				"not already allowed by leaving require_device_trust unset")
+	}
+	if p.RequireAdditionalMFA {
+		add("require_additional_mfa",
+			"the broker cannot tell how an identity authenticated beyond the hardware-key and FIDO methods "+
+				"require_device_trust already covers, so no login is ever asked for a second factor")
+	}
+	if p.NoDataExport {
+		add("no_data_export",
+			"the broker authenticates logins and does not mediate data movement, so this restricts nothing")
+	}
+	if p.SessionRecording {
+		add("session_recording",
+			"the broker does not record sessions and cannot make sshd do so; nothing is recorded")
+	}
+	if len(p.RequireApprovalFor) > 0 {
+		add("require_approval_for",
+			"there is no approval step for a login to wait on, so every listed operation proceeds "+
+				"unapproved")
+	}
+
+	return found
+}
+
+// riskPolicyActions are the actions applyRiskPolicies acts on.
+//
+// (#212) REQUIRE_ADDITIONAL_MFA and REQUIRE_APPROVAL were accepted here and set a
+// field nothing read, so a risk policy carrying either was a no-op that looked
+// like a control. They are refused for the same reason their per-policy
+// equivalents are.
+var riskPolicyActions = map[string]bool{
+	"DENY": true,
+	// LOG is the honest spelling of "notice this and do nothing else": the risk
+	// score and its factors are already on every audit record, so a policy whose
+	// only purpose is to mark a condition has somewhere to go that is not a lie.
+	"LOG": true,
+}
+
+// validatePolicySupport refuses a configuration whose access controls the broker
+// cannot enforce, and reports every problem at once rather than the first.
+//
+// Reporting all of them matters: an operator fixing a config by restart-and-see
+// would otherwise need one restart per unsupported key, and a broker that will
+// not start is a host nobody can log into.
+func validatePolicySupport(cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	var problems []unsupportedPolicySetting
+
+	names := make([]string, 0, len(cfg.Authentication.Policies))
+	for name := range cfg.Authentication.Policies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := fmt.Sprintf("authentication.policies.%s", name)
+		problems = append(problems, unenforceablePolicySettings(path, cfg.Authentication.Policies[name])...)
+	}
+
+	problems = append(problems, unsupportedRiskPolicies(cfg)...)
+	problems = append(problems, unsupportedTimeRestrictions(cfg)...)
+	problems = append(problems, unsupportedGeoRestrictions(cfg)...)
+
+	if len(problems) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "the configuration sets %d access control(s) this broker cannot enforce, "+
+		"and starting would report them as being in force:", len(problems))
+	for _, p := range problems {
+		fmt.Fprintf(&b, "\n  - %s: %s", p.key, p.why)
+	}
+	b.WriteString("\n\nRemove or comment out each setting above to start. " +
+		"Each one is tracked at https://github.com/scttfrdmn/oidc-pam/issues/212 — " +
+		"a release that implements one will accept it again.")
+	return fmt.Errorf("%s", b.String())
+}
+
+// unsupportedRiskPolicies checks that every risk policy has a condition the
+// engine can evaluate and an action it can carry out.
+//
+// (#213) Both used to fail open. evaluateRiskCondition matched three exact
+// strings and returned false for anything else, so the enterprise configuration's
+// only hard denial — `risk_score >= 80`, action DENY — never fired, because the
+// engine recognized `risk_score >= 70` and nothing else. The action switch had no
+// default, so a misspelled action was skipped in silence.
+func unsupportedRiskPolicies(cfg *config.Config) []unsupportedPolicySetting {
+	var found []unsupportedPolicySetting
+
+	for i, rp := range cfg.Authentication.RiskPolicies {
+		path := fmt.Sprintf("authentication.risk_policies[%d]", i)
+
+		if _, err := parseRiskCondition(rp.Condition); err != nil {
+			found = append(found, unsupportedPolicySetting{
+				key: path + ".condition",
+				why: fmt.Sprintf("%v. A condition the engine cannot evaluate never matches, so this "+
+					"policy would never apply", err),
+			})
+		}
+		if !riskPolicyActions[rp.Action] {
+			actions := make([]string, 0, len(riskPolicyActions))
+			for a := range riskPolicyActions {
+				actions = append(actions, a)
+			}
+			sort.Strings(actions)
+			found = append(found, unsupportedPolicySetting{
+				key: path + ".action",
+				why: fmt.Sprintf("%q is not an action this broker performs (it performs %s), so the "+
+					"policy would match and then do nothing", rp.Action, strings.Join(actions, " and ")),
+			})
+		}
+	}
+
+	return found
+}
+
+// unsupportedTimeRestrictions checks that a time restriction can both match and
+// be evaluated.
+//
+// (#213) allowed_hours that did not parse returned "within the allowed hours" —
+// so `09:00-17:00` worked and `9am-5pm` silently allowed every hour of every day.
+// An unloadable timezone fell back to UTC, which moves the window by up to half a
+// day without saying so.
+func unsupportedTimeRestrictions(cfg *config.Config) []unsupportedPolicySetting {
+	var found []unsupportedPolicySetting
+
+	for i, r := range cfg.Authentication.TimeBasedPolicies.TimeRestrictions {
+		path := fmt.Sprintf("authentication.time_based_policies.time_restrictions[%d]", i)
+
+		if len(r.Providers) == 0 {
+			found = append(found, unsupportedPolicySetting{
+				key: path + ".providers",
+				why: "a restriction with no providers matches no login, so its allowed_hours would never " +
+					`apply. Use ["all"], or name the providers it governs`,
+			})
+		}
+		if _, err := parseAllowedHours(r.AllowedHours); err != nil {
+			found = append(found, unsupportedPolicySetting{
+				key: path + ".allowed_hours",
+				why: fmt.Sprintf("%v. An unparseable window used to permit every hour of the day", err),
+			})
+		}
+		if r.Timezone != "" {
+			if _, err := time.LoadLocation(r.Timezone); err != nil {
+				found = append(found, unsupportedPolicySetting{
+					key: path + ".timezone",
+					why: fmt.Sprintf("%v. An unloadable timezone used to fall back to UTC, moving the "+
+						"allowed window by the offset without saying so", err),
+				})
+			}
+		}
+		if len(r.Exceptions) > 0 {
+			found = append(found, unsupportedPolicySetting{
+				key: path + ".exceptions",
+				why: "nothing reads the exception list, so an identity listed here is still subject to " +
+					"allowed_hours",
+			})
+		}
+	}
+
+	return found
+}
+
+// unsupportedGeoRestrictions checks that a geographic restriction can match, and
+// that the broker can tell what country a login came from.
+//
+// The second check is the one that matters. getCountryFromIP answers "" with no
+// GeoIP database configured, and "" is in nobody's allowed_countries — so
+// allowed_countries without geoip_database_path denies every login on the host
+// with the reason "Access not allowed from country: ". That fails closed, which is
+// the right direction, but as a total outage with an empty reason. It is a
+// configuration mistake and belongs at startup.
+func unsupportedGeoRestrictions(cfg *config.Config) []unsupportedPolicySetting {
+	var found []unsupportedPolicySetting
+
+	for i, r := range cfg.Authentication.TimeBasedPolicies.GeoRestrictions {
+		path := fmt.Sprintf("authentication.time_based_policies.geo_restrictions[%d]", i)
+
+		if len(r.Providers) == 0 {
+			found = append(found, unsupportedPolicySetting{
+				key: path + ".providers",
+				why: "a restriction with no providers matches no login, so its country lists would never " +
+					`apply. Use ["all"], or name the providers it governs`,
+			})
+		}
+		if len(r.AllowedCountries) == 0 && len(r.BlockedCountries) == 0 {
+			continue
+		}
+		if cfg.Authentication.GeoIPDatabasePath == "" {
+			found = append(found, unsupportedPolicySetting{
+				key: path,
+				why: "country restrictions need authentication.geoip_database_path. Without it the broker " +
+					"cannot place any login, so an allowed_countries list denies every login on this host " +
+					"and a blocked_countries list blocks none",
+			})
+		}
+	}
+
+	return found
+}
+
+// parseAllowedHours parses a "HH:MM-HH:MM" window into minutes past midnight.
+//
+// An empty window means "no restriction" and is valid; anything else must parse.
+// Returning the window rather than a bool lets the caller evaluate it without
+// re-parsing on every login.
+func parseAllowedHours(allowedHours string) (hourWindow, error) {
+	if strings.TrimSpace(allowedHours) == "" {
+		return hourWindow{unrestricted: true}, nil
+	}
+
+	start, end, found := strings.Cut(allowedHours, "-")
+	if !found {
+		return hourWindow{}, fmt.Errorf("%q is not a window of the form HH:MM-HH:MM", allowedHours)
+	}
+	startMinute, err := parseClockMinute(start)
+	if err != nil {
+		return hourWindow{}, fmt.Errorf("%q: start %w", allowedHours, err)
+	}
+	endMinute, err := parseClockMinute(end)
+	if err != nil {
+		return hourWindow{}, fmt.Errorf("%q: end %w", allowedHours, err)
+	}
+	if startMinute == endMinute {
+		return hourWindow{}, fmt.Errorf("%q opens and closes at the same minute, which allows nothing",
+			allowedHours)
+	}
+	return hourWindow{startMinute: startMinute, endMinute: endMinute}, nil
+}
+
+// hourWindow is a parsed allowed_hours window, in minutes past local midnight.
+type hourWindow struct {
+	unrestricted bool
+	startMinute  int
+	endMinute    int
+}
+
+// contains reports whether t falls inside the window.
+//
+// A window whose end is before its start crosses midnight — "22:00-06:00" is a
+// night shift, not an empty set — and is the union of the two halves. The old
+// code compared against two timestamps built on today's date, so it treated such
+// a window as empty and denied every login for a site that configured one.
+func (w hourWindow) contains(t time.Time) bool {
+	if w.unrestricted {
+		return true
+	}
+	minute := t.Hour()*60 + t.Minute()
+	if w.startMinute < w.endMinute {
+		return minute >= w.startMinute && minute < w.endMinute
+	}
+	return minute >= w.startMinute || minute < w.endMinute
+}
+
+// parseClockMinute parses "HH:MM" into minutes past midnight.
+func parseClockMinute(clock string) (int, error) {
+	hh, mm, found := strings.Cut(strings.TrimSpace(clock), ":")
+	if !found {
+		return 0, fmt.Errorf("%q is not a time of the form HH:MM", clock)
+	}
+	hour, err := strconv.Atoi(hh)
+	if err != nil || hour < 0 || hour > 23 {
+		return 0, fmt.Errorf("%q does not have an hour between 00 and 23", clock)
+	}
+	minute, err := strconv.Atoi(mm)
+	if err != nil || minute < 0 || minute > 59 {
+		return 0, fmt.Errorf("%q does not have a minute between 00 and 59", clock)
+	}
+	return hour*60 + minute, nil
+}
+
+// riskFlag is a condition about a login that the engine can decide from the
+// request and the risk factors it has already computed.
+type riskFlag string
+
+// Every flag corresponds to a risk factor calculateRiskScore already computes, so
+// a policy can name the specific circumstance it cares about instead of guessing
+// which combination of factors adds up to a threshold.
+const (
+	riskUnusualLocation  riskFlag = "unusual_location"
+	riskAfterHours       riskFlag = "after_hours"
+	riskUntrustedNetwork riskFlag = "untrusted_network"
+	riskUnknownDevice    riskFlag = "unknown_device"
+	riskUnknownNetwork   riskFlag = "unknown_network_origin"
+)
+
+// riskFlagNames maps every accepted spelling to its canonical flag.
+//
+// "unknown_network" and "new_device" are aliases because they are the spellings an
+// operator is likely to reach for — "new_device" is what the shipped enterprise
+// configuration used — and silently not matching a reasonable spelling is the
+// defect this whole file exists to remove.
+//
+// There is deliberately no flag for device trust. Risk policies are evaluated
+// before the device flow starts, so at that point the broker has no identity and
+// no `amr` claim, and a flag that always read "untrusted" would be worse than not
+// offering one. require_device_trust covers it, after the identity is known.
+var riskFlagNames = map[riskFlag]riskFlag{
+	riskUnusualLocation:  riskUnusualLocation,
+	riskAfterHours:       riskAfterHours,
+	riskUntrustedNetwork: riskUntrustedNetwork,
+	riskUnknownDevice:    riskUnknownDevice,
+	riskUnknownNetwork:   riskUnknownNetwork,
+	"unknown_network":    riskUnknownNetwork,
+	"new_device":         riskUnknownDevice,
+}
+
+// riskCondition is a risk-policy condition that has been understood.
+//
+// (#213) Conditions are parsed once, at startup, and evaluation takes the parsed
+// form. That is the point: evaluation has no "unrecognized condition" branch left
+// to fall open through, because a condition that cannot be parsed stops the broker
+// instead of quietly never matching.
+type riskCondition struct {
+	// raw is kept for log and error messages, which are read by whoever wrote it.
+	raw string
+
+	// Exactly one of the two shapes is populated.
+
+	// scoreOp and scoreWant hold a `risk_score <op> <n>` comparison.
+	scoreOp   string
+	scoreWant int
+
+	// flags holds a conjunction of named conditions. All must hold.
+	flags []riskFlag
+}
+
+// riskScoreOps are the comparisons a risk_score condition may use.
+var riskScoreOps = map[string]func(score, want int) bool{
+	">=": func(score, want int) bool { return score >= want },
+	">":  func(score, want int) bool { return score > want },
+	"<=": func(score, want int) bool { return score <= want },
+	"<":  func(score, want int) bool { return score < want },
+	"==": func(score, want int) bool { return score == want },
+}
+
+// parseRiskCondition parses a risk policy condition.
+//
+// Two shapes are accepted:
+//
+//	risk_score >= 80              a comparison against the computed score
+//	unusual_location AND after_hours   a conjunction of named conditions
+//
+// Whitespace around the operator is optional, so `risk_score>=80` parses; AND is
+// case-insensitive. Everything else is an error, and an error stops startup.
+func parseRiskCondition(condition string) (riskCondition, error) {
+	trimmed := strings.TrimSpace(condition)
+	if trimmed == "" {
+		return riskCondition{}, fmt.Errorf("the condition is empty")
+	}
+
+	if rest, isScore := cutRiskScorePrefix(trimmed); isScore {
+		return parseRiskScoreCondition(trimmed, rest)
+	}
+
+	// A conjunction of named flags. Splitting on the whole word avoids matching an
+	// "AND" inside a future flag name.
+	parts := splitConjunction(trimmed)
+	parsed := riskCondition{raw: trimmed}
+	for _, part := range parts {
+		flag := riskFlag(strings.ToLower(strings.TrimSpace(part)))
+		canonical, ok := riskFlagNames[flag]
+		if !ok {
+			return riskCondition{}, fmt.Errorf("%q is not a condition this broker can evaluate "+
+				"(it evaluates %s, a conjunction of those joined by AND, or a risk_score comparison "+
+				"such as \"risk_score >= 80\")", part, knownRiskFlags())
+		}
+		parsed.flags = append(parsed.flags, canonical)
+	}
+	return parsed, nil
+}
+
+// cutRiskScorePrefix reports whether the condition is a risk_score comparison and
+// returns what follows the field name.
+func cutRiskScorePrefix(condition string) (string, bool) {
+	const field = "risk_score"
+	if !strings.HasPrefix(strings.ToLower(condition), field) {
+		return "", false
+	}
+	return condition[len(field):], true
+}
+
+// parseRiskScoreCondition parses the operator and threshold of a risk_score
+// comparison.
+func parseRiskScoreCondition(raw, rest string) (riskCondition, error) {
+	rest = strings.TrimSpace(rest)
+
+	// Two-character operators first, so ">=" is not read as ">" followed by "=80".
+	for _, op := range []string{">=", "<=", "==", ">", "<"} {
+		if !strings.HasPrefix(rest, op) {
+			continue
+		}
+		threshold := strings.TrimSpace(rest[len(op):])
+		want, err := strconv.Atoi(threshold)
+		if err != nil {
+			return riskCondition{}, fmt.Errorf("%q does not compare risk_score against a whole number "+
+				"(%q is not one)", raw, threshold)
+		}
+		return riskCondition{raw: raw, scoreOp: op, scoreWant: want}, nil
+	}
+
+	ops := make([]string, 0, len(riskScoreOps))
+	for op := range riskScoreOps {
+		ops = append(ops, op)
+	}
+	sort.Strings(ops)
+	return riskCondition{}, fmt.Errorf("%q does not compare risk_score with one of %s",
+		raw, strings.Join(ops, ", "))
+}
+
+// splitConjunction splits on the word AND, case-insensitively.
+func splitConjunction(condition string) []string {
+	fields := strings.Fields(condition)
+	var parts []string
+	var current []string
+	for _, field := range fields {
+		if strings.EqualFold(field, "AND") {
+			parts = append(parts, strings.Join(current, " "))
+			current = nil
+			continue
+		}
+		current = append(current, field)
+	}
+	return append(parts, strings.Join(current, " "))
+}
+
+// knownRiskFlags lists the accepted flag names for an error message, so that
+// whoever misspelled one is told what the alternatives are.
+func knownRiskFlags() string {
+	names := make([]string, 0, len(riskFlagNames))
+	for name := range riskFlagNames {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// holds reports whether the condition is satisfied by this request.
+//
+// The engine reads the parsed form, so there is no branch here for a condition it
+// does not understand: parseRiskCondition rejected those at startup. A flag
+// conjunction with an empty flag list cannot be constructed by the parser, and if
+// one somehow were, the loop below leaves `every` true — which is why the parser,
+// not this function, is where a malformed condition has to be caught.
+func (c riskCondition) holds(pe *PolicyEngine, req *AuthRequest, result *PolicyResult, now time.Time) bool {
+	if c.scoreOp != "" {
+		compare, ok := riskScoreOps[c.scoreOp]
+		if !ok {
+			// Unreachable: the parser only ever stores an operator from this map.
+			return false
+		}
+		return compare(result.RiskScore, c.scoreWant)
+	}
+
+	for _, flag := range c.flags {
+		if !pe.riskFlagHolds(flag, req, now) {
+			return false
+		}
+	}
+	return len(c.flags) > 0
+}
+
+// riskFlagHolds decides one named condition.
+//
+// The unknown-origin cases follow calculateRiskScore (#169): a login the broker
+// cannot place on any network is not evidence of safety, so untrusted_network
+// holds for it. unknown_network_origin exists so a policy can distinguish the two
+// when it wants to.
+func (pe *PolicyEngine) riskFlagHolds(flag riskFlag, req *AuthRequest, now time.Time) bool {
+	switch flag {
+	case riskUnusualLocation:
+		return pe.isUnusualLocation(req.UserID, req.SourceIP)
+	case riskAfterHours:
+		return pe.isAfterHours(now)
+	case riskUntrustedNetwork:
+		return req.SourceIP == "" || !pe.isPrivateIP(req.SourceIP)
+	case riskUnknownDevice:
+		return req.DeviceID == ""
+	case riskUnknownNetwork:
+		return req.SourceIP == ""
+	default:
+		// Unreachable: the parser only ever stores a canonical flag from
+		// riskFlagNames. Answering false here would make an unhandled flag a silent
+		// no-match, which is exactly the failure this file removes, so a flag added
+		// to the map without a case here must be caught in test rather than
+		// tolerated at runtime — see TestEveryRiskFlagIsEvaluated.
+		return false
+	}
+}

--- a/pkg/auth/policy_support_test.go
+++ b/pkg/auth/policy_support_test.go
@@ -1,0 +1,525 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// TestEveryUnenforceablePolicySettingIsRefusedByName is the acceptance test for
+// #212. Each of these ten settings parsed, loaded, appeared in the configuration
+// the broker was running, and was read by nothing — so a policy that set
+// `session_recording: true` described a control that did not exist and the login
+// proceeded exactly as if it had not been set. Three shipped provider templates and
+// the enterprise production template between them set nine of the ten.
+//
+// The test asserts two things per setting: that the broker refuses to start on it,
+// and that the refusal names it. The second is what makes the error actionable —
+// an operator whose host will not accept logins needs to know which line to delete,
+// not that "something is unsupported".
+func TestEveryUnenforceablePolicySettingIsRefusedByName(t *testing.T) {
+	for _, tc := range []struct {
+		key    string
+		policy config.AuthenticationPolicy
+	}{
+		{"require_reauth_for_new_hosts", config.AuthenticationPolicy{RequireReauthForNewHosts: true}},
+		{"require_institutional_affiliation", config.AuthenticationPolicy{RequireInstitutionalAffiliation: true}},
+		{"require_allocation_verification", config.AuthenticationPolicy{RequireAllocationVerification: true}},
+		{"require_project_membership", config.AuthenticationPolicy{RequireProjectMembership: "nsf-climate"}},
+		{"audit_level", config.AuthenticationPolicy{AuditLevel: "detailed"}},
+		{"allow_untrusted_devices", config.AuthenticationPolicy{AllowUnstrustedDevices: true}},
+		{"require_additional_mfa", config.AuthenticationPolicy{RequireAdditionalMFA: true}},
+		{"no_data_export", config.AuthenticationPolicy{NoDataExport: true}},
+		{"session_recording", config.AuthenticationPolicy{SessionRecording: true}},
+		{"require_approval_for", config.AuthenticationPolicy{RequireApprovalFor: []string{"admin-actions"}}},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			cfg := &config.Config{
+				Authentication: config.AuthenticationConfig{
+					Policies: map[string]config.AuthenticationPolicy{"production": tc.policy},
+				},
+			}
+
+			err := validatePolicySupport(cfg)
+			if err == nil {
+				t.Fatalf("a policy setting %s was accepted; nothing enforces it, so the broker would "+
+					"report a control it does not apply (#212)", tc.key)
+			}
+			// The dotted path, so the message can be searched for in the operator's
+			// own file.
+			want := "authentication.policies.production." + tc.key
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the startup error does not name %s, so it does not say which line to remove:\n%v",
+					want, err)
+			}
+		})
+	}
+}
+
+// TestEveryEnforcedPolicySettingIsAccepted is the other half, and it is the one
+// that stops the refusal from growing: the four settings the broker does enforce
+// must go on working together in one policy.
+func TestEveryEnforcedPolicySettingIsAccepted(t *testing.T) {
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			Policies: map[string]config.AuthenticationPolicy{
+				"default": {
+					RequireGroups:      []string{"production-access"},
+					MaxSessionDuration: 2 * time.Hour,
+					RequireDeviceTrust: true,
+					IPWhitelist:        []string{"10.0.0.0/8"},
+				},
+			},
+		},
+	}
+
+	if err := validatePolicySupport(cfg); err != nil {
+		t.Fatalf("a policy setting only the four enforced settings was refused: %v", err)
+	}
+}
+
+// TestUnenforceableSettingsAreReportedTogether covers the reason validation
+// collects rather than returning the first problem. An operator fixing this by
+// restart-and-see would need one restart per key, and between each restart the host
+// accepts no logins at all.
+func TestUnenforceableSettingsAreReportedTogether(t *testing.T) {
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			Policies: map[string]config.AuthenticationPolicy{
+				"production": {AuditLevel: "detailed", SessionRecording: true, NoDataExport: true},
+				"staging":    {RequireAdditionalMFA: true},
+			},
+		},
+	}
+
+	err := validatePolicySupport(cfg)
+	if err == nil {
+		t.Fatal("four unenforceable settings were accepted")
+	}
+	for _, want := range []string{
+		"authentication.policies.production.audit_level",
+		"authentication.policies.production.session_recording",
+		"authentication.policies.production.no_data_export",
+		"authentication.policies.staging.require_additional_mfa",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the startup error omits %s, so fixing this config takes one restart per key:\n%v",
+				want, err)
+		}
+	}
+}
+
+// TestParseRiskCondition pins the vocabulary of #213. Before this, an unparseable
+// condition reached an evaluator whose switch had a default that answered false: a
+// misspelled flag or an operator the code did not handle meant the policy silently
+// never matched, so a `DENY` on high risk did not deny. Parsing at startup is what
+// removes that branch.
+func TestParseRiskCondition(t *testing.T) {
+	for _, tc := range []struct {
+		condition string
+		wantOp    string
+		wantWant  int
+		wantFlags []riskFlag
+	}{
+		// The spelling the shipped enterprise config uses, which had to keep working.
+		{condition: "risk_score >= 80", wantOp: ">=", wantWant: 80},
+		{condition: "risk_score>=80", wantOp: ">=", wantWant: 80},
+		{condition: "risk_score < 20", wantOp: "<", wantWant: 20},
+		{condition: "risk_score == 0", wantOp: "==", wantWant: 0},
+		{condition: "unusual_location", wantFlags: []riskFlag{riskUnusualLocation}},
+		{
+			condition: "unusual_location AND after_hours",
+			wantFlags: []riskFlag{riskUnusualLocation, riskAfterHours},
+		},
+		// AND is case-insensitive, and the flag names are lowercased.
+		{
+			condition: "UNUSUAL_LOCATION and After_Hours",
+			wantFlags: []riskFlag{riskUnusualLocation, riskAfterHours},
+		},
+		// The two aliases resolve to their canonical flag, so evaluation has one
+		// name per condition however it was written.
+		{condition: "new_device", wantFlags: []riskFlag{riskUnknownDevice}},
+		{condition: "unknown_network", wantFlags: []riskFlag{riskUnknownNetwork}},
+	} {
+		t.Run(tc.condition, func(t *testing.T) {
+			parsed, err := parseRiskCondition(tc.condition)
+			if err != nil {
+				t.Fatalf("parseRiskCondition(%q): %v", tc.condition, err)
+			}
+			if parsed.scoreOp != tc.wantOp || parsed.scoreWant != tc.wantWant {
+				t.Errorf("score comparison = %q %d, want %q %d",
+					parsed.scoreOp, parsed.scoreWant, tc.wantOp, tc.wantWant)
+			}
+			if len(parsed.flags) != len(tc.wantFlags) {
+				t.Fatalf("flags = %v, want %v", parsed.flags, tc.wantFlags)
+			}
+			for i, flag := range tc.wantFlags {
+				if parsed.flags[i] != flag {
+					t.Errorf("flags[%d] = %q, want %q", i, parsed.flags[i], flag)
+				}
+			}
+		})
+	}
+}
+
+// TestParseRiskConditionRejectsWhatItCannotEvaluate covers the conditions that used
+// to be accepted and then never matched. Two of them are verbatim from
+// configs/production/broker-enterprise.yaml, where they named four flags — and one
+// action — that have never existed in this codebase, so both policies were dead
+// text in a file recommended as a production template.
+func TestParseRiskConditionRejectsWhatItCannotEvaluate(t *testing.T) {
+	for _, tc := range []struct{ name, condition string }{
+		{"empty", ""},
+		{"whitespace", "   "},
+		{"misspelled flag", "unusual_locaton"},
+		{"flags that never existed", "new_device AND production_access"},
+		{"more flags that never existed", "contractor AND sensitive_data"},
+		{"one good flag and one bad", "after_hours AND sensitive_data"},
+		{"unsupported field", "trust_score >= 80"},
+		{"no operator", "risk_score 80"},
+		{"non-numeric threshold", "risk_score >= high"},
+		{"operator the engine does not have", "risk_score != 80"},
+		{"nothing after AND", "after_hours AND"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseRiskCondition(tc.condition)
+			if err == nil {
+				t.Fatalf("parseRiskCondition(%q) was accepted as %+v; an accepted condition the engine "+
+					"cannot evaluate never matches, so its DENY never denies (#213)", tc.condition, parsed)
+			}
+		})
+	}
+}
+
+// TestEveryRiskFlagIsEvaluated is the guard riskFlagHolds' default branch points
+// at. That default answers false, so a flag added to riskFlagNames without a case
+// in riskFlagHolds would be accepted at startup and then never hold — the same
+// silent no-match this change exists to remove, reintroduced by an ordinary
+// omission.
+//
+// It works by giving each flag a request that must make it true and one that must
+// make it false. A flag with no case answers false to both, and fails here.
+func TestEveryRiskFlagIsEvaluated(t *testing.T) {
+	// A location history the user is not in, so isUnusualLocation can answer true.
+	// The engine records nothing for "known-user" until RecordLocation is called.
+	engine, err := NewPolicyEngine(&config.Config{})
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	defer engine.Close()
+	engine.RecordLocation("known-user", "10.1.2.3")
+
+	afterHours := time.Date(2026, 3, 4, 2, 30, 0, 0, time.Local)
+	businessHours := time.Date(2026, 3, 4, 11, 0, 0, 0, time.Local)
+
+	// One case per canonical flag. Keyed by flag so a new canonical flag with no
+	// entry here is caught by the completeness check below.
+	cases := map[riskFlag]struct {
+		holds    *AuthRequest
+		holdsAt  time.Time
+		notHolds *AuthRequest
+		notAt    time.Time
+	}{
+		riskUnusualLocation: {
+			holds:    &AuthRequest{UserID: "known-user", SourceIP: "203.0.113.9"},
+			holdsAt:  businessHours,
+			notHolds: &AuthRequest{UserID: "known-user", SourceIP: "10.1.2.3"},
+			notAt:    businessHours,
+		},
+		riskAfterHours: {
+			holds:    &AuthRequest{UserID: "u", SourceIP: "10.0.0.1"},
+			holdsAt:  afterHours,
+			notHolds: &AuthRequest{UserID: "u", SourceIP: "10.0.0.1"},
+			notAt:    businessHours,
+		},
+		riskUntrustedNetwork: {
+			holds:    &AuthRequest{UserID: "u", SourceIP: "203.0.113.9"},
+			holdsAt:  businessHours,
+			notHolds: &AuthRequest{UserID: "u", SourceIP: "10.0.0.1"},
+			notAt:    businessHours,
+		},
+		riskUnknownDevice: {
+			holds:    &AuthRequest{UserID: "u", SourceIP: "10.0.0.1"},
+			holdsAt:  businessHours,
+			notHolds: &AuthRequest{UserID: "u", SourceIP: "10.0.0.1", DeviceID: "laptop-7"},
+			notAt:    businessHours,
+		},
+		riskUnknownNetwork: {
+			holds:    &AuthRequest{UserID: "u", SourceIP: ""},
+			holdsAt:  businessHours,
+			notHolds: &AuthRequest{UserID: "u", SourceIP: "10.0.0.1"},
+			notAt:    businessHours,
+		},
+	}
+
+	// Every canonical flag in the map an operator's condition is resolved against
+	// must have a case here, so adding a flag forces adding its evaluation test.
+	for _, canonical := range riskFlagNames {
+		if _, covered := cases[canonical]; !covered {
+			t.Errorf("riskFlagNames resolves to %q, which no case here exercises; a flag with no "+
+				"case in riskFlagHolds is accepted at startup and then never holds", canonical)
+		}
+	}
+
+	for flag, tc := range cases {
+		t.Run(string(flag), func(t *testing.T) {
+			if !engine.riskFlagHolds(flag, tc.holds, tc.holdsAt) {
+				t.Errorf("riskFlagHolds(%q) is false for a request that should satisfy it; if the flag "+
+					"has no case in riskFlagHolds, a policy naming it never matches", flag)
+			}
+			if engine.riskFlagHolds(flag, tc.notHolds, tc.notAt) {
+				t.Errorf("riskFlagHolds(%q) is true for a request that should not satisfy it", flag)
+			}
+		})
+	}
+}
+
+// TestUntrustedNetworkHoldsForAnUnknownOrigin pins the direction the ambiguous case
+// falls, following #169: a login the broker cannot place on any network is not
+// evidence of a safe one, so the flag holds. Getting this backwards would let a
+// login that reports no source address slip past every untrusted_network policy.
+func TestUntrustedNetworkHoldsForAnUnknownOrigin(t *testing.T) {
+	engine, err := NewPolicyEngine(&config.Config{})
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	defer engine.Close()
+
+	req := &AuthRequest{UserID: "u"} // no SourceIP: a console login, or a PAM_RHOST that is a name
+	if !engine.riskFlagHolds(riskUntrustedNetwork, req, time.Now()) {
+		t.Error("untrusted_network is false for a login with no source address; an unknown origin is " +
+			"not evidence of a trusted one (#169)")
+	}
+}
+
+// TestRiskConditionWithNoFlagsCannotHold covers holds()'s trailing
+// `len(c.flags) > 0`. Without it an empty conjunction — every flag loop trivially
+// satisfied — would return true, so a policy whose condition failed to yield any
+// flag would match every single login. For a DENY policy that locks out the host.
+func TestRiskConditionWithNoFlagsCannotHold(t *testing.T) {
+	engine, err := NewPolicyEngine(&config.Config{})
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	defer engine.Close()
+
+	empty := riskCondition{raw: "constructed with no flags"}
+	if empty.holds(engine, &AuthRequest{UserID: "u"}, &PolicyResult{RiskScore: 0}, time.Now()) {
+		t.Error("a condition with no flags and no score comparison holds, so it would match every login")
+	}
+}
+
+// TestRiskPolicyActions pins the two actions the broker performs. The other two
+// were accepted, set a field nothing read, and let the login proceed exactly as if
+// the policy had not matched — so a config full of REQUIRE_APPROVAL described an
+// approval workflow that has never existed.
+func TestRiskPolicyActions(t *testing.T) {
+	for action, want := range map[string]bool{
+		"DENY":                   true,
+		"LOG":                    true,
+		"REQUIRE_ADDITIONAL_MFA": false,
+		"REQUIRE_APPROVAL":       false,
+		"ALLOW":                  false,
+		"deny":                   false, // the spelling is upper case; a near miss must not pass
+	} {
+		cfg := &config.Config{
+			Authentication: config.AuthenticationConfig{
+				RiskPolicies: []config.RiskPolicy{{Condition: "risk_score >= 80", Action: action}},
+			},
+		}
+		err := validatePolicySupport(cfg)
+		if want && err != nil {
+			t.Errorf("risk action %q was refused: %v", action, err)
+		}
+		if !want && err == nil {
+			t.Errorf("risk action %q was accepted; the broker does not perform it, so the policy would "+
+				"match and then do nothing (#212)", action)
+		}
+	}
+}
+
+// TestParseAllowedHoursSpansMidnight is the case a comparison against two same-day
+// timestamps gets wrong. A window of 22:00-06:00 is the union of two halves of the
+// clock; treating it as one range makes it empty, so a restriction meant to permit
+// overnight access denies all of it — and a restriction meant to *confine* access to
+// those hours permits none.
+func TestParseAllowedHoursSpansMidnight(t *testing.T) {
+	window, err := parseAllowedHours("22:00-06:00")
+	if err != nil {
+		t.Fatalf("parseAllowedHours: %v", err)
+	}
+
+	for _, tc := range []struct {
+		hour, minute int
+		want         bool
+	}{
+		{23, 0, true},  // before midnight
+		{0, 30, true},  // after midnight
+		{5, 59, true},  // last minute in
+		{6, 0, false},  // the end is exclusive
+		{12, 0, false}, // the middle of the day is out
+		{21, 59, false},
+		{22, 0, true}, // the start is inclusive
+	} {
+		at := time.Date(2026, 3, 4, tc.hour, tc.minute, 0, 0, time.Local)
+		if got := window.contains(at); got != tc.want {
+			t.Errorf("22:00-06:00 contains %02d:%02d = %v, want %v", tc.hour, tc.minute, got, tc.want)
+		}
+	}
+}
+
+// TestParseAllowedHours covers the ordinary window and the empty one, which means
+// "no restriction" rather than "no hours".
+func TestParseAllowedHours(t *testing.T) {
+	window, err := parseAllowedHours("08:00-18:00")
+	if err != nil {
+		t.Fatalf("parseAllowedHours: %v", err)
+	}
+	for _, tc := range []struct {
+		hour int
+		want bool
+	}{{7, false}, {8, true}, {17, true}, {18, false}, {23, false}} {
+		at := time.Date(2026, 3, 4, tc.hour, 0, 0, 0, time.Local)
+		if got := window.contains(at); got != tc.want {
+			t.Errorf("08:00-18:00 contains %02d:00 = %v, want %v", tc.hour, got, tc.want)
+		}
+	}
+
+	unrestricted, err := parseAllowedHours("")
+	if err != nil {
+		t.Fatalf("parseAllowedHours(\"\"): %v", err)
+	}
+	if !unrestricted.contains(time.Date(2026, 3, 4, 3, 0, 0, 0, time.Local)) {
+		t.Error("an unset allowed_hours excludes 03:00; it must mean no restriction, not no hours")
+	}
+}
+
+// TestParseAllowedHoursRejectsWhatItCannotRead covers the reason this is parsed at
+// startup. An unreadable window used to leave the restriction inert, so an operator
+// who wrote "8am-6pm" got no time restriction at all and no indication of it.
+func TestParseAllowedHoursRejectsWhatItCannotRead(t *testing.T) {
+	for _, spec := range []string{
+		"8am-6pm",
+		"08:00",
+		"08:00-",
+		"-18:00",
+		"08:00-18:00-20:00",
+		"24:00-06:00",
+		"08:60-18:00",
+		"eight-six",
+	} {
+		if window, err := parseAllowedHours(spec); err == nil {
+			t.Errorf("parseAllowedHours(%q) was accepted as %+v; an allowed_hours the broker cannot "+
+				"read used to leave the restriction inert (#213)", spec, window)
+		}
+	}
+}
+
+// TestTimeRestrictionNeedsAProviderScope and the geo equivalent in
+// policy_geoip_test.go cover the same defect from #213: a restriction naming a
+// provider was skipped unless its list contained the literal "all", so every
+// provider-scoped restriction in every config was inert. Scoping works now, which
+// makes an empty list a configuration error rather than a silent no-op.
+func TestTimeRestrictionNeedsAProviderScope(t *testing.T) {
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TimeBasedPolicies: config.TimeBasedPolicies{
+				TimeRestrictions: []config.TimeRestriction{
+					{AllowedHours: "08:00-18:00"},
+				},
+			},
+		},
+	}
+
+	err := validatePolicySupport(cfg)
+	if err == nil {
+		t.Fatal("a time restriction with an empty providers list was accepted; it applies to no " +
+			"provider, so it restricts nothing (#212)")
+	}
+	if !strings.Contains(err.Error(), "providers") {
+		t.Errorf("the startup error does not name the empty providers list: %v", err)
+	}
+}
+
+// TestTimeRestrictionExceptionsAreRefused covers a setting that made the
+// restriction weaker than it read: exceptions parsed and nothing read it, so a
+// listed group was still refused outside the window. Refusing to start is the only
+// answer that does not misreport which identities the window applies to.
+func TestTimeRestrictionExceptionsAreRefused(t *testing.T) {
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TimeBasedPolicies: config.TimeBasedPolicies{
+				TimeRestrictions: []config.TimeRestriction{{
+					Providers:    []string{"all"},
+					AllowedHours: "08:00-18:00",
+					Exceptions:   []string{"emergency-access"},
+				}},
+			},
+		},
+	}
+
+	err := validatePolicySupport(cfg)
+	if err == nil {
+		t.Fatal("a time restriction with exceptions was accepted; the exception is not applied, so a " +
+			"listed group is still refused outside the window (#212)")
+	}
+	if !strings.Contains(err.Error(), "exceptions") {
+		t.Errorf("the startup error does not name exceptions: %v", err)
+	}
+}
+
+// TestTimeRestrictionTimezoneMustLoad covers the last of the compile-at-startup
+// changes. An unloadable timezone left the window compared against the wrong clock
+// — the broker's own — so a restriction written for America/New_York silently ran
+// in UTC, five hours out.
+func TestTimeRestrictionTimezoneMustLoad(t *testing.T) {
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TimeBasedPolicies: config.TimeBasedPolicies{
+				TimeRestrictions: []config.TimeRestriction{{
+					Providers:    []string{"all"},
+					AllowedHours: "08:00-18:00",
+					Timezone:     "America/Notaplace",
+				}},
+			},
+		},
+	}
+
+	if err := validatePolicySupport(cfg); err == nil {
+		t.Fatal("a time restriction naming a timezone the host cannot load was accepted; the window " +
+			"would be compared against the broker's own clock instead (#213)")
+	}
+}
+
+// TestRestrictionApplies covers the scoping fix itself: "all", an exact name, a
+// case-different name, a non-match, and the empty list that used to be the only
+// thing every provider-scoped restriction effectively had.
+func TestRestrictionApplies(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		providers []string
+		provider  string
+		want      bool
+	}{
+		{"all matches anything", []string{"all"}, "corporate", true},
+		{"all matches an unnamed provider", []string{"all"}, "", true},
+		{"exact name", []string{"contractors"}, "contractors", true},
+		{"case-insensitive name", []string{"Contractors"}, "contractors", true},
+		{"one of several", []string{"corporate", "contractors"}, "contractors", true},
+		{"a different provider", []string{"contractors"}, "corporate", false},
+		{"empty list matches nothing", nil, "contractors", false},
+		// A restriction naming a provider must not apply when the broker does not
+		// know which provider is in play: matching on "" would apply every
+		// provider-scoped restriction at once.
+		{"named provider, unknown provider name", []string{"contractors"}, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := restrictionApplies(tc.providers, tc.provider); got != tc.want {
+				t.Errorf("restrictionApplies(%v, %q) = %v, want %v",
+					tc.providers, tc.provider, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/policy_test.go
+++ b/pkg/auth/policy_test.go
@@ -45,7 +45,7 @@ func TestPolicyEngine_BasicEvaluation(t *testing.T) {
 		Timestamp:  time.Now(),
 	}
 
-	result, err := pe.EvaluateRequest(request)
+	result, err := pe.EvaluateRequest(request, "")
 	if err != nil {
 		t.Fatalf("Failed to evaluate request: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestPolicyEngine_DifferentIPTypes(t *testing.T) {
 			Timestamp:  time.Now(),
 		}
 
-		result, err := pe.EvaluateRequest(request)
+		result, err := pe.EvaluateRequest(request, "")
 		if err != nil {
 			t.Logf("Warning: Failed to evaluate request with IP %s: %v", ip, err)
 			continue
@@ -123,7 +123,7 @@ func TestPolicyEngine_RequestValidation(t *testing.T) {
 	}
 
 	// Test with nil request (should be handled gracefully)
-	result, err := pe.EvaluateRequest(nil)
+	result, err := pe.EvaluateRequest(nil, "")
 	if err == nil {
 		t.Error("Expected error with nil request")
 	}
@@ -133,7 +133,7 @@ func TestPolicyEngine_RequestValidation(t *testing.T) {
 
 	// Test with empty request
 	emptyRequest := &AuthRequest{}
-	result, err = pe.EvaluateRequest(emptyRequest)
+	result, err = pe.EvaluateRequest(emptyRequest, "")
 	if err != nil {
 		t.Logf("Warning: Error with empty request: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestPolicyEngine_TimeBasedEvaluation(t *testing.T) {
 			Timestamp:  timestamp,
 		}
 
-		result, err := pe.EvaluateRequest(request)
+		result, err := pe.EvaluateRequest(request, "")
 		if err != nil {
 			t.Logf("Warning: Failed to evaluate request with timestamp %v: %v", timestamp, err)
 			continue
@@ -218,7 +218,7 @@ func TestPolicyEngine_UserAgentEvaluation(t *testing.T) {
 			Timestamp:  time.Now(),
 		}
 
-		result, err := pe.EvaluateRequest(request)
+		result, err := pe.EvaluateRequest(request, "")
 		if err != nil {
 			t.Logf("Warning: Failed to evaluate request with user agent %s: %v", userAgent, err)
 			continue
@@ -264,7 +264,7 @@ func TestPolicyEngine_TargetHostEvaluation(t *testing.T) {
 			Timestamp:  time.Now(),
 		}
 
-		result, err := pe.EvaluateRequest(request)
+		result, err := pe.EvaluateRequest(request, "")
 		if err != nil {
 			t.Logf("Warning: Failed to evaluate request with host %s: %v", host, err)
 			continue
@@ -296,7 +296,7 @@ func TestPolicyEngine_EmptyConfiguration(t *testing.T) {
 		Timestamp:  time.Now(),
 	}
 
-	result, err := pe.EvaluateRequest(request)
+	result, err := pe.EvaluateRequest(request, "")
 	if err != nil {
 		t.Logf("Warning: Failed to evaluate request with empty config: %v", err)
 		return

--- a/pkg/auth/session_fail_closed_test.go
+++ b/pkg/auth/session_fail_closed_test.go
@@ -1,0 +1,607 @@
+package auth
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/testoidc"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+)
+
+// TestDeviceFlowWillNotActivateASessionThatIsGone is the acceptance gate for #217.
+//
+// A device flow runs for up to its whole lifetime — ten minutes with the shipped
+// providers — and during that window the session it belongs to can be revoked by an
+// operator (`oidc-admin`, RevokeSession) or swept for expiry. The completion path
+// then wrote IsActive: true into the session map unconditionally, which put the
+// revoked session back as a fully active one with an SSH key installed in the
+// account's authorized_keys. The operator who revoked it had no way to know: the
+// revocation was audited as successful, and nothing afterwards said it had been
+// undone.
+//
+// The session is removed before the flow is driven, which is the same state
+// `replaceSession` sees for a mid-flow revocation — the pointer the flow read is no
+// longer the pointer stored — without depending on the timing of a real one.
+func TestDeviceFlowWillNotActivateASessionThatIsGone(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.idp.Script(testoidc.Grant)
+
+	// The operator revokes it while the provider round-trip is in flight.
+	env.broker.removeSession(env.session.ID)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("a session revoked during its device flow was brought back by the flow completing: %+v",
+			session)
+	}
+
+	event := env.auditEvent(t, "authentication_denied")
+	if event.ErrorCode != "SESSION_GONE" {
+		t.Errorf("denial recorded with error_code %q, want SESSION_GONE", event.ErrorCode)
+	}
+	if event.Success {
+		t.Error("the denial event is recorded with success=true")
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("completing the flow for a revoked session was recorded as a successful login (#217)")
+		}
+	}
+
+	// The credential half, which is what makes this more than an accounting error.
+	// The key was generated and installed before the store was attempted, so
+	// refusing to activate without withdrawing it would leave a working SSH key for
+	// a session that does not exist — reachable by anyone holding the private half,
+	// and invisible to `oidc-admin list-sessions`.
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("the key issued to a revoked session is still authorized, so the revocation left a "+
+			"usable login behind (#217):\n%s", data)
+	}
+	if _, err := env.broker.keyManager.LoadKey(env.session.ID); err == nil {
+		t.Error("the key pair issued to a revoked session is still in the key store")
+	}
+}
+
+// TestDeviceFlowDeniesAnUntrustedDeviceWhenPolicyRequiresIt is the enforcement half
+// of require_device_trust (#212). The setting appears in every shipped provider
+// template and used to write a metadata key that nothing read, so `production` tiers
+// asking for a hardware-backed login admitted any device at all.
+//
+// It is enforced here, at the end of the flow, rather than during policy evaluation:
+// device trust comes from the token's `amr` claim (RFC 8176 `hwk`/`fido`), and when
+// policy is evaluated no token exists yet.
+func TestDeviceFlowDeniesAnUntrustedDeviceWhenPolicyRequiresIt(t *testing.T) {
+	env := newPollTestEnv(t)
+	// What a matching policy with require_device_trust: true resolves to. The test
+	// issuer's tokens carry no amr, which is what an IdP that was never configured to
+	// send one does.
+	env.session.RequireDeviceTrust = true
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	if session := env.activeSession(); session != nil {
+		t.Errorf("require_device_trust admitted an identity whose token has no hardware-backed amr "+
+			"method: %+v", session)
+	}
+
+	event := env.auditEvent(t, "authentication_denied")
+	if event.ErrorCode != "DEVICE_NOT_TRUSTED" {
+		t.Errorf("denial recorded with error_code %q, want DEVICE_NOT_TRUSTED", event.ErrorCode)
+	}
+	for _, e := range env.auditEvents(t) {
+		if e.EventType == "authentication_successful" {
+			t.Fatal("a login denied for device trust was also recorded as successful")
+		}
+	}
+
+	authorizedKeys := filepath.Join(env.homeDir, env.session.UserID, ".ssh", "authorized_keys")
+	if data, err := os.ReadFile(authorizedKeys); err == nil && strings.Contains(string(data), "@oidc-pam-") {
+		t.Errorf("a login denied for device trust installed a login key:\n%s", data)
+	}
+}
+
+// TestDeviceFlowAdmitsATrustedDevice is the other half: the requirement must be
+// satisfiable, or it is just an outage. The `amr` claim carrying `hwk` is what
+// UserInfo.DeviceTrusted is derived from.
+func TestDeviceFlowAdmitsATrustedDevice(t *testing.T) {
+	env := newPollTestEnv(t)
+	env.session.RequireDeviceTrust = true
+	// RFC 8176 `hwk`: proof of possession of a hardware-secured key. `fido` is the
+	// other method the broker accepts.
+	claims := testoidc.DefaultClaims()
+	claims["amr"] = []string{"pwd", "hwk"}
+	env.idp.SetClaims(claims)
+	env.idp.Script(testoidc.Grant)
+
+	env.run(t)
+
+	session := env.activeSession()
+	if session == nil {
+		t.Fatal("an identity presenting a hardware-key amr method was denied under require_device_trust")
+	}
+	if !session.IsActive {
+		t.Error("the session is inactive after a login that satisfies require_device_trust")
+	}
+	if !session.DeviceTrusted {
+		t.Error("the session does not record the device as trusted, though amr carried hwk")
+	}
+}
+
+// refreshTestBroker builds a broker for the RefreshSession guards: a real policy
+// engine over cfg, a token store, a file-backed audit logger and one session in the
+// map.
+//
+// No provider is registered. Every guard under test has to answer before the
+// provider is looked up, so a test that reaches the provider gets
+// PROVIDER_NOT_FOUND rather than a false pass — which is itself the assertion that
+// the guard ran too late.
+func refreshTestBroker(t *testing.T, cfg *config.Config, session *Session) (*Broker, string) {
+	t.Helper()
+
+	// "sync" writes on the calling goroutine, so a denial is on disk by the time
+	// RefreshSession returns and no Start()/Stop() pair is needed.
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{
+		Enabled:          true,
+		Outputs:          []config.AuditOutput{{Type: "file", Path: auditPath}},
+		OverflowStrategy: "sync",
+	})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = auditLogger.Stop() })
+
+	broker := &Broker{
+		config:       cfg,
+		sessions:     make(map[string]*Session),
+		policyEngine: newTestPolicyEngine(t, cfg),
+		providers:    map[string]*OIDCProvider{},
+		auditLogger:  auditLogger,
+		tokenManager: newTestTokenManager(t),
+	}
+	broker.setSession(session)
+	return broker, auditPath
+}
+
+// auditEventsAt reads the events an audit logger wrote to path. A run that recorded
+// nothing yields nil rather than an error, so a test can assert on an absence.
+func auditEventsAt(t *testing.T, path string) []security.AuditEvent {
+	t.Helper()
+
+	data, err := os.ReadFile(path) // #nosec G304 -- a path this test just created
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("reading the audit log: %v", err)
+	}
+
+	var events []security.AuditEvent
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var event security.AuditEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("audit line %q is not a valid event: %v", line, err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func refreshTestConfig() *config.Config {
+	return &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:    time.Hour,
+			RefreshThreshold: 15 * time.Minute,
+		},
+	}
+}
+
+// TestRefreshSessionRefusesAPendingSession is the acceptance gate for #215.
+//
+// A device-flow session is stored with IsActive: false and an ExpiresAt one token
+// lifetime out, before anyone has approved anything. Every check RefreshSession made
+// was satisfied by such a session: it existed, the user matched, it had not expired,
+// and it was inside the refresh threshold only if the threshold was wide — so the
+// "not close to expiry" branch returned createSuccessResponse, a `success: true`
+// carrying the session ID and expiry for a login that nobody had authenticated.
+//
+// The severity is bounded by the wire: refresh_session requires a root peer over the
+// IPC socket (internal/ipc verifyPeerCredentials) and internal/brokerclient has no
+// RefreshSession, so no shipped client can reach it. It is a fail-open on a public
+// broker operation, closed here rather than left to depend on those two facts
+// continuing to hold.
+func TestRefreshSessionRefusesAPendingSession(t *testing.T) {
+	// Far enough out that the "not close to expiry" early return is the branch that
+	// answers, which is the one that used to say success.
+	session := &Session{
+		ID:        "pending-device-flow",
+		UserID:    "test-user",
+		Provider:  "test-provider",
+		IsActive:  false,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	broker, _ := refreshTestBroker(t, refreshTestConfig(), session)
+
+	resp, err := broker.RefreshSession("pending-device-flow", "test-user")
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("refreshing a session nobody has authenticated returned success (%+v); the device "+
+			"flow had not completed (#215)", resp)
+	}
+	if resp.ErrorCode != "SESSION_NOT_ACTIVE" {
+		t.Errorf("error_code = %q, want SESSION_NOT_ACTIVE", resp.ErrorCode)
+	}
+}
+
+// TestRefreshSessionRefusesAnExpiredSession covers the same fail-open from the other
+// direction. An ExpiresAt in the past made time.Until negative, so the
+// "close to expiry" comparison was false, the early return was skipped — and the
+// session was renewed. Expiry therefore bounded nothing at all for a client that
+// kept calling.
+func TestRefreshSessionRefusesAnExpiredSession(t *testing.T) {
+	session := &Session{
+		ID:        "expired-session",
+		UserID:    "test-user",
+		Provider:  "test-provider",
+		IsActive:  true,
+		TokenID:   "some-token",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-time.Minute),
+	}
+	broker, _ := refreshTestBroker(t, refreshTestConfig(), session)
+
+	resp, err := broker.RefreshSession("expired-session", "test-user")
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("an expired session was refreshed back to life: %+v", resp)
+	}
+	if resp.ErrorCode != "SESSION_EXPIRED" {
+		t.Errorf("error_code = %q, want SESSION_EXPIRED", resp.ErrorCode)
+	}
+	// Dropped, not merely refused: leaving it in the map keeps the SSH key
+	// installed for the rest of its own window.
+	if got := broker.getSession("expired-session"); got != nil {
+		t.Error("the expired session is still in the session map after the refresh was refused")
+	}
+}
+
+// TestRefreshSessionEnforcesMaxSessionDuration is the enforcement half of
+// max_session_duration (#212). The setting parsed, loaded and was read by nothing:
+// a session's life was `token_lifetime` from each refresh, without limit, so a
+// policy naming a two-hour ceiling bounded a session that could run for weeks.
+//
+// The ceiling is measured from CreatedAt, so it is a ceiling on the session rather
+// than on the gap between refreshes.
+func TestRefreshSessionEnforcesMaxSessionDuration(t *testing.T) {
+	session := &Session{
+		ID:          "long-running-session",
+		UserID:      "test-user",
+		Provider:    "test-provider",
+		IsActive:    true,
+		TokenID:     "some-token",
+		CreatedAt:   time.Now().Add(-3 * time.Hour),
+		ExpiresAt:   time.Now().Add(30 * time.Minute), // not expired in its own right
+		MaxDuration: 2 * time.Hour,
+	}
+	broker, _ := refreshTestBroker(t, refreshTestConfig(), session)
+
+	resp, err := broker.RefreshSession("long-running-session", "test-user")
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("a session three hours into a two-hour max_session_duration was refreshed: %+v", resp)
+	}
+	if resp.ErrorCode != "SESSION_EXPIRED" {
+		t.Errorf("error_code = %q, want SESSION_EXPIRED", resp.ErrorCode)
+	}
+	if got := broker.getSession("long-running-session"); got != nil {
+		t.Error("the session is still in the map after reaching its maximum duration")
+	}
+}
+
+// TestSessionExpiryIsCappedByMaxDuration covers the arithmetic directly, including
+// the case that matters most: the last refresh before the ceiling must not push the
+// expiry — and with it the SSH key's `expiry-time=` — past it.
+func TestSessionExpiryIsCappedByMaxDuration(t *testing.T) {
+	broker := &Broker{config: refreshTestConfig()} // TokenLifetime: 1h
+
+	createdAt := time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name        string
+		now         time.Time
+		maxDuration time.Duration
+		want        time.Time
+	}{
+		{
+			name: "no ceiling gives a full token lifetime",
+			now:  createdAt,
+			want: createdAt.Add(time.Hour),
+		},
+		{
+			name:        "a ceiling beyond the token lifetime does not extend it",
+			now:         createdAt,
+			maxDuration: 8 * time.Hour,
+			want:        createdAt.Add(time.Hour),
+		},
+		{
+			name:        "a ceiling inside the token lifetime caps it",
+			now:         createdAt,
+			maxDuration: 30 * time.Minute,
+			want:        createdAt.Add(30 * time.Minute),
+		},
+		{
+			// The refresh 90 minutes into a 2-hour session gets 30 minutes, not 60.
+			name:        "the last refresh before the ceiling is trimmed to it",
+			now:         createdAt.Add(90 * time.Minute),
+			maxDuration: 2 * time.Hour,
+			want:        createdAt.Add(2 * time.Hour),
+		},
+		{
+			name:        "a zero ceiling means no ceiling",
+			now:         createdAt.Add(90 * time.Minute),
+			maxDuration: 0,
+			want:        createdAt.Add(150 * time.Minute),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := broker.sessionExpiry(createdAt, tc.now, tc.maxDuration)
+			if !got.Equal(tc.want) {
+				t.Errorf("sessionExpiry(created=%v, now=%v, max=%v) = %v, want %v",
+					createdAt, tc.now, tc.maxDuration, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRefreshSessionRefusesWhatPolicyNoLongerAllows is the acceptance gate for the
+// re-evaluation half of #215. Policy used to be evaluated exactly once, when a login
+// started, so every control an operator can change afterwards — group membership, an
+// ip_whitelist, a country list, a deny-on-risk policy — had no effect on a session
+// already running. A client that kept refreshing kept the session, and the SSH key
+// whose expiry-time= is derived from the same ExpiresAt, alive indefinitely; the only
+// remedy was for an operator to find and revoke the session by hand.
+//
+// Here the operator has added a require_groups the live session's identity does not
+// satisfy, which is the ordinary shape of "revoke this person's access".
+func TestRefreshSessionRefusesWhatPolicyNoLongerAllows(t *testing.T) {
+	cfg := refreshTestConfig()
+	cfg.Authentication.Policies = map[string]config.AuthenticationPolicy{
+		"default": {RequireGroups: []string{"production-access"}},
+	}
+
+	session := &Session{
+		ID:        "tightened-out",
+		UserID:    "test-user",
+		Provider:  "test-provider",
+		Groups:    []string{"researchers"}, // not production-access
+		IsActive:  true,
+		TokenID:   "some-token",
+		CreatedAt: time.Now(),
+		// Inside the refresh threshold, so a passing policy check would go on to
+		// look for the provider — which this broker does not have, so a false pass
+		// is distinguishable from a real one.
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	broker, auditPath := refreshTestBroker(t, cfg, session)
+
+	resp, err := broker.RefreshSession("tightened-out", "test-user")
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if resp.Success {
+		t.Fatalf("a session whose identity no longer satisfies require_groups was refreshed: %+v", resp)
+	}
+	if resp.ErrorCode != "POLICY_DENIED" {
+		t.Errorf("error_code = %q, want POLICY_DENIED", resp.ErrorCode)
+	}
+	// The session is dropped rather than left live until its own expiry: policy says
+	// this identity may not have this access, and the SSH key stays installed for as
+	// long as the session does.
+	if got := broker.getSession("tightened-out"); got != nil {
+		t.Error("the session survived a policy denial, so its SSH key stays installed until it expires")
+	}
+
+	// An access that ends because policy changed is the event an operator is looking
+	// for when they ask whether the change took effect, so it has to be in the trail
+	// with the reason — not just refused to the caller.
+	events := auditEventsAt(t, auditPath)
+	var denial *security.AuditEvent
+	for i := range events {
+		if events[i].EventType == "session_refresh_denied" {
+			denial = &events[i]
+		}
+	}
+	if denial == nil {
+		t.Fatalf("the refresh denial was not audited; the log holds %+v", events)
+	}
+	if denial.Success {
+		t.Error("the denial is recorded with success=true")
+	}
+	if denial.ErrorCode != "POLICY_DENIED" {
+		t.Errorf("audited error_code = %q, want POLICY_DENIED", denial.ErrorCode)
+	}
+	if !strings.Contains(denial.ErrorMessage, "production-access") {
+		t.Errorf("audited reason %q does not name the group the identity is missing, so the record does "+
+			"not say why the access ended", denial.ErrorMessage)
+	}
+}
+
+// TestRefreshSessionAllowsWhatPolicyStillAllows is what stops the re-evaluation from
+// being an outage. A session whose identity still satisfies the policy must refresh
+// — and reaching PROVIDER_NOT_FOUND is the proof it got past every guard, since this
+// broker registers no provider.
+func TestRefreshSessionAllowsWhatPolicyStillAllows(t *testing.T) {
+	cfg := refreshTestConfig()
+	cfg.Authentication.Policies = map[string]config.AuthenticationPolicy{
+		"default": {RequireGroups: []string{"production-access"}},
+	}
+
+	session := &Session{
+		ID:        "still-allowed",
+		UserID:    "test-user",
+		Provider:  "test-provider",
+		Groups:    []string{"researchers", "production-access"},
+		IsActive:  true,
+		TokenID:   "some-token",
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	broker, _ := refreshTestBroker(t, cfg, session)
+
+	resp, err := broker.RefreshSession("still-allowed", "test-user")
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if resp.ErrorCode == "POLICY_DENIED" {
+		t.Fatalf("a session that still satisfies require_groups was denied by the re-evaluation: %+v", resp)
+	}
+	if resp.ErrorCode != "PROVIDER_NOT_FOUND" {
+		t.Errorf("error_code = %q, want PROVIDER_NOT_FOUND: the refresh should have got past every "+
+			"guard and on to the token exchange", resp.ErrorCode)
+	}
+	if got := broker.getSession("still-allowed"); got == nil {
+		t.Error("a session that policy still allows was dropped")
+	}
+}
+
+// TestCheckSessionDoesNotResurrectARevokedSession drives the compare-and-set in
+// CheckSession from the outside, the other half of #217: once a session has been
+// revoked, no check that was already in flight may put it back.
+//
+// Revocation is the invariant, not the interleaving — the assertion holds however
+// the goroutines are scheduled, so the test cannot flake. Under -race it is also
+// what shows that the clone, rather than an in-place write to a pointer other
+// readers hold, is what CheckSession does.
+func TestCheckSessionDoesNotResurrectARevokedSession(t *testing.T) {
+	session := &Session{
+		ID:           "checked-then-revoked",
+		UserID:       "test-user",
+		IsActive:     true,
+		CreatedAt:    time.Now(),
+		ExpiresAt:    time.Now().Add(time.Hour),
+		LastAccessed: time.Now().Add(-time.Minute),
+	}
+	broker, _ := refreshTestBroker(t, refreshTestConfig(), session)
+
+	const checkers = 8
+	var wg sync.WaitGroup
+	for range checkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				if _, err := broker.CheckSession(session.ID, session.UserID); err != nil {
+					t.Errorf("CheckSession: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	broker.removeSession(session.ID)
+	wg.Wait()
+
+	if got := broker.getSession(session.ID); got != nil {
+		t.Errorf("a revoked session is back in the session map, put there by a check that was already "+
+			"in flight (#217): %+v", got)
+	}
+}
+
+// TestCheckSessionReportsTheAccessItJustRecorded covers the stale-pointer half of
+// #215. CheckSession clones the session, writes the clone, and then built its
+// response from the pointer it had read — so the caller was handed a LastAccessed
+// from before this check, and would read whatever a future in-place mutation
+// happened to leave there.
+func TestCheckSessionReportsTheAccessItJustRecorded(t *testing.T) {
+	before := time.Now().Add(-time.Hour)
+	session := &Session{
+		ID:           "checked",
+		UserID:       "test-user",
+		IsActive:     true,
+		CreatedAt:    before,
+		ExpiresAt:    time.Now().Add(time.Hour),
+		LastAccessed: before,
+	}
+	broker, _ := refreshTestBroker(t, refreshTestConfig(), session)
+
+	resp, err := broker.CheckSession("checked", "test-user")
+	if err != nil {
+		t.Fatalf("CheckSession: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("CheckSession refused a live session: %+v", resp)
+	}
+
+	// The stored session records this check...
+	stored := broker.getSession("checked")
+	if stored == nil {
+		t.Fatal("the session is gone after a successful check")
+	}
+	if !stored.LastAccessed.After(before) {
+		t.Errorf("stored LastAccessed = %v, not updated past %v", stored.LastAccessed, before)
+	}
+	// ...and the pointer that was read is left alone, which is what makes the
+	// concurrent reader safe.
+	if !session.LastAccessed.Equal(before) {
+		t.Errorf("the session pointer held by other readers was mutated in place: LastAccessed = %v, "+
+			"want the unchanged %v", session.LastAccessed, before)
+	}
+}
+
+// TestReplaceSessionRequiresThePointerItWasGiven pins the primitive both fixes rest
+// on. Every path that invalidates a session either deletes the entry or stores a
+// fresh copy, so "the pointer I read is still the pointer stored" is exactly
+// "nothing has happened to this session since I read it" — a condition that
+// re-reading the session's fields cannot establish.
+func TestReplaceSessionRequiresThePointerItWasGiven(t *testing.T) {
+	broker := &Broker{sessions: make(map[string]*Session)}
+
+	stored := &Session{ID: "s", UserID: "u", IsActive: true}
+	broker.setSession(stored)
+	if broker.getSession("s") != stored {
+		t.Fatal("setSession did not store the session it was given")
+	}
+
+	updated := *stored
+	updated.LastAccessed = time.Now()
+	if !broker.replaceSession(stored, &updated) {
+		t.Fatal("replaceSession refused a store against the pointer it was reading")
+	}
+	if broker.getSession("s") != &updated {
+		t.Error("replaceSession reported success without storing the update")
+	}
+
+	// A second store against the now-stale pointer must be refused: something has
+	// happened to the session since that pointer was read.
+	stale := *stored
+	if broker.replaceSession(stored, &stale) {
+		t.Error("replaceSession accepted a store against a stale pointer, so a slow path could " +
+			"overwrite a newer session with its own older copy")
+	}
+
+	// And a store against a deleted entry, which is the revocation case.
+	broker.removeSession("s")
+	if broker.replaceSession(&updated, &updated) {
+		t.Error("replaceSession accepted a store for a session that had been removed, which is how a " +
+			"revoked session came back (#217)")
+	}
+}

--- a/pkg/auth/shipped_configs_start_test.go
+++ b/pkg/auth/shipped_configs_start_test.go
@@ -1,0 +1,216 @@
+package auth
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+)
+
+// TestShippedConfigsStartAPolicyEngine closes the gap that #212's fix opened.
+//
+// pkg/config's TestShippedConfigsLoad already loads and validates every file under
+// configs/, but loading is not starting: since v0.5.1 the broker also refuses a
+// configuration whose access controls it cannot enforce, and that check lives in
+// pkg/auth. So a shipped template could pass the existing gate and still stop the
+// broker on the operator's host — which is exactly what every one of these files
+// did the moment the check was added, because between them they set nine
+// unenforceable policy keys, two risk actions the broker does not perform, and two
+// risk conditions naming flags that have never existed.
+//
+// The engine is built through NewPolicyEngine, the same call cmd/broker makes, so
+// this fails for anything that would have failed at startup: an unsupported key, an
+// unparseable risk condition, a time restriction scoped to no provider, a country
+// restriction with no GeoIP database, or a GeoIP database path that does not exist.
+func TestShippedConfigsStartAPolicyEngine(t *testing.T) {
+	// configs/providers/aws-identity-center.yaml resolves an env: secret reference.
+	t.Setenv("OIDC_CLIENT_SECRET", "test-client-secret")
+	// These are production templates: no development-mode relaxations.
+	t.Setenv("OIDC_AUTH_DEV", "")
+
+	root := filepath.Join("..", "..")
+	files := wholeConfigsUnder(t, filepath.Join(root, "configs"))
+	if len(files) == 0 {
+		t.Fatal("no whole broker configurations found under configs/ — this gate would pass vacuously")
+	}
+	// The end-to-end harness's configuration, which is only ever loaded inside a
+	// Linux container and so has no other chance to be checked on this host.
+	if e2e := filepath.Join(root, "test", "e2e", "broker.yaml"); isWholeConfigFile(e2e) {
+		files = append(files, e2e)
+	}
+
+	for _, file := range files {
+		name, err := filepath.Rel(root, file)
+		if err != nil {
+			name = file
+		}
+		t.Run(name, func(t *testing.T) {
+			// LoadConfig refuses a file anyone but its owner can read (#209), and a
+			// file in the repository is 0644; the mode is pkg/config's gate, the
+			// content is this one's.
+			cfg, err := config.LoadConfig(copyAt0600(t, file))
+			if err != nil {
+				t.Fatalf("%s does not load: %v", name, err)
+			}
+
+			engine, err := NewPolicyEngine(cfg)
+			if err != nil {
+				t.Fatalf("%s loads but will not start a broker: %v", name, err)
+			}
+			engine.Close()
+		})
+	}
+}
+
+// TestNoUnenforceablePolicyKeyInAnyShippedFile keeps the refused keys out of the
+// YAML this repository ships and the documents an operator pastes from, including
+// the ones no test loads. A key that is only wrong in a commented-out example is
+// still a key someone uncomments; the point of the comments left behind in those
+// files is that they say why, and this gate is what stops a live one reappearing.
+func TestNoUnenforceablePolicyKeyInAnyShippedFile(t *testing.T) {
+	// The ten keys validatePolicySupport refuses, plus the two risk actions. Read
+	// as YAML keys and values, so the prose in CONFIGURATION-GUIDE.md that has to
+	// name them in order to tell an operator to remove them still passes.
+	refusedKeys := []string{
+		"require_reauth_for_new_hosts",
+		"require_institutional_affiliation",
+		"require_allocation_verification",
+		"require_project_membership",
+		"audit_level",
+		"allow_untrusted_devices",
+		"require_additional_mfa",
+		"no_data_export",
+		"session_recording",
+		"require_approval_for",
+	}
+	refusedActions := []string{"REQUIRE_ADDITIONAL_MFA", "REQUIRE_APPROVAL"}
+
+	// docs/design/ is excluded, as it is in pkg/config's documentation gate: it is
+	// marked unmaintained in docs/design/README.md and describes a product that was
+	// never built, including all ten of these settings.
+	roots := []string{"configs", "QUICK-START.md", "DEPLOYMENT.md", "README.md"}
+
+	checked := 0
+	for _, root := range roots {
+		err := filepath.WalkDir(filepath.Join("..", "..", root), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			switch filepath.Ext(path) {
+			case ".yaml", ".yml", ".md":
+			default:
+				return nil
+			}
+			data, err := os.ReadFile(path) // #nosec G304 -- walking a fixed repo-relative root
+			if err != nil {
+				return err
+			}
+			checked++
+			rel := strings.TrimPrefix(path, filepath.Join("..", "..")+string(filepath.Separator))
+			for i, line := range strings.Split(string(data), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "#") {
+					// A commented example is where these now live, with the
+					// explanation of why they are commented.
+					continue
+				}
+				for _, key := range refusedKeys {
+					if strings.HasPrefix(trimmed, key+":") {
+						t.Errorf("%s:%d sets %s, which the broker refuses to start on because "+
+							"nothing enforces it (#212)", rel, i+1, key)
+					}
+				}
+				// Matched as a YAML `action:` value rather than anywhere on the
+				// line: the guide has to be able to name these in prose in order
+				// to tell an operator to remove them, and naming them is what an
+				// operator searches for after the broker refuses to start.
+				if value, isAction := strings.CutPrefix(trimmed, "action:"); isAction {
+					value = strings.Trim(strings.TrimSpace(value), `"'`)
+					for _, action := range refusedActions {
+						if value == action {
+							t.Errorf("%s:%d sets the risk action %s, which the broker refuses to "+
+								"start on: it performs DENY and LOG (#212)", rel, i+1, action)
+						}
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("failed to walk %s: %v", root, err)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no configuration or documentation files were read — this gate would pass vacuously")
+	}
+}
+
+// wholeConfigsUnder returns the YAML files under root that are rooted at the top
+// level of a broker configuration. A provider fragment is skipped: it holds a
+// single oidc.providers entry and no authentication section, so there is no policy
+// for an engine to compile.
+func wholeConfigsUnder(t *testing.T, root string) []string {
+	t.Helper()
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		if isWholeConfigFile(path) {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk %s: %v", root, err)
+	}
+	return files
+}
+
+// isWholeConfigFile reports whether path parses as YAML and carries at least one
+// section of a broker configuration.
+func isWholeConfigFile(path string) bool {
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		return false
+	}
+	for _, section := range []string{"server", "oidc", "authentication", "security", "audit"} {
+		if v.IsSet(section) {
+			return true
+		}
+	}
+	return false
+}
+
+// copyAt0600 copies a configuration to a file only its owner can read, which is
+// the mode LoadConfig requires (#209) and the mode the installers give it.
+func copyAt0600(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path) // #nosec G304 -- a path this test just walked to
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	dst := filepath.Join(t.TempDir(), filepath.Base(path))
+	if err := os.WriteFile(dst, data, 0600); err != nil {
+		t.Fatalf("failed to write %s: %v", dst, err)
+	}
+	return dst
+}


### PR DESCRIPTION
Closes #212, #213, #215, #217, #218.

## ⚠️ Breaking change on upgrade

**A broker whose configuration sets any of these policy keys will refuse to
start:** `require_reauth_for_new_hosts`, `require_institutional_affiliation`,
`require_allocation_verification`, `require_project_membership`, `audit_level`,
`allow_untrusted_devices`, `require_additional_mfa`, `no_data_export`,
`session_recording`, `require_approval_for`. Also refused: a risk policy whose
action is `REQUIRE_ADDITIONAL_MFA` or `REQUIRE_APPROVAL`, and a risk condition
naming a signal that does not exist.

Nothing has ever read any of them. An operator who wrote `require_additional_mfa:
true` in a production tier got a broker that loaded the file, logged nothing and
admitted the login anyway — the stated policy and the code's behaviour differed
with nothing to say so. Refusing to start is the fail-closed answer, but it means
an upgrade can stop a broker that used to run, so it wants a release note rather
than a quiet patch.

Every shipped template was cleaned first (previous commit), and
`configs/CONFIGURATION-GUIDE.md` lists the keys, what replaces them, and where
each requirement can really be enforced — a Keycloak authentication flow, an Okta
sign-on policy, Entra Conditional Access.

**Second thing to know before enabling anything here:**
`require_device_trust: true` denies every login from a provider that does not
emit `hwk` or `fido` in the token's `amr` claim (RFC 8176). It was previously
ignored, so turning it on for the first time is the moment it can lock a fleet
out. Confirm the provider sends `amr` first. The template says so at every
occurrence.

## What was wrong

| # | Defect |
|---|---|
| #212 | `max_session_duration` and `require_device_trust` parsed, loaded, and were read by nothing; ten more keys likewise. A 30-minute cap on a sudo policy bounded a session that could run for weeks. |
| #213 | A time or country restriction naming a provider was evaluated against a provider name taken from the request, so a client could scope itself out of its own restrictions. Unrecognized risk conditions fell through to allow. |
| #215 | `RefreshSession` returned `success: true` for a pending device-flow session nobody had approved, and renewed an expired one — a negative `time.Until` skipped the early return, so expiry bounded nothing for a client that kept calling. Policy was evaluated once, at login, so a group removal or a tightened whitelist had no effect on a live session. |
| #217 | The device-flow completion path wrote `IsActive: true` unconditionally after working for up to the flow's whole lifetime, so a session an operator had revoked came back as a fully active one with an SSH key installed in `authorized_keys`. The revocation was audited as successful and nothing said it had been undone. |
| #218 | Refused logins left no audit trace and had no distinct error code. A valid IdP account with no group membership could be denied on every host on the network and leave nothing to count — sshd's log does not record which OIDC identity was refused. |

## What changed

- `NewPolicyEngine` refuses an unenforceable configuration, and parses risk
  conditions, hour windows and timezones at startup, so evaluation has no
  fall-open branch left.
- `EvaluateRequest` takes the provider the broker selected, as an argument
  (#213).
- `max_session_duration` bounds a session from its creation — including the SSH
  key's `expiry-time=`, derived from the same value — and `require_device_trust`
  is enforced when the flow completes, since policy runs before any token exists.
- Session stores are a compare-and-swap on pointer identity
  (`replaceSession`): every path that invalidates a session either deletes the
  entry or stores a fresh copy, so "the pointer I read is still stored" is exactly
  "nothing has happened since I read it". A completion that loses the race
  withdraws the SSH key and the stored tokens.
- `RefreshSession` refuses an inactive session, an expired one, one past its
  maximum duration, and one policy no longer allows — dropping it rather than
  leaving the key installed until its own expiry.
- Every refusal is audited with the code the client was given. Denial reasons
  name the rule that fired. Reaching for another user's session is recorded with
  both accounts.

## Protocol

`POLICY_DENIED` and `DEVICE_NOT_TRUSTED` are not in oauth2-pam's
`docs/wire-protocol.md` error-code registry. Rather than inventing the spelling
locally, registering them is filed as
[oauth2-pam#103](https://github.com/scttfrdmn/oauth2-pam/issues/103); this broker
changes to match whatever that decides (#179). That issue also records the four
codes whose spelling already diverges from the registry
(`TOO_MANY_SESSIONS`/`SESSION_LIMIT_REACHED`,
`PROVIDER_NOT_FOUND`/`NO_PROVIDER`, `REFRESH_FAILED`/`SESSION_REFRESH_FAILED`,
and `FORBIDDEN`, which has no counterpart); aligning them is a wire change and
belongs to the v0.6.0 conformance work.

## Tests

Every guard was reverted in turn and the test that covers it confirmed to fail —
including the completeness guard on the risk-flag table, checked by injecting a
flag with no evaluation case. Two new gates:

- **No shipped configuration or operator document may name a refused key.** It
  reads YAML keys and `action:` values rather than matching anywhere on a line, so
  the guide can still name them in prose to tell an operator to remove them.
- **Every shipped configuration must build a policy engine.** `pkg/config`'s
  existing gate stops at `LoadConfig` + `Validate`, so a template could pass CI
  and still refuse to start on an operator's host — which is exactly what all of
  them did the moment the check was added.

`go test ./pkg/auth/ ./pkg/config/` is green; `go build ./...` and `go vet ./...`
clean. The cgo PAM packages cannot compile on the macOS host this was written on,
and nothing here touches them.
