### PR TITLE
fix(ssh): refuse the key file a user can turn against the broker (#204, #205, #206, #225, #226, #228, #229)

### DIFF
--- a/pkg/ssh/accounts.go
+++ b/pkg/ssh/accounts.go
@@ -135,6 +135,21 @@ func lookupViaGetent(username string) (Account, error) {
 		return Account{}, ErrUnknownAccount
 	}
 	// name:passwd:uid:gid:gecos:home:shell
+	//
+	// (#229) The home directory is taken from the *end* of the line, not from index 5.
+	// Only GECOS can legitimately contain a colon — an smbldap- or AD-populated GECOS
+	// routinely does, e.g. "Smith, Jane:Engineering" — and getent prints whatever NSS
+	// handed it without escaping, so such a line splits into more than seven fields
+	// and everything after GECOS shifts right. The count check here is `< 7`, so the
+	// line was *accepted*: index 5 then held the tail of the GECOS rather than the
+	// home directory, and the broker went on to write an authorized_keys under a path
+	// like "Engineering" — or, since userPaths refuses a home that does not exist,
+	// denied the login with an error about a home directory nobody had configured.
+	//
+	// Counting home and shell from the right resolves the ambiguity correctly for any
+	// number of colons in GECOS, and is identical to the old behaviour on a well-formed
+	// seven-field line. It is wrong only if the *home directory or shell* contains a
+	// colon, which no passwd database does.
 	fields := strings.Split(strings.SplitN(line, "\n", 2)[0], ":")
 	if len(fields) < 7 {
 		return Account{}, fmt.Errorf("getent returned a passwd line with %d fields: %q", len(fields), line)
@@ -142,7 +157,8 @@ func lookupViaGetent(username string) (Account, error) {
 	if fields[0] != username {
 		return Account{}, fmt.Errorf("getent answered for %q when asked about %q", fields[0], username)
 	}
-	return accountFromStrings(username, fields[5], fields[2], fields[3])
+	home := fields[len(fields)-2]
+	return accountFromStrings(username, home, fields[2], fields[3])
 }
 
 // accountFromStrings builds an Account from the string fields both lookups

--- a/pkg/ssh/accounts_test.go
+++ b/pkg/ssh/accounts_test.go
@@ -61,6 +61,56 @@ exit 2
 	}
 }
 
+// (#229) Only GECOS can legitimately contain a colon, and an smbldap- or
+// AD-populated one routinely does ("Smith, Jane:Engineering" is the shape
+// smbldap-useradd writes, and AD's description attribute is copied verbatim). getent
+// prints what NSS handed it with no escaping, so such an entry splits into more than
+// seven fields and everything after GECOS shifts right.
+//
+// The field count check is `< 7`, so the line was *accepted* and index 5 held the tail
+// of the GECOS instead of the home directory. The broker then either wrote an
+// authorized_keys under a path named after a department, or — since a home that does
+// not exist is refused — denied the login with an error naming a directory no operator
+// had ever configured. Home and shell are therefore counted from the right, which is
+// unambiguous for any number of colons in GECOS and identical on a well-formed line.
+func TestAColonInTheGECOSDoesNotShiftTheHomeDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		name, gecos string
+	}{
+		{name: "no colon", gecos: "Alice Example"},
+		{name: "one colon", gecos: "Smith, Jane:Engineering"},
+		{name: "several colons", gecos: "Jane:Engineering:Floor 3:x1234"},
+		{name: "empty", gecos: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubGetent(t, "echo 'alice:x:4242:4243:"+tc.gecos+":/home/ldap-domain/alice:/bin/bash'\nexit 0\n")
+
+			account, err := lookupViaGetent("alice")
+			if err != nil {
+				t.Fatalf("lookupViaGetent: %v", err)
+			}
+			if account.Home != "/home/ldap-domain/alice" {
+				t.Errorf("home = %q, want /home/ldap-domain/alice: a colon in the GECOS shifted "+
+					"the fields, so the broker would write a key list somewhere sshd never reads "+
+					"(or refuse the login over a home nobody configured)", account.Home)
+			}
+			if account.UID != 4242 || account.GID != 4243 {
+				t.Errorf("uid/gid = %d/%d, want 4242/4243", account.UID, account.GID)
+			}
+		})
+	}
+}
+
+// A line with genuinely too few fields is still a broken answer, not something to
+// index into from the right: with six fields, "the second from last" is the GECOS.
+func TestATruncatedPasswdLineIsRefused(t *testing.T) {
+	stubGetent(t, "echo 'alice:x:4242:4243:Alice:/home/alice'\nexit 0\n")
+
+	if account, err := lookupViaGetent("alice"); err == nil {
+		t.Fatalf("a six-field passwd line was accepted, giving home %q", account.Home)
+	}
+}
+
 // getent exits 2 for "key not found". That is an answer, and it has to be
 // distinguishable from a broken account database: one means "no such user", the
 // other means the broker cannot tell and must not guess.

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -38,6 +40,27 @@ const (
 
 	// lockRetryInterval is how often a blocked writer retries.
 	lockRetryInterval = 50 * time.Millisecond
+
+	// maxAuthorizedKeysBytes bounds how much of a user's authorized_keys the broker
+	// will read into memory.
+	//
+	// (#206) There was no bound. io.ReadAll was pointed at a file in the user's own
+	// directory, so `truncate -s 200G ~/.ssh/authorized_keys` — sparse, instant, no
+	// quota cost — followed by a login grew a 200 GB slice and the root broker was
+	// OOM-killed. Every other account's authentication fails while it is down, systemd
+	// restarts it ten seconds later (Restart=always, no MemoryMax), startup reconcile
+	// reads the same file for any user with a stored key, and it is killed again: a
+	// host-wide authentication outage that persists until an operator finds the file.
+	//
+	// 1 MiB is the bound because of what the file legitimately holds. The largest
+	// entry anyone writes is an options list plus a 16384-bit RSA key — about 2.8 KB
+	// of base64 — plus a comment, so under 3 KB; a 4096-bit RSA entry is about 750
+	// bytes and an ed25519 entry about 100. 1 MiB is therefore roughly 350 of the
+	// largest entries that exist, 1,300 ordinary RSA ones, or 10,000 ed25519 ones, for
+	// a single account. Nothing legitimate is near that, and a file that exceeds it is
+	// refused rather than truncated: silently dropping the tail of a key list would
+	// mean writing back a file with keys missing.
+	maxAuthorizedKeysBytes = 1 << 20
 )
 
 // ErrLockUnavailable is returned when the per-user lock could not be taken within
@@ -105,29 +128,37 @@ func acquireLock(lockFile *os.File, lockPath string, timeout time.Duration) erro
 // that is not a directory the broker alone controls. A lock in a directory someone
 // else can write to is not a lock: they can plant the lock file, or hold it.
 func ensureLockDir(lockDir string) error {
-	info, err := os.Lstat(lockDir)
+	return ensureBrokerOwnedDir("lock directory", lockDir)
+}
+
+// ensureBrokerOwnedDir creates one of the broker's own state directories if it is
+// absent, and refuses one that anybody else could have interfered with. Both the
+// locks (#161) and the authorized_keys backups (#228) depend on living somewhere the
+// account they concern cannot reach.
+func ensureBrokerOwnedDir(what, dir string) error {
+	info, err := os.Lstat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if mkErr := os.MkdirAll(lockDir, 0700); mkErr != nil {
-				return fmt.Errorf("failed to create lock directory %q: %w", lockDir, mkErr)
+			if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
+				return fmt.Errorf("failed to create %s %q: %w", what, dir, mkErr)
 			}
 			return nil
 		}
-		return fmt.Errorf("failed to stat lock directory %q: %w", lockDir, err)
+		return fmt.Errorf("failed to stat %s %q: %w", what, dir, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to use lock directory %q: it is a symlink", lockDir)
+		return fmt.Errorf("refusing to use %s %q: it is a symlink", what, dir)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("refusing to use lock directory %q: it is not a directory", lockDir)
+		return fmt.Errorf("refusing to use %s %q: it is not a directory", what, dir)
 	}
 	if info.Mode().Perm()&0022 != 0 {
-		return fmt.Errorf("refusing to use lock directory %q: mode %#o is writable by group or other",
-			lockDir, info.Mode().Perm())
+		return fmt.Errorf("refusing to use %s %q: mode %#o is writable by group or other",
+			what, dir, info.Mode().Perm())
 	}
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Uid) != os.Geteuid() {
-		return fmt.Errorf("refusing to use lock directory %q: it is owned by uid %d, not by this process (uid %d)",
-			lockDir, stat.Uid, os.Geteuid())
+		return fmt.Errorf("refusing to use %s %q: it is owned by uid %d, not by this process (uid %d)",
+			what, dir, stat.Uid, os.Geteuid())
 	}
 	return nil
 }
@@ -147,23 +178,60 @@ func ensureLockDir(lockDir string) error {
 // their own keys in it; a root-owned 0700 .ssh takes that away with no way for
 // them to get it back.
 func ensureSecureSSHDir(sshDir string, account Account) error {
+	exists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	if mkErr := os.MkdirAll(sshDir, 0700); mkErr != nil {
+		return fmt.Errorf("failed to create .ssh directory: %w", mkErr)
+	}
+	return chownDirToAccount(sshDir, account)
+}
+
+// checkSSHDir is the half of ensureSecureSSHDir that creates nothing: it reports
+// whether .ssh exists, and refuses one that is a symlink, is not a directory, or
+// belongs to a third account. A .ssh that is simply absent is not an error — the
+// account has never had a key — so callers that only remove or read return early
+// rather than bringing a directory into existence on a cleanup pass.
+//
+// (#204) Every entry point goes through this now, and four of them went through
+// nothing. RemovePublicKey and RemoveExpiredKeys used os.Stat(sshDir) purely to ask
+// whether it existed — os.Stat *follows* symlinks, so `ln -s /root/.ssh ~/.ssh`
+// answered yes — and KeyIsAuthorized and ListOIDCKeys did not look at .ssh at all.
+// Nothing further stopped them: authorized_keys inside the linked directory is not
+// itself a symlink, so rejectIfSymlink passes it, O_NOFOLLOW constrains only the
+// final component, and the descriptor's owner is root, which checkOwner accepts
+// because sshd's StrictModes accepts it. So RemoveExpiredKeys and RemovePublicKey
+// rewrote root's key list through a bob-owned temp file, and ListOIDCKeys and
+// KeyIsAuthorized read it out — with no race to win, because the link can be planted
+// before the call and nothing looked.
+//
+// This closes the no-race half. It does not make the check race-free: it is a name
+// being validated and then used, and the fix for that is to hold the home open and
+// perform every subsequent operation with openat(2) relative to a verified .ssh
+// descriptor, which is a larger change than this. What is left is a window an
+// attacker must win, rather than a door standing open.
+func checkSSHDir(sshDir string, account Account) (bool, error) {
 	info, err := os.Lstat(sshDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if mkErr := os.MkdirAll(sshDir, 0700); mkErr != nil {
-				return fmt.Errorf("failed to create .ssh directory: %w", mkErr)
-			}
-			return chownDirToAccount(sshDir, account)
+			return false, nil
 		}
-		return fmt.Errorf("failed to stat .ssh directory: %w", err)
+		return false, fmt.Errorf("failed to stat .ssh directory: %w", err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to use .ssh: %q is a symlink", sshDir)
+		return false, fmt.Errorf("refusing to use .ssh: %q is a symlink", sshDir)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("refusing to use .ssh: %q is not a directory", sshDir)
+		return false, fmt.Errorf("refusing to use .ssh: %q is not a directory", sshDir)
 	}
-	return checkOwner(".ssh directory", sshDir, info, account)
+	if err := checkOwner(".ssh directory", sshDir, info, account); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // rejectIfSymlink returns an error if path exists and is a symbolic link. Used
@@ -193,37 +261,105 @@ func rejectIfSymlink(path string) error {
 // is writable by the user, so between a stat and an open the name can be made to
 // point somewhere else. What is verified has to be the thing that was opened.
 func readAuthorizedKeysLines(path string, account Account) ([]string, error) {
-	if err := rejectIfSymlink(path); err != nil {
+	file, info, err := openRegularFileForRead(path, "authorized_keys")
+	if err != nil {
 		return nil, err
 	}
-	// #nosec G304 -- path is <resolved home>/.ssh/authorized_keys for a validated
-	// login name; symlink-checked above, opened O_NOFOLLOW, and the descriptor's
-	// ownership is verified below.
-	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to open authorized_keys file: %w", err)
+	if file == nil {
+		return nil, nil // no file, so no keys: the normal case for a new account
 	}
 	defer func() { _ = file.Close() }()
 
-	info, err := file.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat the open authorized_keys file: %w", err)
-	}
 	if err := checkOwner("authorized_keys", path, info, account); err != nil {
 		return nil, err
 	}
-
-	data, err := io.ReadAll(file)
+	data, err := readAtMost(file, path, "authorized_keys", info.Size())
 	if err != nil {
-		return nil, fmt.Errorf("failed to read authorized_keys file: %w", err)
+		return nil, err
 	}
 	if len(data) == 0 {
 		return nil, nil
 	}
 	return strings.Split(strings.TrimRight(string(data), "\n"), "\n"), nil
+}
+
+// openRegularFileForRead opens a file the broker is about to read out of a directory
+// the target account controls, and returns it only if what was opened is a regular
+// file. A missing file yields (nil, nil, nil), because for authorized_keys and for a
+// backup that is an answer rather than a failure.
+//
+// (#205) Two things here, and the order of them is the point.
+//
+// O_NONBLOCK: the open used to be plain O_RDONLY|O_NOFOLLOW, and open(2) on a FIFO
+// opened for reading blocks until a writer appears. `rm ~/.ssh/authorized_keys &&
+// mkfifo ~/.ssh/authorized_keys` therefore parked the caller in the kernel forever —
+// measured on this host: an os.OpenFile with those exact flags on a FIFO had not
+// returned after two seconds, while the same open with O_NONBLOCK returned
+// immediately. That block happens inside withFileLock, so the per-user lock is held
+// for the duration, and it happens on the broker's single session-cleanup goroutine,
+// so no session expires and no key is revoked *for any account on the host* again,
+// and Stop() hangs on wg.Wait() until systemd's TimeoutStopSec fires. It is #161
+// reached through a different door: the lock is safe now, but the critical section
+// could still be blocked from inside it.
+//
+// The fstat is on the descriptor, not the path: rejectIfSymlink only tells us what
+// the name pointed at a moment ago, and it tests os.ModeSymlink alone, so a FIFO
+// passed it (confirmed: Lstat of a FIFO reports mode prw------- with ModeSymlink
+// clear and IsRegular false). Checking the mode of what was actually opened closes
+// the check-then-use gap rather than widening the check — whatever the name was
+// swapped for in between, this is the object the read will come from.
+func openRegularFileForRead(path, what string) (*os.File, os.FileInfo, error) {
+	if err := rejectIfSymlink(path); err != nil {
+		return nil, nil, err
+	}
+	// #nosec G304 -- path is <resolved home>/.ssh/<name> for a validated login name, or
+	// a file in the broker's own state directory; symlink-checked above, opened
+	// O_NOFOLLOW so the final component cannot be a link, O_NONBLOCK so a FIFO cannot
+	// wedge the open, and refused below unless the descriptor is a regular file.
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("failed to open %s file: %w", what, err)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("failed to stat the open %s file: %w", what, err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("refusing to read %s %q: it is not a regular file (mode %s)",
+			what, path, info.Mode())
+	}
+	return file, info, nil
+}
+
+// readAtMost reads a whole file that has already been shown to be a regular one,
+// refusing anything larger than maxAuthorizedKeysBytes (#206).
+//
+// The size is checked twice on purpose. The fstat size is what makes an absurd file
+// cheap to refuse — nothing is allocated for a 200 GB sparse file — but the file lives
+// in a directory the account can write, so it can grow between the fstat and the
+// read. The LimitReader is what bounds the allocation whatever the fstat said, and
+// reaching the limit is an error rather than a truncation: a key list silently missing
+// its tail would be written straight back out by the caller.
+func readAtMost(file *os.File, path, what string, size int64) ([]byte, error) {
+	if size > maxAuthorizedKeysBytes {
+		return nil, fmt.Errorf("refusing to read %s %q: it is %d bytes, and anything over %d "+
+			"is not a key list", what, path, size, maxAuthorizedKeysBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxAuthorizedKeysBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s file: %w", what, err)
+	}
+	if len(data) > maxAuthorizedKeysBytes {
+		return nil, fmt.Errorf("refusing to read %s %q: it grew past %d bytes while being read",
+			what, path, maxAuthorizedKeysBytes)
+	}
+	return data, nil
 }
 
 // writeAuthorizedKeysAtomic writes content to the authorized_keys file safely:
@@ -238,14 +374,29 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte, account Acco
 	if err := rejectIfSymlink(path); err != nil {
 		return err
 	}
-	tmpPath := filepath.Join(sshDir, fmt.Sprintf(".authorized_keys.tmp.%d", os.Getpid()))
-	_ = os.Remove(tmpPath) // clear any stale temp from a prior crash
-	// #nosec G304 -- tmpPath is under the validated .ssh dir and opened with
-	// O_EXCL|O_NOFOLLOW, so it cannot follow or clobber a pre-existing symlink.
-	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0600)
+	handOver, err := targetShouldBeHandedToAccount(path, account)
+	if err != nil {
+		return err
+	}
+
+	// (#225) The temp file used to be named .authorized_keys.tmp.<pid>. The broker's
+	// pid is readable by any local user — /proc, ps, systemd's MainPID — and the
+	// directory belongs to the target account, so the account could pre-create that
+	// exact name as a directory, as a symlink, or as a file it holds, and every write
+	// through this function failed. The name is keyed on the broker's pid and nothing
+	// else, so the account obstructing it need not be the account being provisioned:
+	// one user could stop key provisioning for the whole host. Two brokers, or a pid
+	// recycled after a crash, collided on it by accident for the same reason.
+	//
+	// os.CreateTemp picks an unpredictable name and creates it O_EXCL, retrying on
+	// collision, so there is no name to pre-create and nothing to clobber: O_EXCL on
+	// an existing name — including a symlink, dangling or not — fails rather than
+	// following it.
+	tmp, err := os.CreateTemp(sshDir, ".authorized_keys.tmp.*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp authorized_keys: %w", err)
 	}
+	tmpPath := tmp.Name()
 	cleanup := func() { _ = os.Remove(tmpPath) }
 	if _, err := tmp.Write(content); err != nil {
 		_ = tmp.Close()
@@ -253,13 +404,27 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte, account Acco
 		return fmt.Errorf("failed to write temp authorized_keys: %w", err)
 	}
 	// The handover goes through the still-open descriptor rather than through
-	// tmpPath (#203). The temp file sits in a directory the account can write, and
-	// its name was predictable, so a chown by name could be pointed at any file on
-	// the host. fchown(2) can only reach the file that was opened here.
-	if err := chownFileToAccount(tmp, account); err != nil {
+	// tmpPath (#203). The temp file sits in a directory the account can write, so a
+	// chown by name could be pointed at any file on the host. fchown(2) can only reach
+	// the file that was opened here.
+	if handOver {
+		if err := chownFileToAccount(tmp, account); err != nil {
+			_ = tmp.Close()
+			cleanup()
+			return err
+		}
+	}
+	// (#225) fsync before the rename. Without it, on ext4 with the default
+	// data=ordered, a host that loses power just after the rename can come back with
+	// the directory entry durable and the file's contents not — the documented outcome
+	// is a zero-length authorized_keys. Every provisioned key for that account is then
+	// gone, and nothing detects it, because the file exists and parses: the user simply
+	// cannot log in by the mechanism the broker is responsible for until their next
+	// successful login rewrites it.
+	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
 		cleanup()
-		return err
+		return fmt.Errorf("failed to flush temp authorized_keys to disk: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		cleanup()
@@ -269,7 +434,79 @@ func writeAuthorizedKeysAtomic(sshDir, path string, content []byte, account Acco
 		cleanup()
 		return fmt.Errorf("failed to replace authorized_keys: %w", err)
 	}
+	syncDir(sshDir)
 	return nil
+}
+
+// syncDir fsyncs a directory so that a rename into it survives a crash.
+//
+// (#225) The second half of the atomic-replace recipe: fsync on the file makes the
+// contents durable, fsync on the directory makes the *name* pointing at them durable.
+// Without it a crash can leave the account with the previous key list, which is at
+// least a consistent state, but the rename's durability is unspecified.
+//
+// A failure here is logged and not returned. The rename has already happened, so the
+// running system is correct and there is nothing to undo; reporting an error would
+// tell AddPublicKey's caller that provisioning failed when it had succeeded, and deny
+// a login over a durability warning. It is also not something a retry fixes.
+func syncDir(dir string) {
+	// #nosec G304 -- dir is the .ssh directory this write has already validated, opened
+	// O_NOFOLLOW|O_DIRECTORY so it cannot be redirected to anything else.
+	d, err := os.OpenFile(dir, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		log.Warn().Err(err).Str("dir", dir).
+			Msg("Could not open the .ssh directory to flush it; the authorized_keys replacement " +
+				"may not survive a crash")
+		return
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil {
+		log.Warn().Err(err).Str("dir", dir).
+			Msg("Could not flush the .ssh directory; the authorized_keys replacement may not " +
+				"survive a crash")
+	}
+}
+
+// targetShouldBeHandedToAccount reports whether the replacement for path should be
+// given to the account, or left owned by the broker.
+//
+// (#228) chownFileToAccount used to run on every write, whoever owned the file before
+// it. A root-owned authorized_keys — a hardened deployment, an operator who wrote the
+// file with sudo, a configuration-management system that owns it — was therefore
+// handed to the unprivileged account by the broker's first write. Nothing looked
+// wrong afterwards: the contents were correct, and the only visible change was that
+// the user could now edit the list of keys that authorize them, which is exactly what
+// root ownership was there to prevent. sshd is content either way; StrictModes
+// accepts an authorized_keys owned by the target user or by root, provided it is not
+// group- or world-writable, and this function writes 0600.
+//
+// (#171 still holds for the other direction: a file the broker created in someone's
+// home must end up theirs, or they cannot manage their own keys.) So the rule is that
+// the broker hands over what it created and preserves what it found.
+//
+// The existing owner is read with Lstat rather than through a descriptor, and that is
+// sound here even though the directory is user-writable. The chown itself still goes
+// through the temp file's own descriptor, so a swapped name cannot redirect it; the
+// only thing a race can change is the *decision*, and both wrong answers are safe.
+// Deciding to keep root ownership when the file was in fact the user's leaves them a
+// root-owned key list they cannot edit — visible, and not a privilege gain. Deciding
+// to hand over when the file was in fact root-owned requires the attacker to have
+// replaced a root-owned authorized_keys with one of their own first, which means .ssh
+// was writable by them, which means root ownership of the file was not protecting
+// anything to begin with.
+func targetShouldBeHandedToAccount(path string, account Account) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil // the broker is creating it, so it is the broker's to give
+		}
+		return false, fmt.Errorf("failed to stat authorized_keys: %w", err)
+	}
+	uid, ok := statUID(info)
+	if !ok {
+		return false, fmt.Errorf("cannot determine the owner of authorized_keys %q", path)
+	}
+	return uid == account.UID, nil
 }
 
 // writeAuthorizedKeysLines renders the surviving lines back to authorized_keys,
@@ -310,6 +547,7 @@ const DefaultKeyLifetime = 24 * time.Hour
 type AuthorizedKeysManager struct {
 	lookupAccount AccountLookup
 	lockDir       string
+	backupDir     string
 	lockTimeout   time.Duration
 	keyLifetime   time.Duration
 }
@@ -331,9 +569,28 @@ func NewAuthorizedKeysManager(lockDir string) *AuthorizedKeysManager {
 	return &AuthorizedKeysManager{
 		lookupAccount: LookupAccount,
 		lockDir:       lockDir,
-		lockTimeout:   lockAcquireTimeout,
-		keyLifetime:   DefaultKeyLifetime,
+		// Backups live beside the locks, in the broker's own state directory, and never
+		// in the user's .ssh (#228). Derived from lockDir rather than hardcoded so that
+		// a manager pointed at a temporary state directory keeps everything there:
+		// production's /var/lib/oidc-pam/locks yields /var/lib/oidc-pam/backups.
+		backupDir:   filepath.Join(filepath.Dir(lockDir), "backups"),
+		lockTimeout: lockAcquireTimeout,
+		keyLifetime: DefaultKeyLifetime,
 	}
+}
+
+// SetBackupDir overrides where BackupAuthorizedKeys writes and RestoreAuthorizedKeys
+// reads. It must be a directory only the broker can write to — see BackupAuthorizedKeys
+// for why a backup in the user's own .ssh cannot be trusted as a restore source.
+func (akm *AuthorizedKeysManager) SetBackupDir(dir string) {
+	if dir != "" {
+		akm.backupDir = dir
+	}
+}
+
+// BackupPath returns the file BackupAuthorizedKeys writes for an account.
+func (akm *AuthorizedKeysManager) BackupPath(username string) string {
+	return filepath.Join(akm.backupDir, username+".authorized_keys")
 }
 
 // SetAccountLookup replaces the account database this manager resolves homes and
@@ -402,11 +659,52 @@ func (akm *AuthorizedKeysManager) userPaths(username string) (Account, string, s
 	return account, sshDir, filepath.Join(sshDir, "authorized_keys"), nil
 }
 
-// LockPath returns the lock file serializing writes to one user's
-// authorized_keys. The username is validated by every caller before use, so it
-// cannot contain a separator or traverse out of lockDir.
+// LockPath returns the lock file serializing writes to the authorized_keys file
+// this account's home directory resolves to.
+//
+// (#225) The lock used to be named after the account: <lockDir>/<username>.lock. Two
+// accounts can share a home directory — a deliberate configuration for a pair of
+// service identities, and also what an NSS or LDAP misconfiguration produces — and
+// two writers naming their locks after different accounts do not exclude each other
+// even though they are rewriting the same file. Both read, both write, the second
+// rename wins, and one account's key has silently vanished from a file that looks
+// perfectly well-formed. Keying the lock on the directory instead means anything
+// writing a given authorized_keys takes the same lock, whichever account it is for.
+//
+// The name is a hash because the thing being named is a path, which does not fit in a
+// filename and cannot be sanitized into one without making two different paths
+// collide. An operator can recover the mapping with
+// `printf %s /home/bob/.ssh | sha256sum` and comparing the first 32 characters.
+//
+// This is textual, not canonical: a path is not resolved through symlinks first.
+// Resolving would have to happen before .ssh exists, which is exactly when it cannot
+// be resolved, and a fallback that sometimes resolves and sometimes does not would
+// hand two writers of the same file two different lock names — the bug this fixes.
+// So two aliases of one directory (a symlinked component above .ssh) still take
+// different locks. userPaths refuses a symlinked home and checkSSHDir a symlinked
+// .ssh, so reaching that needs an operator to have aliased an intermediate directory,
+// and the atomic replace still leaves a consistent file; what can be lost is one
+// concurrent update.
 func (akm *AuthorizedKeysManager) LockPath(username string) string {
-	return filepath.Join(akm.lockDir, username+".lock")
+	account, err := akm.lookupAccount(username)
+	if err != nil {
+		// A name that does not resolve never reaches a write — userPaths fails first —
+		// so this value guards nothing. It is still distinct per name, so that a caller
+		// holding it cannot accidentally exclude an unrelated account.
+		return akm.lockPathForKey("unresolved-account\x00" + username)
+	}
+	return akm.lockPathForSSHDir(filepath.Join(account.Home, ".ssh"))
+}
+
+// lockPathForSSHDir is what the write paths actually lock on: the .ssh directory they
+// are about to write into. See LockPath.
+func (akm *AuthorizedKeysManager) lockPathForSSHDir(sshDir string) string {
+	return akm.lockPathForKey(filepath.Clean(sshDir))
+}
+
+func (akm *AuthorizedKeysManager) lockPathForKey(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(akm.lockDir, hex.EncodeToString(sum[:16])+".lock")
 }
 
 // SetLockTimeout overrides how long a write waits for the per-user lock before
@@ -466,7 +764,7 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 		return fmt.Errorf("public key is not a valid authorized_keys entry")
 	}
 
-	return withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+	return withFileLock(akm.lockPathForSSHDir(sshDir), akm.lockTimeout, func() error {
 		existing, err := readAuthorizedKeysLines(authorizedKeysPath, account)
 		if err != nil {
 			return err
@@ -526,8 +824,14 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 		return false, err
 	}
 
-	// Check if .ssh directory exists; if not, nothing to remove
-	if _, statErr := os.Stat(sshDir); os.IsNotExist(statErr) {
+	// Validate .ssh rather than merely asking whether it exists (#204): os.Stat
+	// followed a symlinked .ssh, and this path then rewrote whatever it pointed at.
+	// An absent .ssh still means there is nothing to remove.
+	sshDirExists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return false, err
+	}
+	if !sshDirExists {
 		return false, nil
 	}
 
@@ -537,7 +841,7 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 	}
 
 	removed := false
-	err = withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+	err = withFileLock(akm.lockPathForSSHDir(sshDir), akm.lockTimeout, func() error {
 		lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
 		if err != nil {
 			return err
@@ -588,13 +892,26 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 // Without the distinction, one-live-key-per-user would make every revocation of a
 // superseded key look like a failed revocation.
 func (akm *AuthorizedKeysManager) KeyIsAuthorized(username string, publicKey []byte) (bool, error) {
-	account, _, authorizedKeysPath, err := akm.userPaths(username)
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
 	if err != nil {
 		return false, err
 	}
 	target, ok := parseKeyEntry(string(publicKey))
 	if !ok {
 		return false, fmt.Errorf("public key is not a valid authorized_keys entry")
+	}
+
+	// (#204) This used not to look at .ssh at all, so a symlinked .ssh made it report
+	// on somebody else's key list — root's, if it was aimed at /root/.ssh, which
+	// checkOwner accepts. The answer feeds the broker's decision about whether a
+	// revocation that matched nothing is benign, so a wrong answer there is an alarm
+	// about the wrong account.
+	sshDirExists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return false, err
+	}
+	if !sshDirExists {
+		return false, nil
 	}
 
 	lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
@@ -623,8 +940,18 @@ func (akm *AuthorizedKeysManager) RemoveOIDCKeys(username string) (int, error) {
 		return 0, err
 	}
 
+	// An absent .ssh means there is nothing to reconcile; a symlinked one is refused
+	// rather than followed (#204).
+	sshDirExists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return 0, err
+	}
+	if !sshDirExists {
+		return 0, nil
+	}
+
 	removed := 0
-	err = withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+	err = withFileLock(akm.lockPathForSSHDir(sshDir), akm.lockTimeout, func() error {
 		lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
 		if err != nil {
 			return err
@@ -674,12 +1001,18 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 		return err
 	}
 
-	// Check if .ssh directory exists; if not, nothing to clean
-	if _, statErr := os.Stat(sshDir); os.IsNotExist(statErr) {
+	// Validate .ssh rather than merely asking whether it exists (#204). This is the
+	// path the broker's single cleanup goroutine walks for every account on the host,
+	// and os.Stat followed a symlinked .ssh straight into whatever it named.
+	sshDirExists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return err
+	}
+	if !sshDirExists {
 		return nil
 	}
 
-	return withFileLock(akm.LockPath(username), akm.lockTimeout, func() error {
+	return withFileLock(akm.lockPathForSSHDir(sshDir), akm.lockTimeout, func() error {
 		lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
 		if err != nil {
 			return err
@@ -744,9 +1077,20 @@ func (akm *AuthorizedKeysManager) entryHasExpired(line string, now time.Time) bo
 // authorized_keys entries this broker is responsible for, distinguished from the
 // user's own keys by the `@oidc-pam-<timestamp>` comment.
 func (akm *AuthorizedKeysManager) ListOIDCKeys(username string) ([]string, error) {
-	account, _, authorizedKeysPath, err := akm.userPaths(username)
+	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
 	if err != nil {
 		return nil, err
+	}
+
+	// (#204) Also did not look at .ssh. An operator asking which entries the broker
+	// owns for an account must not be shown the contents of a key list the account
+	// merely symlinked to.
+	sshDirExists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return nil, err
+	}
+	if !sshDirExists {
+		return []string{}, nil
 	}
 
 	lines, err := readAuthorizedKeysLines(authorizedKeysPath, account)
@@ -767,21 +1111,35 @@ func (akm *AuthorizedKeysManager) ListOIDCKeys(username string) ([]string, error
 	return oidcKeys, nil
 }
 
-// BackupAuthorizedKeys creates a backup of the authorized_keys file.
+// BackupAuthorizedKeys creates a backup of the authorized_keys file, in the broker's
+// own state directory.
 //
 // Operator-facing recovery API, paired with RestoreAuthorizedKeys; the broker
 // does not call it during authentication. The key-management functions rewrite a
 // file the user also owns, so a copy taken before a manual intervention is worth
 // having.
+//
+// (#228) The backup used to be written to ~/.ssh/authorized_keys.backup and chowned
+// to the account, which made it useless as a recovery source and worse than useless
+// as a restore source. It was user-owned and user-writable, sitting in a directory
+// the user controls under a name they can predict, so the user could rewrite it and
+// then have the broker install its contents with root's privileges; and a backup of a
+// root-owned authorized_keys became user-owned by the act of backing it up. A copy
+// somebody can edit is not a backup of anything. It now lives in the broker's state
+// directory, mode 0700, and is never handed over.
 func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 	account, sshDir, authorizedKeysPath, err := akm.userPaths(username)
 	if err != nil {
 		return err
 	}
-	backupPath := filepath.Join(sshDir, "authorized_keys.backup")
-
-	// Check if original file exists
-	if _, statErr := os.Stat(authorizedKeysPath); os.IsNotExist(statErr) {
+	sshDirExists, err := checkSSHDir(sshDir, account)
+	if err != nil {
+		return err
+	}
+	if !sshDirExists {
+		return nil // nothing to back up
+	}
+	if _, statErr := os.Lstat(authorizedKeysPath); os.IsNotExist(statErr) {
 		return nil // No file to backup
 	}
 
@@ -794,11 +1152,13 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 		data = []byte(strings.Join(lines, "\n") + "\n")
 	}
 
-	// Write the backup without following a planted symlink at the backup path.
-	if err := rejectIfSymlink(backupPath); err != nil {
+	if err := ensureBrokerOwnedDir("backup directory", akm.backupDir); err != nil {
 		return err
 	}
-	// #nosec G304 -- validated username path; symlink-checked above and opened O_NOFOLLOW.
+	backupPath := akm.BackupPath(username)
+	// #nosec G304 -- <backupDir>/<validated login name>.authorized_keys, in a directory
+	// ensureBrokerOwnedDir has just checked only this process can write; O_NOFOLLOW so
+	// that even there the final component cannot be a link.
 	bf, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
@@ -807,11 +1167,9 @@ func (akm *AuthorizedKeysManager) BackupAuthorizedKeys(username string) error {
 		_ = bf.Close()
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
-	// The backup sits in the user's own .ssh, so it is theirs, not root's (#171) —
-	// handed over through the open descriptor, not by name (#203).
-	if err := chownFileToAccount(bf, account); err != nil {
+	if err := bf.Sync(); err != nil {
 		_ = bf.Close()
-		return err
+		return fmt.Errorf("failed to flush backup to disk: %w", err)
 	}
 	if err := bf.Close(); err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
@@ -837,20 +1195,24 @@ func (akm *AuthorizedKeysManager) RestoreAuthorizedKeys(username string) error {
 	if err != nil {
 		return err
 	}
-	backupPath := filepath.Join(sshDir, "authorized_keys.backup")
+	backupPath := akm.BackupPath(username)
 
-	// Check if backup exists
-	if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
-		return fmt.Errorf("no backup file found")
-	}
-
-	// Copy backup to authorized_keys
-	if err := rejectIfSymlink(backupPath); err != nil {
+	// The backup is read the same way authorized_keys is: bounded, and only if the
+	// descriptor turns out to be a regular file. It is in the broker's own directory
+	// now (#228), so neither guard should ever fire — but this is the one path that
+	// writes a file's contents into an account's key list with root's privileges, and
+	// it is not the place to assume a directory is beyond reach.
+	bf, info, err := openRegularFileForRead(backupPath, "backup")
+	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(backupPath) // #nosec G304 -- resolved home, symlink-checked above
+	if bf == nil {
+		return fmt.Errorf("no backup file found at %s", backupPath)
+	}
+	data, err := readAtMost(bf, backupPath, "backup", info.Size())
+	_ = bf.Close()
 	if err != nil {
-		return fmt.Errorf("failed to read backup file: %w", err)
+		return err
 	}
 
 	if err := ensureSecureSSHDir(sshDir, account); err != nil {

--- a/pkg/ssh/authorized_keys_test.go
+++ b/pkg/ssh/authorized_keys_test.go
@@ -448,7 +448,7 @@ func TestBackupAuthorizedKeys(t *testing.T) {
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	backupPath := filepath.Join(sshDir, "authorized_keys.backup")
+	backupPath := akm.BackupPath(username)
 
 	// Create .ssh directory and authorized_keys file
 	err = os.MkdirAll(sshDir, 0700)
@@ -469,13 +469,52 @@ func TestBackupAuthorizedKeys(t *testing.T) {
 	}
 
 	// Verify backup file exists and has correct content
-	backupData, err := os.ReadFile(backupPath)
+	backupData, err := os.ReadFile(backupPath) // #nosec G304 -- test temp dir
 	if err != nil {
 		t.Errorf("Failed to read backup file: %v", err)
 	}
 
 	if string(backupData) != originalContent {
 		t.Errorf("Backup content doesn't match original. Expected: %s, Got: %s", originalContent, string(backupData))
+	}
+}
+
+// (#228) The backup must not be written into the directory it is a backup of. A copy
+// of authorized_keys in the user's own .ssh, owned by the user, is a file the user can
+// edit — so RestoreAuthorizedKeys read a key list from a place its subject controls
+// and installed it as the authorized one, which is a self-service way to reinstate any
+// key the broker had revoked. It also has to survive the home directory, which a
+// backup inside the home does not.
+func TestBackupDoesNotLandInTheUsersSSHDir(t *testing.T) {
+	base := t.TempDir()
+	akm := newTestManager(t, base)
+	username := "testuser"
+	sshDir := filepath.Join(base, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "authorized_keys"),
+		[]byte("ssh-rsa AAAAB3NzaC1yc2E testuser@example.com\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := akm.BackupAuthorizedKeys(username); err != nil {
+		t.Fatalf("BackupAuthorizedKeys: %v", err)
+	}
+
+	entries, err := os.ReadDir(sshDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "authorized_keys" {
+			t.Errorf("backup left %s in the user's own .ssh, where the user can edit it; "+
+				"backups belong in the broker's state directory (#228)", filepath.Join(sshDir, e.Name()))
+		}
+	}
+
+	if _, err := os.Stat(akm.BackupPath(username)); err != nil {
+		t.Errorf("expected the backup in the broker's backup directory: %v", err)
 	}
 }
 
@@ -509,12 +548,15 @@ func TestRestoreAuthorizedKeys(t *testing.T) {
 	username := "testuser"
 	sshDir := filepath.Join(tmpDir, username, ".ssh")
 	authorizedKeysPath := filepath.Join(sshDir, "authorized_keys")
-	backupPath := filepath.Join(sshDir, "authorized_keys.backup")
+	backupPath := akm.BackupPath(username)
 
 	// Create .ssh directory and backup file
 	err = os.MkdirAll(sshDir, 0700)
 	if err != nil {
 		t.Fatalf("Failed to create .ssh directory: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0700); err != nil {
+		t.Fatalf("Failed to create backup directory: %v", err)
 	}
 
 	backupContent := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... backup@example.com\n"
@@ -735,5 +777,63 @@ func TestRemoveExpiredKeysNonExistentFile(t *testing.T) {
 	err = akm.RemoveExpiredKeys(username)
 	if err != nil {
 		t.Errorf("Expected no error when removing expired keys from non-existent file, got: %v", err)
+	}
+}
+
+// (#228) The broker hands over what it created and preserves what it found. A
+// root-owned authorized_keys — a hardened deployment, an operator who wrote it with
+// sudo, a configuration-management system that owns it — must not become the user's by
+// the act of the broker writing to it. The contents would stay correct and the only
+// visible change would be that the user could now edit the list of keys that authorize
+// them, which is what root ownership was there to prevent.
+//
+// The chown itself cannot be exercised here: chownFileToAccount is a no-op for a
+// non-root process, so an unprivileged test can never observe an ownership change (that
+// half belongs in the e2e suite, which runs as root in a container). What *is* testable
+// unprivileged is the decision, which is where the defect was — the old code did not
+// make one, it chowned unconditionally.
+func TestOwnershipOfAnExistingAuthorizedKeysIsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	me := os.Geteuid()
+
+	// A file that does not exist yet: the broker is creating it, so it is the
+	// broker's to give away (#171 — a root-created file in someone's home that stays
+	// root's leaves them unable to manage their own keys).
+	absent := filepath.Join(dir, "not-there")
+	handOver, err := targetShouldBeHandedToAccount(absent, Account{Username: "alice", UID: me})
+	if err != nil {
+		t.Fatalf("targetShouldBeHandedToAccount(absent): %v", err)
+	}
+	if !handOver {
+		t.Error("a file the broker is about to create would not be given to the account, " +
+			"so the user could not edit their own authorized_keys (#171)")
+	}
+
+	// A file that already belongs to the account: handing it over is a no-op, and
+	// saying so keeps the two cases distinguishable.
+	own := filepath.Join(dir, "theirs")
+	if err := os.WriteFile(own, nil, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	handOver, err = targetShouldBeHandedToAccount(own, Account{Username: "alice", UID: me})
+	if err != nil {
+		t.Fatalf("targetShouldBeHandedToAccount(own): %v", err)
+	}
+	if !handOver {
+		t.Error("a file already owned by the account was not identified as the account's")
+	}
+
+	// A file owned by somebody other than the account. Unprivileged, the only such
+	// file this test can make is one owned by *this* uid attributed to a different
+	// account, which exercises the same comparison the root-owned case does: the
+	// existing owner is not the account, so the ownership stands.
+	handOver, err = targetShouldBeHandedToAccount(own, Account{Username: "alice", UID: me + 1})
+	if err != nil {
+		t.Fatalf("targetShouldBeHandedToAccount(other): %v", err)
+	}
+	if handOver {
+		t.Errorf("an authorized_keys owned by uid %d would be handed to uid %d. The broker "+
+			"must preserve an ownership it did not create — otherwise its first write "+
+			"downgrades a root-owned key list to a user-editable one (#228).", me, me+1)
 	}
 }

--- a/pkg/ssh/docs_test.go
+++ b/pkg/ssh/docs_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+	// The DST tests below name real zones, so the test binary carries the tz database
+	// rather than depending on one being installed wherever the suite runs.
+	_ "time/tzdata"
 )
 
 // The entry this package installs carries an `expiry-time=` option, which is how
@@ -92,10 +95,19 @@ func TestTheExpiryTimespecIsTheFormEverySupportedSSHDParses(t *testing.T) {
 		t.Errorf("the expiry is written as %q, not the 14-digit YYYYMMDDHHMMSS sshd(8) "+
 			"documents", timespec)
 	}
-	if got, want := timespec, expiresAt.Local().Format("20060102150405"); got != want {
+	// Local digits, not UTC ones: sshd resolves an unsuffixed timespec through
+	// mktime(3) in the host's own zone, so UTC digits would move the expiry by the
+	// host's offset. Which local offset it uses is the subject of
+	// TestTheExpiryIsWrittenAtStandardTimeBecauseThatIsHowSSHDReadsIt — it is the
+	// zone's *standard* offset whatever the time of year, so the expected value here is
+	// derived that way rather than from expiresAt.Local(), which would make this test
+	// pass or fail according to the date it happens to use and the zone the host is in.
+	stdOffset := standardOffsetForTest(t, time.Local, expiresAt.Year())
+	want := expiresAt.In(time.FixedZone("", stdOffset)).Format("20060102150405")
+	if got := timespec; got != want {
 		t.Errorf("the expiry is written as %q, want %q: sshd reads an unsuffixed timespec in "+
-			"the host's own time zone, so writing UTC digits would move the expiry by the "+
-			"host's offset", got, want)
+			"the host's own time zone at its standard offset, so writing UTC digits — or the "+
+			"daylight-saving offset — would move the expiry", got, want)
 	}
 
 	// And what is written must be read back as the same instant, or the sweep and
@@ -117,4 +129,144 @@ func readDoc(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(content)
+}
+
+// standardOffsetForTest derives a zone's standard-time offset without using the
+// implementation under test: it takes the offset in force on 1 January and on 1 July
+// and returns the smaller, which is standard time in any zone whose DST rule advances
+// the clock. (Europe/Dublin, which the tz database encodes as permanent summer time
+// with *negative* DST in winter, is the exception, and is not used below.)
+func standardOffsetForTest(t *testing.T, loc *time.Location, year int) int {
+	t.Helper()
+
+	_, january := time.Date(year, 1, 1, 12, 0, 0, 0, loc).Zone()
+	_, july := time.Date(year, 7, 1, 12, 0, 0, 0, loc).Zone()
+	if january < july {
+		return january
+	}
+	return july
+}
+
+// (#226) sshd resolves an unsuffixed timespec at the zone's *standard* offset, whatever
+// the time of year, so that is the offset the option has to be written at.
+//
+// parse_absolute_time() in misc.c does memset(&tm, 0, sizeof(tm)), strptime(), then
+// mktime(). The memset leaves tm_isdst == 0 and strptime does not set it; zero means
+// "daylight saving is not in effect", not "work it out" (which is -1). Measured on both
+// libcs that matter, for the wall clock 2026-08-14 12:00:00 in America/New_York:
+//
+//	tm_isdst =  0  ->  17:00 UTC  (12:00 EST)
+//	tm_isdst = -1  ->  16:00 UTC  (12:00 EDT)
+//
+// identical on Darwin libc and on glibc 2.41. Rendering the expiry at the offset in
+// force at that instant — what this used to do — therefore told sshd a time one hour
+// later than intended for the whole DST half of the year: the broker ended the session
+// and the audit trail said the access had ended, while the key still authenticated for
+// another hour. The sweep read it back the same wrong way, so nothing noticed.
+//
+// The check below is what sshd will make of the digits, computed independently: parse
+// them as a wall clock and subtract the zone's standard offset.
+func TestTheExpiryIsWrittenAtStandardTimeBecauseThatIsHowSSHDReadsIt(t *testing.T) {
+	for _, zone := range []string{
+		"UTC",
+		"America/New_York", // northern DST
+		"Europe/Berlin",    // northern DST, positive offset
+		"Australia/Sydney", // southern DST, so its summer is the other half of the year
+		"Asia/Kolkata",     // a half-hour offset and no DST at all
+		"Africa/Nairobi",   // no DST
+	} {
+		loc, err := time.LoadLocation(zone)
+		if err != nil {
+			t.Fatalf("LoadLocation(%q): %v", zone, err)
+		}
+		for _, when := range []time.Time{
+			time.Date(2026, 1, 15, 9, 30, 0, 0, time.UTC),
+			time.Date(2026, 8, 14, 16, 0, 0, 0, time.UTC),
+			time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC),
+		} {
+			name := zone + "/" + when.Format("2006-01")
+			t.Run(name, func(t *testing.T) {
+				spec := formatExpiryTimespecIn(when, loc)
+
+				// What sshd does with it: strptime into a zeroed tm, then mktime with
+				// tm_isdst == 0, i.e. resolve the wall clock at the standard offset.
+				nominal, err := time.ParseInLocation("20060102150405", spec, time.UTC)
+				if err != nil {
+					t.Fatalf("sshd could not parse %q: %v", spec, err)
+				}
+				std := standardOffsetForTest(t, loc, when.In(loc).Year())
+				asSSHDReadsIt := nominal.Add(-time.Duration(std) * time.Second)
+				if !asSSHDReadsIt.Equal(when) {
+					t.Errorf("expiry %s written as %q, which sshd resolves to %s: %s out. "+
+						"An expiry sshd reads as later than the session it belongs to is a key "+
+						"that keeps working after the access ended",
+						when, spec, asSSHDReadsIt, asSSHDReadsIt.Sub(when))
+				}
+
+				// And the sweep must read back what was written, or it removes a key
+				// before or after sshd stops honouring it.
+				back, ok := parseExpiryTimespecIn(spec, loc)
+				if !ok {
+					t.Fatalf("this package cannot read back the %q it wrote", spec)
+				}
+				if !back.Equal(when) {
+					t.Errorf("%q reads back as %s, want %s: the sweep and sshd disagree about "+
+						"when the key stops working", spec, back, when)
+				}
+			})
+		}
+	}
+}
+
+// The concrete case, spelled out, because it is the one that was wrong and an
+// off-by-one-hour is easy to reintroduce while every round-trip test still passes.
+func TestASummerExpiryIsNotWrittenAtTheDaylightSavingOffset(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("LoadLocation: %v", err)
+	}
+
+	// 16:00 UTC on 14 August 2026 is 12:00 EDT, and 11:00 EST.
+	when := time.Date(2026, 8, 14, 16, 0, 0, 0, time.UTC)
+	const wantEST = "20260814110000"
+	const daylight = "20260814120000" // what rendering at the offset in force gives
+
+	got := formatExpiryTimespecIn(when, loc)
+	if got == daylight {
+		t.Errorf("the expiry is written as %q, the wall clock in EDT. sshd resolves an "+
+			"unsuffixed timespec with tm_isdst = 0, so it reads that as 12:00 EST = 17:00 UTC "+
+			"and keeps honouring the key for an hour after the session ended", got)
+	}
+	if got != wantEST {
+		t.Errorf("the expiry is written as %q, want %q (the same instant at the zone's "+
+			"standard offset)", got, wantEST)
+	}
+
+	// The reading side has to make the same assumption, or the sweep removes a key
+	// before sshd stops honouring it and drops the user mid-session. An entry that says
+	// 20260814120000 means 12:00 EST — 17:00 UTC — to sshd, even though 14 August is in
+	// EDT, and it has to mean that here too.
+	asSSHDReadsIt, ok := parseExpiryTimespecIn(daylight, loc)
+	if !ok {
+		t.Fatalf("%q cannot be read back", daylight)
+	}
+	if want := time.Date(2026, 8, 14, 17, 0, 0, 0, time.UTC); !asSSHDReadsIt.Equal(want) {
+		t.Errorf("%q reads as %s, want %s (both in UTC): mktime with tm_isdst = 0 resolves "+
+			"that wall clock at the standard offset, so reading it as daylight time makes the "+
+			"sweep revoke the key an hour before sshd does",
+			daylight, asSSHDReadsIt.UTC(), want.UTC())
+	}
+
+	// The Z form is what #226 proposed instead. It is correct for sshd 9.1+ and refused
+	// outright by everything older, which is most of the supported platforms — hence
+	// TestTheExpiryTimespecIsTheFormEverySupportedSSHDParses. It must still be *read*,
+	// though, both because an sshd 9.1+ host's own keys may carry it and because an
+	// operator may have written one by hand.
+	utc, ok := parseExpiryTimespecIn("20260814160000Z", loc)
+	if !ok {
+		t.Fatal("the Z-suffixed form sshd 9.1+ accepts cannot be read")
+	}
+	if !utc.Equal(when) {
+		t.Errorf("the Z form read back as %s, want %s (both in UTC)", utc.UTC(), when.UTC())
+	}
 }

--- a/pkg/ssh/entry.go
+++ b/pkg/ssh/entry.go
@@ -235,8 +235,8 @@ func splitOptions(options string) []string {
 	return out
 }
 
-// expiryTimespecLayout is the format the broker writes: sshd's YYYYMMDDHHMMSS, in
-// the host's own time zone, which is how sshd reads a timespec with no suffix.
+// expiryTimespecLayout is the format the broker writes: sshd's YYYYMMDDHHMMSS,
+// rendered at the host zone's standard-time offset (see standardTimeOffset).
 //
 // Not the UTC form. Suffixing the timespec with Z to mean UTC was added in OpenSSH
 // 9.1; every sshd before that parses a timespec by its length (8, 12 or 14 digits)
@@ -244,36 +244,127 @@ func splitOptions(options string) []string {
 // writing UTC would have limited this to Debian 12/Ubuntu 24.04-era hosts and
 // broken RHEL 8 and 9, Debian 11 and Ubuntu 20.04 and 22.04 — and broken them in
 // the way that is hardest to see, since the file looks correct and only sshd
-// disagrees. The two processes share a host and therefore a time zone, so the
-// local form is unambiguous in practice.
+// disagrees.
+//
+// Verified rather than assumed: misc.c at tag V_9_0_P1 switches on strlen(s) over
+// {8,12,14} and returns SSH_ERR_INVALID_FORMAT for anything else, while V_9_1_P1 is
+// the first tag that strips a trailing "Z"/"UTC" before that switch. So the plain
+// 14-digit form is the only one the supported range parses, and #226's proposed fix
+// — append "Z" — would deny every login on the majority of supported platforms.
 const expiryTimespecLayout = "20060102150405"
+
+// standardTimeOffset returns the UTC offset loc keeps when daylight saving is *not*
+// in effect around t. It is the offset sshd will use to read an unsuffixed timespec,
+// and it is not necessarily the offset in force at t.
+//
+// (#226) This is what the option's value has to be rendered at, and getting it wrong
+// is a revocation gap rather than cosmetic drift. sshd parses the timespec with
+// parse_absolute_time() (misc.c), which does:
+//
+//	memset(&tm, 0, sizeof(tm));
+//	strptime(buf, fmt, &tm);
+//	mktime(&tm);
+//
+// The memset leaves tm.tm_isdst == 0, and strptime does not set it. Zero means "DST
+// is not in effect" — not "work it out", which would be -1 — so mktime resolves the
+// wall clock at the zone's standard offset whatever time of year it is. Measured, on
+// both libcs that matter, for 2026-08-14 12:00:00 in America/New_York:
+//
+//	tm_isdst =  0  ->  2026-08-14 17:00 UTC   (i.e. 12:00 EST)
+//	tm_isdst = -1  ->  2026-08-14 16:00 UTC   (i.e. 12:00 EDT)
+//
+// identical on Darwin libc and on glibc 2.41 (Debian, python:3-slim), which settles
+// the question #226 left open. Rendering the expiry at the offset in force at t —
+// what this used to do — therefore made sshd honour a key for an hour longer than
+// the session it belonged to for the whole of the DST half of the year: the broker
+// expired the session, the audit trail said the access had ended, and the key still
+// authenticated. Rendering it at the standard offset makes the two agree exactly.
+//
+// A host in UTC, or in any zone with no DST rule, is unaffected either way: t is
+// never DST there, so this returns the offset at t and the output is unchanged.
+func standardTimeOffset(t time.Time, loc *time.Location) int {
+	local := t.In(loc)
+	if !local.IsDST() {
+		_, offset := local.Zone()
+		return offset
+	}
+	// Probe outward for the nearest instant in this zone that is not DST and take
+	// that period's offset. This is deliberately the same search glibc's mktime makes
+	// when the tm it is handed asks for an isdst it cannot satisfy locally, so the two
+	// arrive at the same offset. A day's granularity is enough: the shortest non-DST
+	// period in the tz database is about eight days (Africa/Tunis, 1943), and the
+	// shortest DST period about seven.
+	for days := 1; days <= 200; days++ {
+		for _, direction := range []int{-1, 1} {
+			if probe := local.AddDate(0, 0, direction*days); !probe.IsDST() {
+				_, offset := probe.Zone()
+				return offset
+			}
+		}
+	}
+	// A zone that is on DST all year round (Europe/Dublin's negative-DST encoding is
+	// the closest real case). Nothing better to say than the offset at t.
+	_, offset := local.Zone()
+	return offset
+}
 
 // parseExpiryTimespec reads any of the forms sshd(8) documents for a timespec:
 // YYYYMMDD or YYYYMMDDHHMM[SS], each optionally suffixed with Z for UTC and
-// otherwise in the host's own time zone.
+// otherwise at the host zone's standard-time offset.
 //
 // It reads more forms than formatExpiryTimespec writes on purpose. The sweep must
 // agree with sshd about when an entry stops working, and an entry it did not write
 // — an operator's own expiring key, or the Z form an sshd 9.1+ host accepts — is
 // still one whose expiry it should honour rather than guess at.
+//
+// (#226) Reading the unsuffixed form at the standard offset rather than "in local
+// time" is the other half of that agreement. Parsing with time.ParseInLocation and
+// time.Local resolves a summer wall clock as DST, which is precisely what sshd does
+// not do — so the sweep would have removed a key up to an hour before sshd stopped
+// honouring it, dropping users mid-session, and the round trip through
+// formatExpiryTimespec would not have been the identity.
 func parseExpiryTimespec(value string) (time.Time, bool) {
-	loc := time.Local
-	if strings.HasSuffix(value, "Z") || strings.HasSuffix(value, "z") {
+	return parseExpiryTimespecIn(value, time.Local)
+}
+
+// parseExpiryTimespecIn is parseExpiryTimespec against an explicit zone, so that the
+// DST behaviour can be tested on a host in any time zone.
+func parseExpiryTimespecIn(value string, loc *time.Location) (time.Time, bool) {
+	isUTC := strings.HasSuffix(value, "Z") || strings.HasSuffix(value, "z")
+	if isUTC {
 		value = value[:len(value)-1]
-		loc = time.UTC
 	}
 	for _, layout := range []string{"20060102150405", "200601021504", "20060102"} {
-		if parsed, err := time.ParseInLocation(layout, value, loc); err == nil {
-			return parsed, true
+		// Read the digits as a wall clock first, with no zone applied, then place it.
+		nominal, err := time.ParseInLocation(layout, value, time.UTC)
+		if err != nil {
+			continue
 		}
+		if isUTC {
+			return nominal, true
+		}
+		// Within an hour or so of a DST transition the standard offset derived from
+		// nominal can be the neighbouring period's, and mktime's own search has the
+		// same ambiguity from the other side. An hour of disagreement in the two hours
+		// a year a transition covers is not worth a second parse to chase.
+		offset := standardTimeOffset(nominal, loc)
+		return nominal.Add(-time.Duration(offset) * time.Second), true
 	}
 	return time.Time{}, false
 }
 
-// formatExpiryTimespec renders an expiry for sshd's expiry-time= option, in the
-// host's local time because that is what sshd reads an unsuffixed timespec as.
+// formatExpiryTimespec renders an expiry for sshd's expiry-time= option at the host
+// zone's standard-time offset, because that is how sshd reads an unsuffixed timespec
+// whatever the time of year (#226; see standardTimeOffset).
 func formatExpiryTimespec(t time.Time) string {
-	return t.Local().Format(expiryTimespecLayout)
+	return formatExpiryTimespecIn(t, time.Local)
+}
+
+// formatExpiryTimespecIn is formatExpiryTimespec against an explicit zone, so that
+// the DST behaviour can be tested on a host in any time zone.
+func formatExpiryTimespecIn(t time.Time, loc *time.Location) string {
+	offset := standardTimeOffset(t, loc)
+	return t.In(time.FixedZone("", offset)).Format(expiryTimespecLayout)
 }
 
 // brokerEntryLine renders the authorized_keys line the broker installs: the key

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -41,22 +41,45 @@ type SSHKey struct {
 	ExpiresAt  time.Time
 }
 
-// usernamePattern is a strict allowlist for POSIX-style login names: a leading
-// lowercase letter or underscore, followed by lowercase letters, digits,
-// underscores, or hyphens, with an optional trailing '$'. Anchored and length
-// bounded. This is a positive allowlist (M-7) rather than a denylist, so it also
-// rejects "..", path separators, leading dots, and other traversal tricks.
-var usernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}\$?$`)
+// usernamePattern is the allowlist for a login name. It is anchored and length
+// bounded, and it is still a positive allowlist (M-7) rather than a denylist, so it
+// rejects "..", path separators, leading dots and other traversal tricks by
+// construction: the first character may only be a letter, a digit or an underscore.
+//
+// (#229) It used to be `^[a-z_][a-z0-9_-]{0,31}\$?$` — lowercase POSIX login names
+// and nothing else — which is not the population this product is deployed into. SSSD
+// presents an Active Directory account as `DOMAIN\user` or `user@realm` depending on
+// use_fully_qualified_names, both of which that pattern refused, along with every
+// `first.last`, every machine account with a `$`, and every name with a capital
+// letter in it. A site running the modal enterprise Linux identity stack therefore
+// had *every* username rejected before any authentication was attempted, and the
+// failure surfaced as a broker error rather than as a username-format policy.
+//
+// What the check is actually for is the two places a name reaches the filesystem or
+// an argument list: it is joined into a filename, and it is passed to getent(1) as
+// argv. So the characters that stay refused are the ones that matter there —
+// anything outside this set, which excludes `/`, NUL, every control character and
+// every kind of whitespace, and a leading `-` that getent would read as an option.
+// Whether the name exists is NSS's answer to give, not this pattern's.
+//
+// Whitespace is refused for a third reason worth naming: the broker stamps each key
+// it issues with a `<username>@oidc-pam-<unix>` comment and recognises its own
+// entries by parsing that single field back out. A name with a space in it would
+// split the comment, and an entry the sweep cannot recognise is a credential that
+// never expires.
+var usernamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._@\\$-]{0,127}$`)
 
-// validateUsername rejects usernames that are not valid POSIX login names,
-// which also prevents path-traversal when usernames are joined into filesystem
-// paths under the broker's base directory.
+// validateUsername rejects names that cannot be used safely as a path element or as
+// an argument to the account-database lookup. It is not an assertion that the account
+// exists: LookupAccount asks NSS that, and the resolved uid and home directory are
+// what every subsequent operation uses.
 func validateUsername(username string) error {
 	if username == "" {
 		return fmt.Errorf("username cannot be empty")
 	}
 	if !usernamePattern.MatchString(username) {
-		return fmt.Errorf("username %q is not a valid POSIX login name", username)
+		return fmt.Errorf("username %q contains characters that are not safe in a path "+
+			"or an argument list", username)
 	}
 	return nil
 }

--- a/pkg/ssh/lock_test.go
+++ b/pkg/ssh/lock_test.go
@@ -57,11 +57,14 @@ func seedStaleKey(t *testing.T, baseDir, username string) string {
 	return path
 }
 
-// runWithin runs fn and returns its error, failing the test if fn has not
-// returned by limit. Without the guard a regression would hang the whole package
-// until `go test` times out ten minutes later with no indication of which call
-// blocked.
-func runWithin(t *testing.T, limit time.Duration, fn func() error) error {
+// runWithin runs fn and returns its error, failing the test if fn has not returned by
+// limit. `what` names what was being waited for, and should say what a timeout would
+// mean, because a call that blocks forever is the failure being tested for in more
+// than one place: on a held lock (#161) and on a FIFO in the user's .ssh (#205).
+//
+// Without the guard such a regression hangs the whole package until `go test` times
+// out ten minutes later, with a goroutine dump and no indication of which call blocked.
+func runWithin(t *testing.T, limit time.Duration, what string, fn func() error) error {
 	t.Helper()
 
 	done := make(chan error, 1)
@@ -70,7 +73,8 @@ func runWithin(t *testing.T, limit time.Duration, fn func() error) error {
 	case err := <-done:
 		return err
 	case <-time.After(limit):
-		t.Fatalf("call did not return within %s while the lock was held; it is blocking on the lock (#161)", limit)
+		t.Fatalf("%s did not return within %s: it is blocked in the kernel rather than "+
+			"failing, which is the defect itself and not a slow test", what, limit)
 		return nil
 	}
 }
@@ -85,7 +89,8 @@ func TestRemoveExpiredKeysGivesUpWhenTheLockIsHeld(t *testing.T) {
 	path := seedStaleKey(t, base, "alice")
 	holdLock(t, akm, "alice")
 
-	err := runWithin(t, 5*time.Second, func() error { return akm.RemoveExpiredKeys("alice") })
+	err := runWithin(t, 5*time.Second, "RemoveExpiredKeys while another writer held alice's lock (#161)",
+		func() error { return akm.RemoveExpiredKeys("alice") })
 	if !errors.Is(err, ErrLockUnavailable) {
 		t.Fatalf("expected ErrLockUnavailable, got %v", err)
 	}
@@ -112,7 +117,8 @@ func TestAddPublicKeyGivesUpWhenTheLockIsHeld(t *testing.T) {
 	holdLock(t, akm, "alice")
 
 	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ alice@oidc-pam")
-	err := runWithin(t, 5*time.Second, func() error { return akm.AddPublicKey("alice", key, testExpiry()) })
+	err := runWithin(t, 5*time.Second, "AddPublicKey while another writer held alice's lock (#161)",
+		func() error { return akm.AddPublicKey("alice", key, testExpiry()) })
 	if !errors.Is(err, ErrLockUnavailable) {
 		t.Fatalf("expected ErrLockUnavailable, got %v", err)
 	}
@@ -130,7 +136,8 @@ func TestOneUsersLockDoesNotBlockAnother(t *testing.T) {
 	seedStaleKey(t, base, "alice")
 	holdLock(t, akm, "alice")
 
-	if err := runWithin(t, 5*time.Second, func() error { return akm.RemoveExpiredKeys("bob") }); err != nil {
+	if err := runWithin(t, 5*time.Second, "RemoveExpiredKeys for bob while alice held her lock",
+		func() error { return akm.RemoveExpiredKeys("bob") }); err != nil {
 		t.Fatalf("RemoveExpiredKeys(bob): %v", err)
 	}
 
@@ -170,8 +177,49 @@ func TestTheLockIsNotInTheUsersHome(t *testing.T) {
 		}
 	}
 
-	if _, err := os.Stat(filepath.Join(lockDir, "alice.lock")); err != nil {
+	lockPath := akm.LockPath("alice")
+	if filepath.Dir(lockPath) != lockDir {
+		t.Fatalf("lock path %s is not in the broker's lock directory %s", lockPath, lockDir)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
 		t.Errorf("expected the lock in the broker's lock directory: %v", err)
+	}
+}
+
+// (#225) The lock has to name the file it protects, not the account that asked for
+// it. Two accounts sharing one home — a role account and its owner, or a pair of AD
+// principals mapped to one POSIX home, which is how service accounts are commonly
+// set up — write the *same* authorized_keys, so keying the lock on the username gave
+// them different lock files and no mutual exclusion at all. Each would read, modify
+// and rewrite the whole file, and whichever renamed last silently discarded the
+// other's key: a login that reported success and then could not authenticate.
+func TestTwoAccountsSharingAHomeShareALock(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "shared")
+	if err := os.MkdirAll(home, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	akm := NewAuthorizedKeysManager(t.TempDir())
+	akm.SetAccountLookup(func(username string) (Account, error) {
+		// Both names resolve to one home, as a passwd database with two entries
+		// pointing at the same directory does.
+		return Account{Username: username, Home: home, UID: os.Geteuid(), GID: os.Getegid()}, nil
+	})
+	akm.SetLockTimeout(150 * time.Millisecond)
+
+	if alice, bob := akm.LockPath("alice"), akm.LockPath("bob"); alice != bob {
+		t.Errorf("alice and bob share %s but lock different files:\n  %s\n  %s", home, alice, bob)
+	}
+
+	holdLock(t, akm, "alice")
+
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ bob@oidc-pam")
+	err := runWithin(t, 5*time.Second, "AddPublicKey for bob while alice held the lock on their shared home (#225)",
+		func() error { return akm.AddPublicKey("bob", key, testExpiry()) })
+	if !errors.Is(err, ErrLockUnavailable) {
+		t.Fatalf("bob wrote %s while alice held the lock on it: expected ErrLockUnavailable, got %v",
+			filepath.Join(home, ".ssh", "authorized_keys"), err)
 	}
 }
 

--- a/pkg/ssh/security_hardening_test.go
+++ b/pkg/ssh/security_hardening_test.go
@@ -3,8 +3,11 @@ package ssh
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // TestAddPublicKeyRejectsSymlinkedAuthorizedKeys verifies the C-2 fix: the root
@@ -81,17 +84,44 @@ func TestAddPublicKeyRejectsEmbeddedNewline(t *testing.T) {
 	}
 }
 
+// validateUsername guards the two places a login name reaches something that can be
+// injected into: a path element, and getent(1)'s argv. It is not a statement about
+// which accounts exist — NSS answers that.
+//
+// (#229) The pattern used to be `^[a-z_][a-z0-9_-]{0,31}\$?$`, i.e. lowercase POSIX
+// login names only. That is not the population this product deploys into: SSSD
+// presents an AD account as `DOMAIN\user` or `user@realm` depending on
+// use_fully_qualified_names, and neither form — nor `First.Last`, nor a machine
+// account's `$`, nor any capital letter — matched. A site on the modal enterprise
+// identity stack had every username refused before authentication was even attempted.
+// The cases below that carry a comment are the ones that were rejected before.
 func TestValidateUsernameAllowlist(t *testing.T) {
-	valid := []string{"alice", "bob_123", "svc-account", "_systemd", "user$"}
+	valid := []string{
+		"alice", "bob_123", "svc-account", "_systemd", "user$",
+		"Alice",              // a capital letter is legal in a POSIX login name
+		"1user",              // so is a leading digit (useradd allows it; NSS certainly does)
+		"DOMAIN\\user",       // SSSD, use_fully_qualified_names = false
+		"alice@corp.example", // SSSD, use_fully_qualified_names = true
+		"First.Last",         // the common AD sAMAccountName shape
+		"WORKSTATION$",       // an AD machine account
+		"toolongusernameusernameusernameusernameusername",
+		strings.Repeat("a", 128), // the bound is a path/argv sanity limit, not 32
+	}
 	for _, u := range valid {
 		if err := validateUsername(u); err != nil {
 			t.Errorf("expected %q to be valid, got: %v", u, err)
 		}
 	}
+
+	// What must stay refused is what is dangerous in a path or an argument list.
 	invalid := []string{
 		"", "..", "../etc", "/etc/passwd", ".", ".ssh",
-		"Alice", "user name", "evil;rm", "a\x00b", "1user",
-		"toolongusernameusernameusernameusernameusername",
+		"user name",  // whitespace would also split the broker's key comment
+		"user\tname", //
+		"alice\n", "evil;rm", "a\x00b",
+		"-oProxyCommand",         // getent would read a leading dash as an option
+		"a/b",                    // a separator escapes the directory the name is joined into
+		strings.Repeat("a", 129), // past the bound
 	}
 	for _, u := range invalid {
 		if err := validateUsername(u); err == nil {
@@ -245,4 +275,337 @@ func TestNothingInThisPackageChownsByName(t *testing.T) {
 			}
 		}
 	}
+}
+
+// everyReadingEntryPoint is every exported operation that reads a user's
+// authorized_keys before doing anything else. They are enumerated because the
+// hardening below is only worth having if it holds on all of them: a single entry
+// point that still follows a symlink, blocks on a FIFO or reads an unbounded file is
+// the whole defect, and each of these is reachable from the broker (login, logout,
+// session expiry, the periodic sweep) or from oidc-admin.
+//
+// RestoreAuthorizedKeys is deliberately absent: it reads the *backup*, not the key
+// list, so it has its own cases.
+func everyReadingEntryPoint(akm *AuthorizedKeysManager, username string) map[string]func() error {
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ " + username + "@oidc-pam-1")
+	return map[string]func() error{
+		"AddPublicKey":         func() error { return akm.AddPublicKey(username, key, testExpiry()) },
+		"RemovePublicKey":      func() error { _, err := akm.RemovePublicKey(username, key); return err },
+		"RemoveOIDCKeys":       func() error { _, err := akm.RemoveOIDCKeys(username); return err },
+		"RemoveExpiredKeys":    func() error { return akm.RemoveExpiredKeys(username) },
+		"KeyIsAuthorized":      func() error { _, err := akm.KeyIsAuthorized(username, key); return err },
+		"ListOIDCKeys":         func() error { _, err := akm.ListOIDCKeys(username); return err },
+		"BackupAuthorizedKeys": func() error { return akm.BackupAuthorizedKeys(username) },
+	}
+}
+
+// (#205) A FIFO where authorized_keys should be must not block the caller.
+//
+// open(2) on a FIFO for reading blocks until a writer appears, and the open used to
+// be plain O_RDONLY|O_NOFOLLOW — which a FIFO passes, since rejectIfSymlink tests
+// os.ModeSymlink alone. So `rm ~/.ssh/authorized_keys && mkfifo
+// ~/.ssh/authorized_keys` parked the broker in the kernel indefinitely, *inside*
+// withFileLock and on the single session-cleanup goroutine: no session would expire
+// and no key would be revoked for any account on the host again, and Stop() would
+// hang on wg.Wait() until systemd's TimeoutStopSec killed it. One unprivileged user,
+// one command, no race to win.
+//
+// The fix is O_NONBLOCK on the open plus an fstat on the descriptor that came back,
+// so what is checked is the object the read would come from rather than what the name
+// pointed at earlier.
+func TestAFIFOWhereAuthorizedKeysShouldBeCannotWedgeTheBroker(t *testing.T) {
+	base := t.TempDir()
+	akm := newTestManager(t, base)
+	username := "testuser"
+	sshDir := filepath.Join(base, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fifo := filepath.Join(sshDir, "authorized_keys")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		t.Fatalf("Mkfifo: %v", err)
+	}
+
+	for name, call := range everyReadingEntryPoint(akm, username) {
+		t.Run(name, func(t *testing.T) {
+			// The deadline is the assertion. Without O_NONBLOCK this call never returns
+			// at all, and a test that only checked the error would hang the package until
+			// go test's ten-minute timeout with no indication of which call blocked.
+			err := runWithin(t, 5*time.Second, name+" with a FIFO where authorized_keys should be (#205)", call)
+			if err == nil {
+				t.Fatalf("%s accepted a FIFO at %s", name, fifo)
+			}
+			if !strings.Contains(err.Error(), "not a regular file") {
+				t.Errorf("%s refused the FIFO with %v, which does not say the file is not a "+
+					"regular one; the refusal has to come from the fstat on the descriptor", name, err)
+			}
+		})
+	}
+}
+
+// The same for the backup, which RestoreAuthorizedKeys reads and then installs as an
+// account's key list. It lives in the broker's own directory now (#228), so this is
+// defence in depth rather than a reachable attack — but it is the one path that writes
+// a file's contents into a key list with root's privileges.
+func TestAFIFOWhereTheBackupShouldBeCannotWedgeRestore(t *testing.T) {
+	base := t.TempDir()
+	akm := newTestManager(t, base)
+	username := "testuser"
+	if err := os.MkdirAll(filepath.Join(base, username, ".ssh"), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	backupPath := akm.BackupPath(username)
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0700); err != nil {
+		t.Fatalf("MkdirAll backup dir: %v", err)
+	}
+	if err := syscall.Mkfifo(backupPath, 0600); err != nil {
+		t.Fatalf("Mkfifo: %v", err)
+	}
+
+	err := runWithin(t, 5*time.Second, "RestoreAuthorizedKeys with a FIFO where the backup should be (#205)",
+		func() error { return akm.RestoreAuthorizedKeys(username) })
+	if err == nil {
+		t.Fatalf("RestoreAuthorizedKeys accepted a FIFO at %s", backupPath)
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("the refusal was %v, which does not say the backup is not a regular file", err)
+	}
+}
+
+// (#206) The whole of authorized_keys is read into memory, so its size has to be
+// bounded before the read rather than after. A user can make the file as large as
+// their quota allows — and larger than any quota, since a sparse file costs nothing
+// to create: `truncate -s 8T ~/.ssh/authorized_keys` is instant and occupies no
+// blocks. The broker then tried to allocate it, was killed by the OOM killer or by
+// systemd's MemoryMax, and took every other account's session management with it.
+//
+// The bound is 1 MiB, which is not a guess: the largest entry a real key list can
+// hold is under 3 KB (a 16384-bit RSA key is about 2.4 KB of base64, plus options and
+// a comment), so 1 MiB is room for roughly 350 of those, 1,300 RSA-4096 entries or
+// 10,000 ed25519 ones. No human key list is near it and no generated one should be.
+// Reaching the limit is an error rather than a truncation: a key list silently
+// missing its tail is one the caller would write straight back out, deleting keys.
+func TestAnAbsurdlyLargeAuthorizedKeysIsRefusedRatherThanRead(t *testing.T) {
+	base := t.TempDir()
+	akm := newTestManager(t, base)
+	username := "testuser"
+	sshDir := filepath.Join(base, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(sshDir, "authorized_keys")
+
+	// Sparse, so this is instant and costs no disk: exactly how the file would be
+	// created in anger.
+	const size = 8 << 30 // 8 GiB
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := f.Truncate(size); err != nil {
+		_ = f.Close()
+		t.Skipf("this filesystem will not make a sparse %d-byte file: %v", size, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	for name, call := range everyReadingEntryPoint(akm, username) {
+		t.Run(name, func(t *testing.T) {
+			// A deadline as well as an error: reading 8 GiB would not fail, it would
+			// take the process out, and a test that waited for that would time out the
+			// package rather than report anything.
+			err := runWithin(t, 30*time.Second, name+" with an 8 GiB sparse authorized_keys (#206)", call)
+			if err == nil {
+				t.Fatalf("%s read a %d-byte authorized_keys", name, int64(size))
+			}
+			if !strings.Contains(err.Error(), "not a key list") {
+				t.Errorf("%s failed with %v, which does not say the file was refused for its "+
+					"size; the size has to be checked before the read, not after", name, err)
+			}
+		})
+	}
+}
+
+// (#225) The temporary file the atomic write goes through used to be named
+// .authorized_keys.tmp.<pid>. The broker's pid is public — /proc, ps, systemd's
+// MainPID — and the temp file is created in a directory the target account owns, so
+// the account could pre-create that exact name and every write through it failed.
+// Worse, the name depends on the broker's pid and on nothing else, so the account
+// doing the obstructing need not be the account being provisioned: one user could
+// stop key provisioning for every account on the host, and two brokers (or a pid
+// recycled after a crash) collided on it by accident for the same reason.
+//
+// os.CreateTemp picks an unpredictable name and creates it O_EXCL, so there is no
+// name to squat and nothing to clobber.
+func TestAPreCreatedTempNameDoesNotBlockProvisioning(t *testing.T) {
+	base := t.TempDir()
+	akm := newTestManager(t, base)
+	username := "testuser"
+	sshDir := filepath.Join(base, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Squat the predictable name with a non-empty directory. That is the version of
+	// the defect with no race in it at all: the old code did `os.Remove(tmpPath)`
+	// first, which clears a plain file the account planted (and loses a race against
+	// an account that recreates it), but rmdir cannot remove a directory with
+	// something in it, and the O_CREAT|O_EXCL open that followed then failed with
+	// EEXIST on every attempt, for ever.
+	squat := filepath.Join(sshDir, ".authorized_keys.tmp."+strconv.Itoa(os.Getpid()))
+	if err := os.Mkdir(squat, 0700); err != nil {
+		t.Fatalf("Mkdir squat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(squat, "pin"), nil, 0600); err != nil {
+		t.Fatalf("WriteFile in squat: %v", err)
+	}
+
+	key := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ testuser@oidc-pam-1")
+	if err := akm.AddPublicKey(username, key, testExpiry()); err != nil {
+		t.Fatalf("AddPublicKey was blocked by a squatted temp name %s: %v", squat, err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(sshDir, "authorized_keys")) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(content), "AAAAC3NzaC1lZDI1NTE5AAAAINrqnRJYKhFTuTjCGAZ") {
+		t.Errorf("the key was not installed; authorized_keys is %q", content)
+	}
+}
+
+// (#204) A symlinked .ssh has to be refused by every entry point, not only by the one
+// that creates the directory.
+//
+// Only AddPublicKey went through ensureSecureSSHDir, which lstats .ssh and refuses a
+// link. The read-only and removal paths called os.Stat instead — which *follows*
+// symlinks, so it reports on the target — and then opened .ssh/authorized_keys, where
+// O_NOFOLLOW constrains the final component only and cannot see that a parent
+// component was a link. So a user who replaced ~/.ssh with a link to /root/.ssh had
+// the broker read root's key list through it and, on the removal paths, rewrite it:
+// RemoveOIDCKeys would strip root's broker-issued keys, and RemoveExpiredKeys would
+// rewrite the whole file as root's authorized_keys with entries missing. Now every
+// entry point goes through checkSSHDir first.
+func TestASymlinkedSSHDirIsRefusedByEveryEntryPoint(t *testing.T) {
+	base := t.TempDir()
+	akm := newTestManager(t, base)
+	username := "testuser"
+
+	// Somebody else's key list, reachable only through the link.
+	victimDir := filepath.Join(base, "victim-ssh")
+	if err := os.MkdirAll(victimDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	const victimContent = "ssh-rsa AAAAB3NzaC1yc2EVICTIM root@oidc-pam-1\n"
+	victimKeys := filepath.Join(victimDir, "authorized_keys")
+	if err := os.WriteFile(victimKeys, []byte(victimContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink(victimDir, filepath.Join(base, username, ".ssh")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	for name, call := range everyReadingEntryPoint(akm, username) {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			if err == nil {
+				t.Fatalf("%s operated on a symlinked .ssh", name)
+			}
+			if !strings.Contains(err.Error(), "symlink") {
+				t.Errorf("%s failed with %v, which does not say the .ssh directory was a "+
+					"symlink", name, err)
+			}
+			data, readErr := os.ReadFile(victimKeys) // #nosec G304 -- test temp dir
+			if readErr != nil {
+				t.Fatalf("ReadFile: %v", readErr)
+			}
+			if string(data) != victimContent {
+				t.Errorf("%s rewrote another account's key list through the link: %q", name, data)
+			}
+		})
+	}
+
+	// RestoreAuthorizedKeys is the same question from the other side: it must not
+	// install a key list through the link either.
+	backupPath := akm.BackupPath(username)
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0700); err != nil {
+		t.Fatalf("MkdirAll backup dir: %v", err)
+	}
+	if err := os.WriteFile(backupPath, []byte("ssh-ed25519 AAAARESTORED x@oidc-pam-1\n"), 0600); err != nil {
+		t.Fatalf("WriteFile backup: %v", err)
+	}
+	if err := akm.RestoreAuthorizedKeys(username); err == nil {
+		t.Error("RestoreAuthorizedKeys wrote a key list through a symlinked .ssh")
+	}
+	data, err := os.ReadFile(victimKeys) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != victimContent {
+		t.Errorf("RestoreAuthorizedKeys overwrote another account's key list: %q", data)
+	}
+}
+
+// (#225) The durability half of the atomic replace, which cannot be tested from a
+// process: proving it needs the power cut, and nothing observable in-process
+// distinguishes a write that was fsynced from one that was not.
+//
+// It still matters. Without the fsync on the file, a host on ext4 with the default
+// data=ordered that loses power just after the rename comes back with the directory
+// entry durable and the contents not — the documented outcome is a zero-length
+// authorized_keys. Every provisioned key for that account is then gone, and nothing
+// detects it, because the file exists and parses: the user simply cannot log in by the
+// mechanism the broker is responsible for until their next successful login rewrites
+// it. Without the fsync on the *directory*, the rename's own durability is unspecified.
+//
+// So this is a source guard on the order of operations, in the spirit of
+// TestNothingInThisPackageChownsByName: it catches the removal of the syncs by someone
+// who does not know why they are there, which is the realistic regression, and it
+// makes no claim to have observed a crash.
+func TestTheAtomicWriteSyncsTheFileBeforeTheRenameAndTheDirectoryAfter(t *testing.T) {
+	source, err := os.ReadFile("authorized_keys.go") // #nosec G304 -- this package's own source
+	if err != nil {
+		t.Fatalf("read authorized_keys.go: %v", err)
+	}
+	body := functionBody(t, string(source), "func writeAuthorizedKeysAtomic(")
+
+	sync := strings.Index(body, "tmp.Sync()")
+	rename := strings.Index(body, "os.Rename(")
+	dirSync := strings.Index(body, "syncDir(")
+
+	switch {
+	case sync < 0:
+		t.Error("writeAuthorizedKeysAtomic does not fsync the temp file. A crash just after " +
+			"the rename can then leave a zero-length authorized_keys, silently destroying " +
+			"every provisioned key for that account (#225).")
+	case rename < 0:
+		t.Fatal("writeAuthorizedKeysAtomic no longer renames; this guard needs rewriting")
+	case sync > rename:
+		t.Errorf("writeAuthorizedKeysAtomic fsyncs the temp file at offset %d, after the "+
+			"rename at %d. The point of the fsync is that the contents are durable before "+
+			"the name pointing at them is (#225).", sync, rename)
+	}
+	if dirSync < 0 || dirSync < rename {
+		t.Error("writeAuthorizedKeysAtomic does not fsync the .ssh directory after the " +
+			"rename, so the rename's durability is unspecified (#225).")
+	}
+}
+
+// functionBody returns the source text of the function whose declaration starts with
+// decl, up to the closing brace in column zero. Crude, and sufficient: it is used to
+// ask about the order of statements in one known function.
+func functionBody(t *testing.T, source, decl string) string {
+	t.Helper()
+
+	start := strings.Index(source, decl)
+	if start < 0 {
+		t.Fatalf("cannot find %q in the source; this guard needs updating", decl)
+	}
+	end := strings.Index(source[start:], "\n}\n")
+	if end < 0 {
+		t.Fatalf("cannot find the end of %q", decl)
+	}
+	return source[start : start+end]
 }


### PR DESCRIPTION
Seven `pkg/ssh` audit findings from the v0.5.1 milestone. Every one of them is reached through the same place: the broker writes into `~/.ssh`, which the target account owns.

## Behaviour changes an operator will notice

**Backups move.** `BackupAuthorizedKeys` wrote `~/.ssh/authorized_keys.backup`; it now writes `/var/lib/oidc-pam/backups/<user>.authorized_keys` (derived from the lock directory, so a manager pointed at a temp state dir keeps everything together). An existing backup in a user's `.ssh` is not migrated and is not read — `RestoreAuthorizedKeys` will report no backup found until a fresh one is taken. That is deliberate: the old location is user-writable, and this is the one path that installs a file's contents into a key list with root's privileges.

**Lock filenames change.** `<lockDir>/<user>.lock` becomes `<lockDir>/<sha256 of the .ssh path, 32 hex chars>.lock`. Stale files from the old scheme are harmless; `printf %s /home/bob/.ssh | sha256sum` recovers the mapping.

**Ownership is preserved, not asserted.** A root-owned `authorized_keys` stays root-owned. A deployment that relied on the broker handing the file to the user on first write will keep a root-owned file — which is what root ownership was there for.

**Usernames the broker used to refuse now work.** `DOMAIN\user`, `user@realm`, `First.Last`, `WORKSTATION$`, and any name with a capital letter. Whether the account exists is still NSS's answer.

**`expiry-time=` values change by an hour during DST.** The written timespec is now the zone's standard-time offset rather than the offset in force, because that is how sshd resolves an unsuffixed timespec. Keys issued by an older broker are read back correctly either way (the parser honours a `Z` suffix and otherwise assumes standard time, same as sshd).

## The findings

| | What was wrong |
|---|---|
| #204 | `os.Stat` follows symlinks, so `ln -s /root/.ssh ~/.ssh` let four entry points read and rewrite root's key list. `checkOwner` accepts uid 0 because sshd's StrictModes does, so nothing downstream objected. New `checkSSHDir` gates all eight entry points. |
| #205 | `open(2)` on a FIFO for reading blocks until a writer appears — inside `withFileLock`, on the broker's single cleanup goroutine. `mkfifo ~/.ssh/authorized_keys` stopped key revocation for every account on the host and hung `Stop()`. Fixed with `O_NONBLOCK` plus an `IsRegular` check on the descriptor. |
| #206 | Unbounded `io.ReadAll` on a user-controlled file. `truncate -s 200G ~/.ssh/authorized_keys` OOM-killed the root broker from an unprivileged account, repeatedly, since `Restart=always` brings it back into the same read. Bounded at 1 MiB (~350 of the largest legitimate entries that exist). |
| #225 | Temp file named after the broker's pid, which any local user can read — squattable, and a host-wide provisioning outage. No `fsync`, so a crash after the rename can leave a zero-length key file on ext4 `data=ordered`. Lock keyed on the account, so two accounts sharing a home lost one of two concurrent writes. |
| #226 | `parse_absolute_time()` memsets `tm`, leaving `tm_isdst == 0` — "DST is not in effect", not "work it out". Rendering at the offset in force made sshd honour a key an hour past the session, while the audit trail said the access had ended. |
| #228 | Items 1–2: every write chowned to the account, downgrading a root-owned key list on first write; the backup lived where its own subject could edit it. |
| #229 | A colon in GECOS (routine from SSSD/AD) shifted `getent`'s fields, so the broker took a garbage string as the home. And the username allowlist refused every username at a site running SSSD against AD. |

## What is *not* in here

- **#204's residual race.** What is fixed is the no-race half — the link can be planted before the call and nothing looked. A name validated and then used still leaves a window; closing it needs the home held open and every operation done with `openat(2)` relative to a verified `.ssh` descriptor, which is a rewrite of the file rather than a fix in it. #228 item 3 (`reconcileIssuedKeys`, `pkg/auth/broker.go`) is likewise out of scope here.
- **#229's suggested fix** (lean on `user.Lookup`) is unusable: the released broker is built `CGO_ENABLED=0`, so `os/user` has no NSS behind it — which is why `lookupViaGetent` exists at all.
- **#226's suggested fix** (append `Z`, write UTC) would refuse the whole entry on RHEL 8/9, Debian 11, Ubuntu 20.04/22.04 — and refuse it in the way that is hardest to see, since the file looks right and only sshd disagrees.

## Verification

Every guard was proven non-vacuous by reintroducing the defect and watching the covering test fail, then restoring. Notably the #204 proof does not check a message — it shows the victim's key list overwritten through the link — and the #205 proof shows a 5-second timeout expiring in the kernel rather than an error string.

`go build ./...`, `go vet ./pkg/ssh/`, `gofmt -l pkg/ssh/` clean; `go test -count=1 ./pkg/ssh/ ./pkg/auth/` green.

Not observed on this host (macOS, unprivileged): the chown behaviour, since both helpers are no-ops when `euid != 0` — only the *decision* is tested, and the root-owned-stays-root-owned outcome belongs in the e2e container suite. The FIFO block was measured on Darwin, not Linux. The ext4 zero-length outcome is reasoned from documentation, not reproduced; #225's durability guard is a source-order test that makes no claim to have observed a crash. No real sshd was asked to parse a timespec — the `tm_isdst` semantics were measured against Darwin libc and glibc 2.41 and read out of `misc.c`, and the version boundaries come from the OpenSSH source history.

Closes #204, #205, #206, #225, #226, #229. #228 is partly addressed — items 1 and 2 here, item 3 (`reconcileIssuedKeys`) still open.