### PR TITLE
fix(ipc): keep the broker listening, and refuse an untrustworthy socket (#200, #211, #216, #224)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -492,15 +492,32 @@ ProtectSystem=strict
 # service, so no authorized_keys can be written at all (#171).
 ProtectHome=false
 # ProtectSystem=strict makes everything read-only, so every path the broker
-# writes is listed: its runtime socket, its logs, its state directory (issued keys
-# and per-user locks), and the home directories it provisions keys into. Add your
-# own home path here if homes are not under /home. The "-" prefix makes a missing
-# path non-fatal: without it systemd refuses to start the unit at all on a host
-# that has no /home, which is exactly the host whose homes are somewhere else.
-ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam -/home
+# writes is listed: its logs, its state directory (issued keys and per-user locks),
+# and the home directories it provisions keys into. Add your own home path here if
+# homes are not under /home. The "-" prefix makes a missing path non-fatal: without
+# it systemd refuses to start the unit at all on a host that has no /home, which is
+# exactly the host whose homes are somewhere else.
+#
+# The socket directory is deliberately not listed. It lives on the /run tmpfs, which
+# is empty after a reboot, and a bare ReadWritePaths entry for a path that does not
+# exist makes systemd fail the unit's namespace setup with 226/NAMESPACE before
+# ExecStart runs — forever, since Restart=always retries the identical failure. Use
+# RuntimeDirectory= instead, which creates it (#211).
+ReadWritePaths=/var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam -/home
 StateDirectory=oidc-pam
 StateDirectoryMode=0700
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
+# Creates /run/oidc-auth root:root 0750 before ExecStart and removes it on stop, and
+# reasserts that mode and owner on every start. Both halves matter: write access to
+# the directory holding the socket is enough to unlink it and bind an impostor at the
+# same path, which the broker now refuses to serve under (#200).
+RuntimeDirectory=oidc-auth
+RuntimeDirectoryMode=0750
+# CAP_CHOWN is what lets the broker hand a newly written authorized_keys to the
+# account it belongs to; without it every key provisioning failed with EPERM and
+# every login was denied (#202). It is only safe because the handover goes through
+# fchown(2) on an already-open descriptor rather than chown(2) on a path the account
+# can replace with a symlink (#203).
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID
 
 # Resource limits
 LimitNOFILE=65536
@@ -686,10 +703,16 @@ server {
     delaycompress
     missingok
     notifempty
-    create 640 oidc-auth oidc-auth
-    postrotate
-        systemctl reload oidc-auth-broker
-    endscript
+    # No `create`: copytruncate leaves the original file in place, so create would
+    # have no effect. The broker runs as root, not as oidc-auth.
+    # copytruncate, not a postrotate reload. The broker has no configuration reload
+    # and never had one; this stanza used to say `systemctl reload oidc-auth-broker`,
+    # which sent a SIGHUP that terminated the process — a ten-second authentication
+    # outage for the whole host, every night, with nothing in the journal but a clean
+    # exit and a restart (#224). The unit no longer advertises ExecReload= and the
+    # broker now ignores a stray SIGHUP, but neither of those reopens the log file,
+    # which is what rotation actually needs.
+    copytruncate
 }
 ```
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -120,6 +120,9 @@ func main() {
 		Str("socket_path", cfg.Server.SocketPath).
 		Msg("OIDC Authentication Broker started successfully")
 
+	// Keep a stray SIGHUP from taking the broker down (#224).
+	ignoreSIGHUP()
+
 	// Wait for shutdown signal
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -171,6 +174,36 @@ func main() {
 	}
 
 	log.Info().Msg("OIDC Authentication Broker stopped")
+}
+
+// ignoreSIGHUP stops a SIGHUP from terminating the broker.
+//
+// Go's default disposition for SIGHUP is to kill the process, and the broker has no
+// configuration reload: the config is read once, at startup, before auth.NewBroker,
+// and nothing re-reads it. So every SIGHUP the broker has ever received was a
+// ten-second authentication outage for the whole host — Restart=always brings it
+// back RestartSec=10s later — with nothing in the journal but a clean exit and a
+// restart (#224).
+//
+// The shipped unit no longer advertises ExecReload=, so `systemctl reload` refuses
+// the job outright. This handler covers what the unit cannot: a site's logrotate
+// postrotate stanza, or an operator's `kill -HUP` on the daemon that holds
+// /var/log/oidc-auth open. Those are the documented idiom for "reload your logs" and
+// this repo does not control them.
+//
+// Swallowing the signal is deliberately not the same as implementing reload, and the
+// log line says so: whoever sent it wanted new configuration to take effect and has
+// to be told that only a restart does that.
+func ignoreSIGHUP() {
+	hup := make(chan os.Signal, 1)
+	signal.Notify(hup, syscall.SIGHUP)
+	go func() {
+		for range hup {
+			log.Warn().Msg("Received SIGHUP and ignored it: the broker has no configuration " +
+				"reload — configuration is read once at startup, so restart the service to " +
+				"apply changes")
+		}
+	}()
 }
 
 func setupLogging(level string) {

--- a/cmd/broker/sighup_test.go
+++ b/cmd/broker/sighup_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// hupSurvivedMarker is printed by the child process below only if it is still
+// running after sending itself a SIGHUP.
+const hupSurvivedMarker = "BROKER-SURVIVED-SIGHUP"
+
+// childEnv makes the test re-invoke itself as the process under test.
+const childEnv = "OIDC_BROKER_SIGHUP_CHILD"
+
+// A SIGHUP must not kill the broker.
+//
+// Go's default disposition for SIGHUP is to terminate, and the broker has no reload,
+// so a `systemctl reload` or a logrotate postrotate stanza used to take the host's
+// authentication down for RestartSec=10s — daily, at whatever hour logrotate runs,
+// with nothing in the journal that reads as an error (#224).
+//
+// This has to run in a child process: the assertion is that the process is still
+// alive, which cannot be made about a test binary that has already been killed. The
+// child sends the signal to itself, so delivery is not racy — kill(2) delivers an
+// unblocked pending signal before it returns, which means an unhandled SIGHUP would
+// have terminated the child before it could print anything.
+func TestSIGHUPDoesNotKillTheBroker(t *testing.T) {
+	if os.Getenv(childEnv) == "1" {
+		runSIGHUPChild()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSIGHUPDoesNotKillTheBroker$") // #nosec G204 -- re-executes this test binary
+	cmd.Env = append(os.Environ(), childEnv+"=1")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		t.Fatalf("the broker installs no SIGHUP handler, so SIGHUP killed it (%v). "+
+			"`systemctl reload`, or any logrotate postrotate stanza that reloads the "+
+			"service, is then a ten-second authentication outage for the whole host "+
+			"(#224).\nchild output:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), hupSurvivedMarker) {
+		t.Fatalf("child exited 0 but never reported surviving SIGHUP; the test proved "+
+			"nothing.\nchild output:\n%s", output)
+	}
+}
+
+// runSIGHUPChild is the process under test: it installs the broker's real signal
+// handling and then sends itself the signal.
+func runSIGHUPChild() {
+	ignoreSIGHUP()
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGHUP); err != nil {
+		_, _ = os.Stderr.WriteString("failed to send SIGHUP: " + err.Error() + "\n")
+		os.Exit(3)
+	}
+
+	// Belt and braces: if nothing is handling SIGHUP the kernel has already killed
+	// us by now, so reaching the print below is the result.
+	time.Sleep(100 * time.Millisecond)
+
+	_, _ = os.Stdout.WriteString(hupSurvivedMarker + "\n")
+	os.Exit(0)
+}

--- a/cmd/broker/systemd_unit_test.go
+++ b/cmd/broker/systemd_unit_test.go
@@ -94,6 +94,143 @@ func TestShippedUnitLetsTheBrokerWriteWhereItMust(t *testing.T) {
 	}
 }
 
+// The socket directory has to exist before ExecStart, on every boot.
+//
+// It holds the socket every PAM login connects to, and nothing but systemd can
+// create it in time: /run is a tmpfs, so a directory the installer made is gone
+// after a reboot, and ProtectSystem=strict makes /run read-only to the service, so
+// the broker cannot create it either. It was listed in ReadWritePaths without a "-"
+// prefix, which meant systemd failed the unit's namespace setup with 226/NAMESPACE
+// before ExecStart ran, and Restart=always retried that forever. On a host wired
+// with configs/pam/ssh, that is "nobody can SSH in after a reboot" (#211).
+//
+// Not verifiable from Go, and not verifiable on the machine most of this is written
+// on: it needs systemd. This test pins the settings; `systemd-analyze verify` and a
+// VM or nspawn boot with an empty /run are what confirm the behaviour.
+func TestShippedUnitCreatesItsRuntimeDirectoryOnEveryBoot(t *testing.T) {
+	settings := shippedUnitSettings(t)
+
+	// oidc-auth, not oidc-pam: this must be the directory in server.socket_path,
+	// /var/run/oidc-auth/broker.sock, which resolves to /run/oidc-auth.
+	if got := settings["RuntimeDirectory"]; got != "oidc-auth" {
+		t.Errorf("RuntimeDirectory=%q, want oidc-auth: without it /run/oidc-auth does not "+
+			"exist after a reboot, and neither systemd nor the broker creates it, so the "+
+			"broker never starts and no login succeeds (#211)", got)
+	}
+
+	// 0750 root:root is also what keeps the socket un-hijackable: write access to
+	// this directory is enough to unlink the socket and bind an impostor, and
+	// RuntimeDirectoryMode is reasserted on every start, so it heals a host whose
+	// installer chowned the directory to an unprivileged account (#200).
+	if got := settings["RuntimeDirectoryMode"]; got != "0750" {
+		t.Errorf("RuntimeDirectoryMode=%q, want 0750: any account that can write to the "+
+			"socket's directory can replace the socket with its own (#200)", got)
+	}
+
+	// And nothing under the /run tmpfs may be a bare ReadWritePaths entry, which is
+	// the shape of the original bug: a hard dependency on a path that does not
+	// survive a reboot and that nothing recreates.
+	for _, entry := range strings.Fields(settings["ReadWritePaths"]) {
+		if strings.HasPrefix(entry, "/run/") || strings.HasPrefix(entry, "/var/run/") {
+			t.Errorf("ReadWritePaths lists %s: /run is a tmpfs, so on the first boot after "+
+				"install systemd fails the unit's namespace setup before ExecStart. Have "+
+				"systemd create the directory with RuntimeDirectory= instead (#211)", entry)
+		}
+	}
+}
+
+// The unit must not advertise a reload the broker cannot perform.
+//
+// It used to carry ExecReload=/bin/kill -HUP $MAINPID while the broker installed no
+// SIGHUP handler, and Go's default disposition for SIGHUP is to terminate. So
+// `systemctl reload oidc-auth-broker` — the action the unit itself advertises — and
+// any logrotate postrotate stanza that reloads the service killed the broker, for a
+// ten-second authentication outage that looked like a clean exit in the journal
+// (#224).
+//
+// The broker now ignores SIGHUP (see ignoreSIGHUP, pinned by
+// TestSIGHUPDoesNotKillTheBroker), so restoring this line would no longer kill it —
+// it would silently do nothing while systemctl reported success, which is why the
+// line stays out until there is a real reload to advertise.
+func TestShippedUnitDoesNotAdvertiseAReloadTheBrokerCannotDo(t *testing.T) {
+	settings := shippedUnitSettings(t)
+
+	if got := settings["ExecReload"]; got != "" {
+		t.Errorf("ExecReload=%q, want no ExecReload at all: the broker reads its "+
+			"configuration once at startup and has no reload, so a reload either kills it "+
+			"(SIGHUP's default disposition) or silently does nothing. Without ExecReload, "+
+			"systemctl reload refuses the job and says so (#224)", got)
+	}
+}
+
+// The unit in DEPLOYMENT.md must not drift from the one this repo installs.
+//
+// An operator who follows the deployment guide types that unit in by hand rather
+// than installing the shipped file — it is presented as the unit to use — so a
+// setting the guide omits is a setting their host does not have. It had already
+// drifted: the guide's copy carried neither CAP_CHOWN nor RuntimeDirectory=, so a
+// host built from the guide had #202 (every SSH key provisioning denied by EPERM)
+// and #211 (the broker never starts after a reboot) with both fixed in the shipped
+// unit and the tests above passing.
+//
+// Only the settings whose absence is an outage are compared. The guide is allowed
+// to differ in wording, ordering and commentary, and to omit tuning like
+// LimitNOFILE — this is a check on what breaks, not a diff.
+func TestTheDocumentedUnitAgreesWithTheShippedOne(t *testing.T) {
+	shipped := shippedUnitSettings(t)
+
+	path := filepath.Join("..", "..", "DEPLOYMENT.md")
+	content, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	documented := unitSettings(string(content))
+	if documented["ExecStart"] == "" {
+		t.Fatalf("no systemd unit found in %s; this test is pinned to the unit the "+
+			"deployment guide tells operators to write", path)
+	}
+
+	for _, setting := range []string{
+		"ProtectHome",           // #171: an empty /home means no key can be installed
+		"StateDirectory",        // the issued keys and the per-user locks
+		"StateDirectoryMode",    //
+		"RuntimeDirectory",      // #211: no socket directory after a reboot
+		"RuntimeDirectoryMode",  // #200: and nobody else may write into it
+		"CapabilityBoundingSet", // #202: CAP_CHOWN or every provisioning fails
+		"ProtectSystem",         // the hardening that must not quietly come off
+		"NoNewPrivileges",
+	} {
+		if documented[setting] != shipped[setting] {
+			t.Errorf("DEPLOYMENT.md has %s=%q where the shipped unit has %q. An operator who "+
+				"follows the guide gets the guide's value, so a fix that lands only in "+
+				"configs/systemd/ has not shipped",
+				setting, documented[setting], shipped[setting])
+		}
+	}
+
+	// Neither unit may hard-depend on a path under the /run tmpfs — the shape of
+	// #211, and the reason RuntimeDirectory= exists.
+	for _, entry := range strings.Fields(documented["ReadWritePaths"]) {
+		if strings.HasPrefix(entry, "/run/") || strings.HasPrefix(entry, "/var/run/") {
+			t.Errorf("the unit in DEPLOYMENT.md lists %s in ReadWritePaths: /run is a tmpfs, "+
+				"so systemd fails the unit's namespace setup on the first boot after install "+
+				"(#211)", entry)
+		}
+	}
+}
+
+// shippedUnitSettings parses the unit this repo installs.
+func shippedUnitSettings(t *testing.T) map[string]string {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "configs", "systemd", "oidc-auth-broker.service")
+	content, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return unitSettings(string(content))
+}
+
 // unitSettings collects the last value of each key in a systemd unit, ignoring
 // comments. Last wins, as systemd does for non-list settings.
 func unitSettings(content string) map[string]string {

--- a/configs/systemd/oidc-auth-broker.service
+++ b/configs/systemd/oidc-auth-broker.service
@@ -9,7 +9,25 @@ Type=simple
 User=root
 Group=root
 ExecStart=/usr/local/bin/oidc-auth-broker --config=/etc/oidc-auth/broker.yaml
-ExecReload=/bin/kill -HUP $MAINPID
+# There is deliberately no ExecReload=. The broker reads its configuration once, at
+# startup, and has no reload: pkg/config is loaded before auth.NewBroker and nothing
+# re-reads it.
+#
+# This line used to be `ExecReload=/bin/kill -HUP $MAINPID`, which advertised a
+# reload the broker could not perform — and Go's default disposition for SIGHUP is to
+# terminate. So `systemctl reload oidc-auth-broker` after an edit to broker.yaml, or a
+# logrotate postrotate stanza reloading the service that holds /var/log/oidc-auth
+# open, killed the broker outright. Restart=always brought it back RestartSec=10s
+# later, so the symptom was a daily ten-second authentication outage with nothing in
+# the journal but a clean exit (#224).
+#
+# Without ExecReload, `systemctl reload` refuses the job instead ("Job type reload is
+# not applicable"), which is the honest answer. The broker also ignores a stray
+# SIGHUP now (see cmd/broker/main.go) so a hand-written `kill -HUP` cannot kill it
+# either — but ignoring a signal is not a reload, and advertising one would only move
+# the surprise from "the service died" to "the new configuration silently did not
+# take effect". If a real reload is ever implemented, this line comes back and
+# TestShippedUnitDoesNotAdvertiseAReloadTheBrokerCannotDo changes with it.
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=30s
@@ -38,11 +56,37 @@ ProtectHome=false
 # site that keeps homes on /export/home — still starts. Without it systemd fails
 # the unit outright when a listed path is missing, which would turn a misconfigured
 # home path into a broker that never runs.
-ReadWritePaths=/var/run/oidc-auth /var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam -/home
+#
+# The broker's socket directory is deliberately *not* listed here: RuntimeDirectory=
+# below both creates it and makes it writable to this service, and a bare
+# ReadWritePaths entry for a path on the /run tmpfs is the bug described there.
+ReadWritePaths=/var/log/oidc-auth /etc/oidc-auth /var/lib/oidc-pam -/home
 # Creates /var/lib/oidc-pam (0700, root) before ExecStart, so a first start on a
 # host installed by hand does not fail on a missing state directory.
 StateDirectory=oidc-pam
 StateDirectoryMode=0700
+# Creates /run/oidc-auth (which is what /var/run/oidc-auth resolves to) root:root
+# 0750 before ExecStart, and removes it on stop.
+#
+# This directory holds the socket every PAM login connects to, and it used to be
+# created only by the installers — so it did not survive a reboot. /run is a fresh
+# tmpfs after boot, the directory was gone, and because it was listed in
+# ReadWritePaths *without* a "-" prefix, systemd failed the unit's mount-namespace
+# setup with 226/NAMESPACE before ExecStart ever ran. The broker's own MkdirAll never
+# got the chance, ProtectSystem=strict would have made /run read-only to it anyway,
+# and Restart=always retried forever with the identical failure. On a host wired with
+# configs/pam/ssh that means nobody can log in after a reboot except via the recovery
+# paths in configs/pam/ssh (#211).
+#
+# RuntimeDirectory= is the fix rather than a "-" prefix, because the prefix only stops
+# the unit failing: it would start a broker whose socket directory does not exist and
+# cannot be created. systemd creating the directory is also what makes the ownership
+# right — root:root 0750 is reasserted on every start, healing a host whose installer
+# had chowned it to the unprivileged oidc-auth account, from where the socket could be
+# unlinked and replaced by an impostor (#200; internal/ipc refuses to bind under such
+# a directory).
+RuntimeDirectory=oidc-auth
+RuntimeDirectoryMode=0750
 # CAP_CHOWN is what lets the broker hand a newly written authorized_keys to the
 # account it belongs to. CapabilityBoundingSet caps the *effective* set even for
 # User=root, so without it every chown(2) to another uid returned EPERM, every SSH

--- a/internal/ipc/accept_test.go
+++ b/internal/ipc/accept_test.go
@@ -1,0 +1,153 @@
+package ipc
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The accept loop must survive an accept(2) failure that says nothing about the
+// listener.
+//
+// EMFILE is the one that matters: an unprivileged local user opens connections
+// until the broker's descriptor table is full, and the next accept fails. The loop
+// used to return on any non-timeout error, which left a process that is still
+// running — systemd sees it healthy, Restart=always never fires, nothing in the
+// journal reads as fatal — and that never accepts another connection. On a host
+// wired with configs/pam/ssh, `auth sufficient pam_oidc.so` then fails for every
+// login and falls through to pam_deny (#216).
+func TestAcceptLoopSurvivesATransientAcceptError(t *testing.T) {
+	server, err := NewServer(filepath.Join(t.TempDir(), "unused.sock"), nil, 0660, "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// net.Pipe rather than a real socket: it is not a *net.UnixConn, so
+	// verifyPeerCredentials rejects it identically on every platform and this test
+	// asserts the same thing whether or not it runs as root on Linux.
+	handlerSide, peerSide := net.Pipe()
+
+	listener := &scriptedListener{}
+	listener.push(nil, &net.OpError{Op: "accept", Net: "unix", Err: syscall.EMFILE})
+	listener.push(handlerSide, nil)
+
+	server.listener = listener
+	server.wg.Add(1)
+	go server.acceptConnections(context.Background())
+	t.Cleanup(func() { _ = server.Stop() })
+
+	// The connection offered *after* the EMFILE has to be served. Reading the
+	// rejection off it is the proof: the handler ran.
+	if err := peerSide.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	payload, err := readOneResponse(peerSide)
+	if err != nil {
+		t.Fatalf("the connection offered after an EMFILE was never handled (%v): the accept "+
+			"loop exited on the first non-timeout error, so the broker keeps running but "+
+			"accepts nothing for the rest of its life (#216)", err)
+	}
+	if len(payload) == 0 {
+		t.Fatal("handler wrote nothing to the connection accepted after an EMFILE")
+	}
+
+	if got := listener.acceptCalls(); got < 2 {
+		t.Errorf("Accept was called %d time(s); the loop stopped accepting after the "+
+			"EMFILE (#216)", got)
+	}
+}
+
+// A closed listener is the one accept error that does mean stop: Stop closes it, and
+// retrying forever would leak a goroutine per Server for the life of the process.
+func TestAcceptLoopStopsWhenTheListenerIsClosed(t *testing.T) {
+	server, err := NewServer(filepath.Join(t.TempDir(), "unused.sock"), nil, 0660, "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	listener := &scriptedListener{}
+	listener.push(nil, &net.OpError{Op: "accept", Net: "unix", Err: net.ErrClosed})
+
+	server.listener = listener
+	server.wg.Add(1)
+	// Stop unblocks the loop if it did not return by itself, so a failure here is
+	// reported rather than hanging the package's test binary.
+	t.Cleanup(func() { _ = server.Stop() })
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		server.acceptConnections(context.Background())
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("accept loop is still running after net.ErrClosed: Stop would block " +
+			"forever waiting for it")
+	}
+}
+
+// scriptedListener hands out a prepared sequence of accept results and then blocks
+// until it is closed, which is what a real listener does between connections.
+type scriptedListener struct {
+	mu      sync.Mutex
+	results []acceptResult
+	calls   atomic.Int64
+
+	closeOnce sync.Once
+	closed    chan struct{}
+	initOnce  sync.Once
+}
+
+type acceptResult struct {
+	conn net.Conn
+	err  error
+}
+
+func (l *scriptedListener) init() {
+	l.initOnce.Do(func() { l.closed = make(chan struct{}) })
+}
+
+func (l *scriptedListener) push(conn net.Conn, err error) {
+	l.init()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.results = append(l.results, acceptResult{conn, err})
+}
+
+func (l *scriptedListener) Accept() (net.Conn, error) {
+	l.init()
+	l.calls.Add(1)
+
+	l.mu.Lock()
+	if len(l.results) > 0 {
+		next := l.results[0]
+		l.results = l.results[1:]
+		l.mu.Unlock()
+		return next.conn, next.err
+	}
+	l.mu.Unlock()
+
+	<-l.closed
+	return nil, &net.OpError{Op: "accept", Net: "unix", Err: net.ErrClosed}
+}
+
+func (l *scriptedListener) Close() error {
+	l.init()
+	l.closeOnce.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *scriptedListener) Addr() net.Addr { return scriptedAddr{} }
+
+func (l *scriptedListener) acceptCalls() int { return int(l.calls.Load()) }
+
+type scriptedAddr struct{}
+
+func (scriptedAddr) Network() string { return "unix" }
+func (scriptedAddr) String() string  { return "scripted" }

--- a/internal/ipc/peer_creds_linux.go
+++ b/internal/ipc/peer_creds_linux.go
@@ -5,30 +5,22 @@ package ipc
 import (
 	"fmt"
 	"net"
-	"syscall"
 )
 
 // verifyPeerCredentials checks that the connecting process is running as root (UID 0).
 // PAM modules always run as root, so non-root connections are rejected.
+//
+// The kernel lookup itself lives in getPeerCredentials so there is exactly one of
+// it: this function used to carry its own copy of the SO_PEERCRED call, and the two
+// copies drifted — one of them reached the descriptor in a way that disabled the
+// connection's read deadline (#216).
 func verifyPeerCredentials(conn net.Conn) error {
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return fmt.Errorf("connection is not a Unix socket")
-	}
-	rawConn, err := unixConn.SyscallConn()
+	uid, _, err := getPeerCredentials(conn)
 	if err != nil {
-		return fmt.Errorf("failed to get raw connection: %w", err)
+		return err
 	}
-	var cred *syscall.Ucred
-	var credErr error
-	_ = rawConn.Control(func(fd uintptr) {
-		cred, credErr = syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
-	})
-	if credErr != nil {
-		return fmt.Errorf("failed to get peer credentials: %w", credErr)
-	}
-	if cred.Uid != 0 {
-		return fmt.Errorf("peer UID %d is not root", cred.Uid)
+	if uid != 0 {
+		return fmt.Errorf("peer UID %d is not root", uid)
 	}
 	return nil
 }

--- a/internal/ipc/peercred.go
+++ b/internal/ipc/peercred.go
@@ -1,0 +1,39 @@
+package ipc
+
+import (
+	"fmt"
+	"net"
+)
+
+// withSocketFD runs fn on the file descriptor underlying a Unix socket connection.
+//
+// The obvious way to reach a descriptor — (*net.UnixConn).File() — must not be used
+// here. net.conn.File() hands the duplicate to os.newFile as kindSock with
+// nonBlocking=true, which sets File.nonblock so that Fd() calls pfd.SetBlocking(),
+// i.e. syscall.SetNonblock(fd, false). dup(2) shares the open file description, and
+// therefore the file status flags, with the original descriptor: clearing
+// O_NONBLOCK on the duplicate clears it on the connection. From that point a read
+// on the connection blocks in the kernel, the runtime poller never sees it, and the
+// deadline set by handleConnection cannot fire — one client that connects and sends
+// nothing then holds its handler goroutine for the life of the process (#216).
+// os.File.Fd's own documentation states the consequence: "On Unix and Windows,
+// File.SetDeadline methods will stop working."
+//
+// SyscallConn().Control has no such side effect. It pins the descriptor for the
+// duration of the callback and leaves its status flags alone, so every
+// peer-credential lookup in this package goes through here.
+func withSocketFD(conn net.Conn, fn func(fd int) error) error {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("connection is not a Unix socket")
+	}
+	rawConn, err := unixConn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("failed to get raw connection: %w", err)
+	}
+	var fnErr error
+	if err := rawConn.Control(func(fd uintptr) { fnErr = fn(int(fd)) }); err != nil {
+		return fmt.Errorf("failed to access socket descriptor: %w", err)
+	}
+	return fnErr
+}

--- a/internal/ipc/peercred_darwin.go
+++ b/internal/ipc/peercred_darwin.go
@@ -15,23 +15,17 @@ const xucredVersion0 = 0
 
 // getPeerCredentials extracts the UID and GID of the peer process from a Unix socket connection
 // using the LOCAL_PEERCRED socket option (macOS/Darwin).
+//
+// The descriptor is reached through withSocketFD rather than (*net.UnixConn).File():
+// File()+Fd() clears O_NONBLOCK on the connection and so voids its read deadline for
+// the rest of the connection's life (#216).
 func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return 0, 0, fmt.Errorf("connection is not a Unix socket")
-	}
-
-	f, err := unixConn.File()
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get file descriptor: %w", err)
-	}
-	// File() returns a duplicate descriptor, so closing it does not disturb conn;
-	// there is nothing to do about a failure to close a descriptor we only read a
-	// sockopt from. Matches peercred_linux.go.
-	defer func() { _ = f.Close() }()
-
-	cred, err := unix.GetsockoptXucred(int(f.Fd()), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
-	if err != nil {
+	var cred *unix.Xucred
+	if err := withSocketFD(conn, func(fd int) error {
+		var credErr error
+		cred, credErr = unix.GetsockoptXucred(fd, unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+		return credErr
+	}); err != nil {
 		return 0, 0, fmt.Errorf("failed to get peer credentials: %w", err)
 	}
 

--- a/internal/ipc/peercred_deadline_test.go
+++ b/internal/ipc/peercred_deadline_test.go
@@ -1,0 +1,149 @@
+//go:build linux || darwin || freebsd
+
+package ipc
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// A peer-credential lookup must not disturb the connection it inspects.
+//
+// The obvious implementation — (*net.UnixConn).File() and then Fd() — does. Fd()
+// puts the descriptor back into blocking mode, and because dup(2) shares the open
+// file description, O_NONBLOCK is cleared on the connection itself. The runtime
+// poller is then bypassed for that connection and SetDeadline has no effect, so a
+// client that connects and sends nothing holds its handler goroutine (and an OS
+// thread) for the life of the process. With maxConcurrentConnections handlers stuck
+// that way the broker answers nothing at all, and on a host wired with
+// configs/pam/ssh that denies every login (#216).
+//
+// This runs wherever getPeerCredentials is implemented, including this project's
+// macOS development hosts: the defect was reported against the Linux file, but the
+// Darwin and FreeBSD implementations had copied the same idiom.
+func TestPeerCredentialLookupLeavesTheReadDeadlineWorking(t *testing.T) {
+	serverConn, clientConn := unixConnPairForTest(t)
+
+	if _, _, err := getPeerCredentials(serverConn); err != nil {
+		t.Fatalf("getPeerCredentials: %v", err)
+	}
+
+	// The mechanism, checked directly: the connection must still be non-blocking,
+	// which is what lets the runtime poller enforce deadlines on it.
+	if flags := fileStatusFlags(t, serverConn); flags&unix.O_NONBLOCK == 0 {
+		t.Errorf("getPeerCredentials cleared O_NONBLOCK on the connection (flags %#o): the "+
+			"runtime poller is now bypassed and SetDeadline is a no-op for the rest of "+
+			"this connection's life (#216)", flags)
+	}
+
+	// The consequence, checked behaviourally: the peer sends nothing, so this read
+	// must come back as a timeout rather than blocking forever. Note that the peer
+	// end is deliberately left open — closing it would end the read with EOF and
+	// prove nothing.
+	if err := serverConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := serverConn.Read(buf)
+		readDone <- err
+	}()
+
+	select {
+	case err := <-readDone:
+		netErr, ok := err.(net.Error)
+		if !ok || !netErr.Timeout() {
+			t.Errorf("read after getPeerCredentials returned %v, want a deadline-exceeded "+
+				"timeout", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("read is still blocked 5s after a 200ms read deadline: getPeerCredentials " +
+			"voided the deadline, so a client that sends nothing pins this handler " +
+			"goroutine forever (#216)")
+
+		// Unblock the reader before returning. It is parked in a blocking read(2)
+		// holding a reference to the descriptor, and (*net.UnixConn).Close waits
+		// for that reference to be dropped — so leaving it there would hang the
+		// test's cleanup instead of reporting the failure above.
+		_ = clientConn.Close()
+		<-readDone
+	}
+}
+
+// unixConnPairForTest returns the two ends of a connected Unix socket, server end
+// first. Both are closed when the test finishes.
+func unixConnPairForTest(t *testing.T) (server, client net.Conn) {
+	t.Helper()
+
+	// os.MkdirTemp rather than t.TempDir: a Unix socket path is limited to ~104
+	// bytes on macOS and t.TempDir embeds the (long) test name.
+	dir, err := os.MkdirTemp("", "ipcpair-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	listener, err := net.Listen("unix", filepath.Join(dir, "s.sock"))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	type accepted struct {
+		conn net.Conn
+		err  error
+	}
+	accepts := make(chan accepted, 1)
+	go func() {
+		conn, err := listener.Accept()
+		accepts <- accepted{conn, err}
+	}()
+
+	client, err = net.Dial("unix", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	got := <-accepts
+	if got.err != nil {
+		t.Fatalf("accept: %v", got.err)
+	}
+	t.Cleanup(func() { _ = got.conn.Close() })
+
+	return got.conn, client
+}
+
+// fileStatusFlags returns the F_GETFL flags of a connection's descriptor. It uses
+// SyscallConn().Control, which — unlike File() — has no side effect on the flags it
+// is reporting.
+func fileStatusFlags(t *testing.T, conn net.Conn) int {
+	t.Helper()
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatalf("connection is %T, want *net.UnixConn", conn)
+	}
+	rawConn, err := unixConn.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+	var flags int
+	var flagsErr error
+	if err := rawConn.Control(func(fd uintptr) {
+		flags, flagsErr = unix.FcntlInt(fd, unix.F_GETFL, 0)
+	}); err != nil {
+		t.Fatalf("Control: %v", err)
+	}
+	if flagsErr != nil {
+		t.Fatalf("F_GETFL: %v", flagsErr)
+	}
+	return flags
+}

--- a/internal/ipc/peercred_freebsd.go
+++ b/internal/ipc/peercred_freebsd.go
@@ -15,20 +15,17 @@ const xucredVersion0 = 0
 
 // getPeerCredentials extracts the UID and GID of the peer process from a Unix socket connection
 // using the LOCAL_PEERCRED socket option (FreeBSD).
+//
+// The descriptor is reached through withSocketFD rather than (*net.UnixConn).File():
+// File()+Fd() clears O_NONBLOCK on the connection and so voids its read deadline for
+// the rest of the connection's life (#216).
 func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return 0, 0, fmt.Errorf("connection is not a Unix socket")
-	}
-
-	f, err := unixConn.File()
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get file descriptor: %w", err)
-	}
-	defer f.Close()
-
-	cred, err := unix.GetsockoptXucred(int(f.Fd()), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
-	if err != nil {
+	var cred *unix.Xucred
+	if err := withSocketFD(conn, func(fd int) error {
+		var credErr error
+		cred, credErr = unix.GetsockoptXucred(fd, unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+		return credErr
+	}); err != nil {
 		return 0, 0, fmt.Errorf("failed to get peer credentials: %w", err)
 	}
 

--- a/internal/ipc/peercred_linux.go
+++ b/internal/ipc/peercred_linux.go
@@ -10,22 +10,21 @@ import (
 
 // getPeerCredentials extracts the UID and GID of the peer process from a Unix socket connection
 // using the SO_PEERCRED socket option (Linux only).
+//
+// This is the only place the kernel is asked for a peer's identity on Linux;
+// verifyPeerCredentials is layered on top of it. There used to be a second,
+// independent implementation here that reached the descriptor through
+// (*net.UnixConn).File(), which silently cleared O_NONBLOCK on the connection and
+// so voided the read deadline for the rest of that connection's life — see the
+// comment on withSocketFD and #216.
 func getPeerCredentials(conn net.Conn) (uid, gid uint32, err error) {
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return 0, 0, fmt.Errorf("connection is not a Unix socket")
-	}
-
-	f, err := unixConn.File()
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get file descriptor: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	cred, err := syscall.GetsockoptUcred(int(f.Fd()), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
-	if err != nil {
+	var cred *syscall.Ucred
+	if err := withSocketFD(conn, func(fd int) error {
+		var credErr error
+		cred, credErr = syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+		return credErr
+	}); err != nil {
 		return 0, 0, fmt.Errorf("failed to get peer credentials: %w", err)
 	}
-
 	return cred.Uid, cred.Gid, nil
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -36,6 +37,13 @@ type Server struct {
 // maxConcurrentConnections caps the number of simultaneously handled IPC
 // connections so a peer cannot exhaust goroutines/FDs by opening many at once.
 const maxConcurrentConnections = 128
+
+// acceptBackoffMin and acceptBackoffMax bound the pause between retries after a
+// failed accept(2). See nextAcceptBackoff.
+const (
+	acceptBackoffMin = 5 * time.Millisecond
+	acceptBackoffMax = 1 * time.Second
+)
 
 // Request represents a request from PAM module
 type Request struct {
@@ -93,15 +101,24 @@ func NewServer(socketPath string, broker *auth.Broker, socketMode os.FileMode, s
 
 // Start starts the IPC server
 func (s *Server) Start(ctx context.Context) error {
-	// Remove existing socket file
-	if err := os.RemoveAll(s.socketPath); err != nil {
-		return fmt.Errorf("failed to remove existing socket: %w", err)
-	}
-
 	// Create socket directory if it doesn't exist
 	socketDir := filepath.Dir(s.socketPath)
 	if err := os.MkdirAll(socketDir, 0750); err != nil {
 		return fmt.Errorf("failed to create socket directory: %w", err)
+	}
+
+	// Refuse to serve under a directory another account can write to. MkdirAll
+	// above is a no-op when the directory already exists, so an installer that
+	// created it 0755 and chowned it to an unprivileged account leaves that mode
+	// and owner in place — and write permission on the directory is enough to
+	// unlink this socket and bind an impostor at the same path (#200).
+	if err := verifySocketDirTrusted(socketDir); err != nil {
+		return fmt.Errorf("refusing to listen on %s: %w", s.socketPath, err)
+	}
+
+	// Remove existing socket file
+	if err := os.RemoveAll(s.socketPath); err != nil {
+		return fmt.Errorf("failed to remove existing socket: %w", err)
 	}
 
 	// Set umask to 0117 before creating the socket so it is created with
@@ -188,6 +205,8 @@ func (s *Server) Stop() error {
 func (s *Server) acceptConnections(ctx context.Context) {
 	defer s.wg.Done()
 
+	backoff := time.Duration(0)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -203,21 +222,52 @@ func (s *Server) acceptConnections(ctx context.Context) {
 			conn, err := s.listener.Accept()
 			if err != nil {
 				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					backoff = 0
 					continue
 				}
-				// For other errors, check if we should continue or exit
+
+				// A deliberate shutdown is the only reason to stop accepting.
 				select {
 				case <-ctx.Done():
 					return
 				case <-s.stopChan:
 					return
 				default:
-					log.Error().
-						Err(err).
-						Msg("Failed to accept connection")
+				}
+				if errors.Is(err, net.ErrClosed) {
 					return
 				}
+
+				// Everything else is transient and must not take the broker's
+				// socket out of service. accept(2) fails with EMFILE/ENFILE when
+				// the descriptor table is full, ECONNABORTED when the peer goes
+				// away between the SYN and the accept, and EINTR on a signal —
+				// none of which say anything about the listener. This loop used to
+				// return here, so the first such error left a process that systemd
+				// still saw as healthy, with Restart=always never firing, that
+				// accepted no connection again for the rest of its life: on a host
+				// wired with configs/pam/ssh, every login denied until an operator
+				// noticed and restarted it by hand (#216).
+				backoff = nextAcceptBackoff(backoff)
+				event := log.Error()
+				if isTransientAcceptError(err) {
+					event = log.Warn()
+				}
+				event.
+					Err(err).
+					Dur("retry_in", backoff).
+					Msg("Failed to accept connection; retrying")
+
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					return
+				case <-s.stopChan:
+					return
+				}
+				continue
 			}
+			backoff = 0
 
 			// Bound concurrent connections (L-4): if at capacity, reject rather
 			// than spawning an unbounded number of handler goroutines.
@@ -225,6 +275,11 @@ func (s *Server) acceptConnections(ctx context.Context) {
 			case s.connSem <- struct{}{}:
 			default:
 				log.Warn().Msg("Connection rejected: at maximum concurrent connections")
+				// This write happens on the accept loop itself, not in a handler, so
+				// it gets a deadline of its own: a peer that connects, fills the
+				// socket buffer and never reads must not be able to park the loop
+				// that every other login depends on (#216).
+				_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				s.sendErrorResponse(conn, "SERVER_BUSY", "Server at capacity, try again")
 				_ = conn.Close()
 				continue
@@ -237,11 +292,48 @@ func (s *Server) acceptConnections(ctx context.Context) {
 	}
 }
 
+// nextAcceptBackoff returns how long to pause after a failed accept(2).
+//
+// The pause exists so that a failure which is transient but not instantly cleared
+// — a full descriptor table, most obviously — is retried without spinning a core
+// and without filling the journal. It is capped so the broker never stays deaf for
+// longer than a second once the condition clears.
+func nextAcceptBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return acceptBackoffMin
+	}
+	if next := current * 2; next < acceptBackoffMax {
+		return next
+	}
+	return acceptBackoffMax
+}
+
+// isTransientAcceptError reports whether err is one of the accept(2) failures with
+// a known, self-clearing cause. It only chooses the log level: every error other
+// than a closed listener is retried either way, because a broker that has stopped
+// accepting connections is indistinguishable from a broker that is down, except
+// that nothing restarts it.
+func isTransientAcceptError(err error) bool {
+	return errors.Is(err, syscall.EMFILE) ||
+		errors.Is(err, syscall.ENFILE) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EINTR) ||
+		errors.Is(err, syscall.EAGAIN)
+}
+
 // handleConnection handles a single IPC connection
 func (s *Server) handleConnection(conn net.Conn) {
 	defer s.wg.Done()
 	defer func() { <-s.connSem }() // release the concurrency slot (L-4)
 	defer func() { _ = conn.Close() }()
+
+	// Set the connection timeout before anything reads from or writes to conn, so
+	// that no path through this function — including the rejection below, which
+	// writes to a peer that may never read — can block a handler goroutine
+	// indefinitely. This deadline is only as good as the descriptor's O_NONBLOCK
+	// flag: see the comment on withSocketFD for how a peer-credential lookup used
+	// to clear it and void every deadline on the connection (#216).
+	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Verify peer is root — PAM modules always run as root
 	if err := verifyPeerCredentials(conn); err != nil {
@@ -249,9 +341,6 @@ func (s *Server) handleConnection(conn net.Conn) {
 		s.sendErrorResponse(conn, "PERMISSION_DENIED", "Connection rejected")
 		return
 	}
-
-	// Set connection timeout
-	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Verify peer credentials if required
 	if s.requirePeerAuth {

--- a/internal/ipc/socketdir.go
+++ b/internal/ipc/socketdir.go
@@ -1,0 +1,67 @@
+package ipc
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// verifySocketDirTrusted refuses to let the broker bind inside a directory that an
+// account other than root or the broker itself can write to.
+//
+// The socket's own 0660 root mode does not protect it: write permission on the
+// *directory* is enough to unlink(2) the socket and bind(2) a replacement at the
+// same path. The real broker keeps serving on its now-unlinked inode, logs nothing
+// and stays green in `systemctl status`, while every PAM login connects to the
+// impostor — which can answer {"success":true} and, with the shipped
+// `auth sufficient pam_oidc.so`, short-circuit the whole auth stack. That is
+// authentication as any user, including root, from whatever account owns the
+// directory (#200).
+//
+// The installers created exactly that: mkdir 0755 followed by
+// `chown -R oidc-auth:oidc-auth`, for an account no shipped component runs as. The
+// systemd unit now has systemd create and own the directory
+// (RuntimeDirectory=oidc-auth, RuntimeDirectoryMode=0750), which also resets mode
+// and ownership on every start; this check is the part that does not depend on the
+// host being wired up correctly.
+//
+// Scope, stated plainly: this checks the socket's own directory, not its ancestors.
+// A writable ancestor would let an attacker rename the directory rather than the
+// socket, but /run and /var are root-owned on any host where the rest of this
+// service makes sense, and walking to / would reject an ordinary $TMPDIR.
+func verifySocketDirTrusted(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("cannot stat socket directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("socket directory %s is not a directory", dir)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		// Fail closed: an unknown owner is an unverified owner.
+		return fmt.Errorf("cannot determine the owner of socket directory %s", dir)
+	}
+	return checkSocketDirOwnership(dir, st.Uid, info.Mode(), os.Geteuid())
+}
+
+// checkSocketDirOwnership holds the actual rule, separated from the stat(2) call so
+// it can be tested for owners this process cannot create on disk.
+//
+// The rule: nobody but root and the broker's own uid may write into the directory
+// the socket lives in. Ownership by the broker's own uid is accepted so that a
+// developer running the broker as themselves — and the package's own tests, in
+// $TMPDIR — are not required to be root.
+func checkSocketDirOwnership(dir string, owner uint32, mode os.FileMode, euid int) error {
+	if perm := mode.Perm(); perm&0022 != 0 {
+		return fmt.Errorf("socket directory %s has mode %04o: group- or other-writable, "+
+			"so any account with that access can unlink the broker's socket and bind an "+
+			"impostor in its place (#200)", dir, perm)
+	}
+	if owner != 0 && owner != uint32(euid) { // #nosec G115 -- a uid always fits uint32
+		return fmt.Errorf("socket directory %s is owned by uid %d, which is neither root "+
+			"nor this process (uid %d): that account can unlink the broker's socket and "+
+			"bind an impostor in its place (#200)", dir, owner, euid)
+	}
+	return nil
+}

--- a/internal/ipc/socketdir_test.go
+++ b/internal/ipc/socketdir_test.go
@@ -1,0 +1,128 @@
+package ipc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The socket's directory decides who can impersonate the broker.
+//
+// The socket file's own 0660 root mode is not the control that matters: write
+// permission on the directory is enough to unlink(2) the socket and bind(2) an
+// impostor at the same path, and no client verifies the server. The installers
+// created the directory 0755 and chowned it to an unprivileged account that nothing
+// runs as, so this was reachable from that uid alone (#200).
+func TestSocketDirectoryOwnershipRule(t *testing.T) {
+	const self = 1000
+
+	cases := []struct {
+		name       string
+		owner      uint32
+		mode       os.FileMode
+		wantReject string // substring the refusal must explain; "" means accept
+	}{
+		{name: "root owned 0750, what the unit now creates", owner: 0, mode: 0750},
+		{name: "root owned 0755", owner: 0, mode: 0755},
+		{name: "owned by this process, as in $TMPDIR", owner: self, mode: 0700},
+		{
+			name:       "the installers' directory: 0755 owned by oidc-auth",
+			owner:      999,
+			mode:       0755,
+			wantReject: "owned by uid 999",
+		},
+		{
+			name:       "root owned but group writable",
+			owner:      0,
+			mode:       0770,
+			wantReject: "group- or other-writable",
+		},
+		{
+			name:       "root owned but world writable",
+			owner:      0,
+			mode:       0777,
+			wantReject: "group- or other-writable",
+		},
+		{
+			name:       "owned by a third account, not readable by others",
+			owner:      42,
+			mode:       0700,
+			wantReject: "owned by uid 42",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkSocketDirOwnership("/run/oidc-auth", tc.owner, tc.mode, self)
+			switch {
+			case tc.wantReject == "" && err != nil:
+				t.Errorf("uid %d mode %04o was refused (%v), but no account other than "+
+					"root or the broker itself can write to it", tc.owner, tc.mode, err)
+			case tc.wantReject != "" && err == nil:
+				t.Errorf("uid %d mode %04o was accepted, but that account can unlink the "+
+					"broker's socket and bind an impostor in its place (#200)",
+					tc.owner, tc.mode)
+			case tc.wantReject != "" && !strings.Contains(err.Error(), tc.wantReject):
+				t.Errorf("refusal for uid %d mode %04o was %q, which does not say %q, so an "+
+					"operator cannot tell what to fix", tc.owner, tc.mode, err, tc.wantReject)
+			}
+		})
+	}
+}
+
+// Start must apply the rule, not just define it. A directory this process created
+// itself is accepted; the same directory made world-writable is not, and the broker
+// refuses to serve rather than serving on a socket anyone can replace.
+func TestStartRefusesAWorldWritableSocketDirectory(t *testing.T) {
+	dir, err := os.MkdirTemp("", "ipcdir-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	socketPath := filepath.Join(dir, "broker.sock")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Sanity: the directory as created is trusted, so the refusal below is caused by
+	// the mode change and nothing else.
+	server, err := NewServer(socketPath, nil, 0660, "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start on a %s: %v", "0700 directory this process owns", err)
+	}
+	if err := server.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0777); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	server, err = NewServer(socketPath, nil, 0660, "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	err = server.Start(ctx)
+	if err == nil {
+		_ = server.Stop()
+		t.Fatal("Start succeeded with a world-writable socket directory: any local account " +
+			"can now unlink the socket and bind an impostor that answers every login with " +
+			"success (#200)")
+	}
+	for _, want := range []string{"refusing to listen", socketPath, "0777"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Start's refusal %q does not mention %q", err, want)
+		}
+	}
+
+	// Fail closed: nothing may be listening on that path.
+	if _, err := os.Stat(socketPath); err == nil {
+		t.Error("Start refused but left a socket behind at the untrusted path")
+	}
+}


### PR DESCRIPTION
Four findings from the v0.5.1 milestone. Each one ends at the same place: a host where nobody can log in, and where nothing reports a failure — `systemctl status` is green, the journal is quiet, and `Restart=always` never fires because the process has not exited.

## #200 — the socket can be replaced under the broker's feet

The socket is created 0660 root:root. That does not protect it, because write permission on the *directory* is enough to `unlink(2)` the socket and `bind(2)` a replacement at the same path. The real broker keeps serving on its now-unlinked inode and notices nothing. Every PAM login reaches the impostor instead — which can answer `{"success":true}` and, with the shipped `auth sufficient pam_oidc.so`, short-circuit the whole auth stack. That is authentication as any user, including root, from whatever account owns that directory.

The installers created exactly that condition: `mkdir -p 0755` followed by `chown -R oidc-auth:oidc-auth`, for an account no shipped component runs as.

Two changes, because either alone leaves a gap:
- `Start()` refuses to bind under a directory that is group- or other-writable, or owned by anyone but root or the broker's own uid. This is the half that does not depend on the host being wired up correctly. Scope is the socket's own directory, not its ancestors — a writable ancestor would let an attacker rename the directory rather than the socket, but `/run` and `/var` are root-owned on any host where this service makes sense, and walking to `/` would reject an ordinary `$TMPDIR`.
- The unit has systemd create and own the directory (`RuntimeDirectory=oidc-auth`, `RuntimeDirectoryMode=0750`), which reasserts mode and ownership on **every start** — so a host whose installer had chowned it heals on the next restart.

**Not closed by this PR.** `scripts/install.sh:351,499` and `install-release.sh` still `chown -R oidc-auth:oidc-auth "$RUN_DIR"`. Those files have in-flight changes on another branch, so the removal goes there rather than conflicting here; #200 stays open until it lands. A systemd-managed host is already covered by `RuntimeDirectory=` above, and a hand-started broker now refuses rather than serving from a hijackable directory — so neither state is exploitable in the meantime.

## #211 — the broker never starts after a reboot

`/run` is a tmpfs, so the socket directory the installer created is gone after a boot. Because it was listed in `ReadWritePaths` *without* a `-` prefix, systemd failed the unit's mount-namespace setup with `226/NAMESPACE` before `ExecStart` ever ran. The broker's own `MkdirAll` never got the chance; `ProtectSystem=strict` would have made `/run` read-only to it anyway; `Restart=always` retried the identical failure forever. On a host wired with `configs/pam/ssh`, that is "nobody can SSH in after a reboot".

`RuntimeDirectory=` is the fix rather than a `-` prefix. The prefix only stops the unit from failing — it would start a broker whose socket directory does not exist and cannot be created.

## #216 — three ways to stop answering while looking healthy

1. **The accept loop returned on any non-timeout error.** `accept(2)` fails with `EMFILE`/`ENFILE` when the descriptor table is full, `ECONNABORTED` when the peer goes away between the SYN and the accept, and `EINTR` on a signal — none of which say anything about the listener. The first one left a live process that accepted no connection again for the rest of its life. Now retried with a capped backoff (5 ms doubling to 1 s), returning only on a deliberate shutdown or `net.ErrClosed`.
2. **The peer-credential lookup voided every deadline on the connection.** It reached the descriptor via `(*net.UnixConn).File()`, and `File().Fd()` calls `SetBlocking`, clearing `O_NONBLOCK`. `dup(2)` shares the open file description and therefore the status flags, so clearing it on the duplicate clears it on the connection: reads then block in the kernel where the runtime poller cannot see them, and `SetDeadline` cannot fire. `os.File.Fd`'s own documentation states it — *"On Unix and Windows, File.SetDeadline methods will stop working."* One client that connected and sent nothing held its handler goroutine forever. All lookups now go through `withSocketFD` (`SyscallConn().Control`, which leaves the flags alone), and `verifyPeerCredentials` is layered on `getPeerCredentials` so there is no longer a second, independently drifting copy of the syscall.
3. **The at-capacity rejection ran unbounded on the accept loop itself.** A peer that connects, fills the socket buffer and never reads could park the loop every other login depends on. It gets its own write deadline, and `handleConnection` now sets the connection deadline before *anything* reads or writes.

## #224 — `systemctl reload` killed the broker

The unit carried `ExecReload=/bin/kill -HUP $MAINPID` while the broker installed no SIGHUP handler, and Go's default disposition for SIGHUP is to terminate. So the action the unit itself advertised — and the logrotate `postrotate` stanza this repo's own deployment guide recommends — killed the broker. `Restart=always` brought it back 10 s later, so the symptom was a nightly ten-second authentication outage with nothing in the journal but a clean exit and a restart.

- No more `ExecReload=`, so `systemctl reload` refuses the job ("Job type reload is not applicable") instead of lying.
- The broker ignores a stray SIGHUP and logs that configuration is read once at startup — for the `kill -HUP` idiom this repo does not control. Ignoring a signal is deliberately not the same as implementing reload, and the log line says so.
- The documented logrotate stanza uses `copytruncate`.

Restoring `ExecReload` would no longer kill the broker — it would silently do nothing while systemctl reported success, which is why the line stays out until there is a real reload to advertise.

## Documentation drift, fixed and pinned

`DEPLOYMENT.md`'s unit carried neither `CAP_CHOWN` nor `RuntimeDirectory=`. The guide presents that unit as the one to use, so a host built by following it had #202 (every SSH key provisioning denied by `EPERM`) and #211 — both already fixed in `configs/systemd/`, with every existing test passing. `TestTheDocumentedUnitAgreesWithTheShippedOne` now compares the settings whose absence is an outage, so a fix that lands in only one of the two files fails the build. Proven non-vacuous by removing `CAP_CHOWN` from the guide's copy and watching it fail.

## Verification

`go build ./...`, `go vet ./internal/ipc/ ./cmd/broker/`, `gofmt` clean; `go test -count=1 ./internal/ipc/ ./cmd/broker/` green.

Not verifiable here: the systemd behaviour needs systemd. The unit settings are pinned by tests that parse the file, but `226/NAMESPACE`, `RuntimeDirectory=` creation, and `systemctl reload` refusing the job want `systemd-analyze verify` and a VM or nspawn boot with an empty `/run`. `SO_PEERCRED` is Linux-only, so the Darwin/FreeBSD variants of the `withSocketFD` change are compile-checked and reviewed rather than executed.

Closes #211, #216, #224. #200 is addressed on the broker and unit side; it stays open for the installer `chown`.