### PR TITLE
fix(install): make the installers survivable, and put the module where PAM looks (#207, #208, #209, #220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,16 @@ jobs:
             exit 1
           fi
           echo "release.yml's build job is gated on the CI workflow."
+
+      # The installer and uninstaller decide, in shell, whether a host stays
+      # loggable-in: #207 was an uninstaller that reduced /etc/pam.d/sshd to
+      # `auth requisite pam_deny.so` and reported success. This exercises that
+      # logic against a throwaway /etc/pam.d — no root, no PAM headers, nothing
+      # installed — so the guard is not left to a reviewer's reading.
+      - name: Check the installer PAM wiring
+        run: ./test/scripts/test-pam-wiring.sh
+
+      - name: Shellcheck the install scripts
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          shellcheck --severity=warning scripts/*.sh test/scripts/*.sh

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -242,10 +242,18 @@ systemctl status oidc-auth-broker
 ```
 
 The bundled `install.sh` places `oidc-auth-broker`, `oidc-pam-helper`, and
-`oidc-admin` in `/usr/local/bin`, `pam_oidc.so` in `/lib/security`, an example
-config in `/etc/oidc-auth/broker.yaml`, and the systemd unit in
-`/etc/systemd/system`. It does **not** start the broker or modify PAM unless
-`--configure-pam` is supplied, so it cannot lock you out on its own.
+`oidc-admin` in `/usr/local/bin`, `pam_oidc.so` in whichever directory *this
+host's* libpam loads modules from, an example config in
+`/etc/oidc-auth/broker.yaml` (mode `0600`, `root:root` — the broker refuses to
+start otherwise), and the systemd unit in `/etc/systemd/system`. It does **not**
+start the broker or modify PAM unless `--configure-pam` is supplied, so it cannot
+lock you out on its own.
+
+The module directory is detected, not assumed: it is `/lib/<triplet>/security` on
+Debian/Ubuntu and `/lib64/security` on RHEL-family systems, and there is no
+`/lib/security` on either, which is where every release up to v0.4.2 wrote it
+(#208). Set `PAM_MODULE_DIR` if detection gets it wrong; the installer refuses
+rather than guessing, because a module outside that path never loads at all.
 
 ### Method 3: Source Compilation
 
@@ -260,6 +268,11 @@ cd oidc-pam
 make build
 sudo make install
 ```
+
+`make install` detects libpam's module directory the same way the installers do
+and refuses if it cannot find it; set `PAM_MODULE_DIR` to override. It installs no
+PAM configuration at all — use `sudo ./scripts/install.sh --configure-pam` if you
+want `/etc/pam.d/sshd` wired for you, and read "PAM Integration" below first.
 
 ## Configuration
 
@@ -542,19 +555,45 @@ reason is recorded as an `ssh_key_provisioning_failed` audit event.
 
 ### 1. File Permissions
 
+Everything the broker reads or writes is root-owned, because the broker runs as
+root. There is no `oidc-auth` service account — nothing runs as one, and earlier
+versions of this guide and of `scripts/install.sh` created one and gave it the
+socket and log directories. That was a privilege boundary pointing the wrong way:
+write access to the directory holding the socket is enough to unlink the socket and
+bind an impostor at the same path, which every PAM login then talks to (#200), and
+a log file an unprivileged account owns is one it can replace with a symlink for a
+root process to append through. If you installed an earlier version, re-run the
+installer or apply the commands below; the broker now refuses to serve from a
+directory anyone else can write to.
+
 ```bash
-# Set secure permissions
-sudo chown -R oidc-auth:oidc-auth /etc/oidc-auth
+# Configuration: read by the root broker, and holds the OIDC client secret
+sudo chown -R root:root /etc/oidc-auth
 sudo chmod 750 /etc/oidc-auth
 sudo chmod 640 /etc/oidc-auth/broker.yaml
 
-# Log directory permissions
-sudo chown -R oidc-auth:oidc-auth /var/log/oidc-auth
+# Log directory
+sudo chown -R root:root /var/log/oidc-auth
 sudo chmod 750 /var/log/oidc-auth
 
-# PAM module permissions
-sudo chown root:root /lib/security/pam_oidc.so
-sudo chmod 644 /lib/security/pam_oidc.so
+# Socket directory. systemd's RuntimeDirectory= reasserts this on every start;
+# these are the values a hand-built host needs before the first one.
+sudo chown root:root /run/oidc-auth
+sudo chmod 750 /run/oidc-auth
+
+# Broker state: the SSH keys it issues and the locks serializing its
+# authorized_keys writes. Created by StateDirectory= in the unit.
+sudo chown -R root:root /var/lib/oidc-pam
+sudo chmod 700 /var/lib/oidc-pam
+
+# PAM module. Install it in the directory libpam itself loads from, which differs
+# by distribution -- /lib/<triplet>/security on Debian/Ubuntu, /lib64/security on
+# RHEL-family. `scripts/install.sh` detects it; if you place the module by hand,
+# find it with the directory holding pam_permit.so. A module outside that path
+# never loads at all (#208).
+PAM_DIR="$(dirname "$(find /lib /usr/lib -name pam_permit.so -print -quit)")"
+sudo chown root:root "$PAM_DIR/pam_oidc.so"
+sudo chmod 644 "$PAM_DIR/pam_oidc.so"
 ```
 
 ### 2. Network Security

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,28 @@ endif
 # CI Lint job, the verification container and a local `make lint` cannot disagree.
 GOLANGCI_LINT_VERSION := $(shell tr -d '[:space:]' < .golangci-version)
 
+# Resolve the directory this host's libpam loads modules from, into $$pamdir.
+#
+# `make install` used to copy the module to /lib/security, which exists on neither
+# Debian/Ubuntu (/lib/<triplet>/security) nor RHEL-family (/lib64/security)
+# systems (#208) -- so the copy failed, or, once an operator created the directory
+# to get past that, put the module somewhere PAM never looks and every login on
+# the shipped stack was refused by pam_deny.so instead.
+#
+# scripts/install.sh's detect_pam_dir is the one implementation of the probe;
+# sourcing that script defines its functions and runs nothing. Override with
+# PAM_MODULE_DIR, exactly as the installers do.
+define resolve_pam_dir
+pamdir="$${PAM_MODULE_DIR:-$$(bash -c 'source ./scripts/install.sh; detect_pam_dir' || true)}"; \
+if [ -z "$$pamdir" ]; then \
+	echo "Could not find the directory libpam loads modules from. Install your" >&2; \
+	echo "distribution's PAM modules (libpam-modules on Debian/Ubuntu, pam on" >&2; \
+	echo "RHEL-family), or set PAM_MODULE_DIR to the directory holding pam_unix.so." >&2; \
+	exit 1; \
+fi; \
+echo "  PAM module directory: $$pamdir"
+endef
+
 # Default target
 all: build
 
@@ -119,10 +141,11 @@ verify-linux:
 ## Install binaries to system locations
 install: build
 	@echo "Installing binaries..."
-	sudo cp $(BINARY_DIR)/$(PAM_MODULE) /lib/security/
-	sudo cp $(BINARY_DIR)/$(BROKER_BINARY) /usr/local/bin/
-	sudo cp $(BINARY_DIR)/$(HELPER_BINARY) /usr/local/bin/
-	sudo cp $(BINARY_DIR)/$(ADMIN_BINARY) /usr/local/bin/
+	@set -e; $(resolve_pam_dir); \
+	sudo install -m 0644 $(BINARY_DIR)/$(PAM_MODULE) "$$pamdir/$(PAM_MODULE)"
+	sudo install -m 0755 $(BINARY_DIR)/$(BROKER_BINARY) /usr/local/bin/$(BROKER_BINARY)
+	sudo install -m 0755 $(BINARY_DIR)/$(HELPER_BINARY) /usr/local/bin/$(HELPER_BINARY)
+	sudo install -m 0755 $(BINARY_DIR)/$(ADMIN_BINARY) /usr/local/bin/$(ADMIN_BINARY)
 	sudo cp configs/systemd/oidc-auth-broker.service /etc/systemd/system/
 	sudo systemctl daemon-reload
 	sudo systemctl enable oidc-auth-broker
@@ -130,12 +153,15 @@ install: build
 ## Install development version
 install-dev: build
 	@echo "Installing development version..."
-	sudo cp $(BINARY_DIR)/$(PAM_MODULE) /lib/security/
-	sudo cp $(BINARY_DIR)/$(BROKER_BINARY) /usr/local/bin/
-	sudo cp $(BINARY_DIR)/$(HELPER_BINARY) /usr/local/bin/
-	sudo cp $(BINARY_DIR)/$(ADMIN_BINARY) /usr/local/bin/
-	sudo mkdir -p /etc/oidc-auth
-	sudo cp configs/examples/broker.yaml /etc/oidc-auth/
+	@set -e; $(resolve_pam_dir); \
+	sudo install -m 0644 $(BINARY_DIR)/$(PAM_MODULE) "$$pamdir/$(PAM_MODULE)"
+	sudo install -m 0755 $(BINARY_DIR)/$(BROKER_BINARY) /usr/local/bin/$(BROKER_BINARY)
+	sudo install -m 0755 $(BINARY_DIR)/$(HELPER_BINARY) /usr/local/bin/$(HELPER_BINARY)
+	sudo install -m 0755 $(BINARY_DIR)/$(ADMIN_BINARY) /usr/local/bin/$(ADMIN_BINARY)
+	sudo install -d -m 0750 -o root -g root /etc/oidc-auth
+	# 0600 root:root: this file holds the token encryption key and every client
+	# secret, and the broker refuses to start if anyone else can read it (#209).
+	sudo install -m 0600 -o root -g root configs/examples/broker.yaml /etc/oidc-auth/broker.yaml
 	sudo cp configs/systemd/oidc-auth-broker.service /etc/systemd/system/
 	sudo systemctl daemon-reload
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -77,12 +77,16 @@ All Go dependencies are managed through `go.mod` and will be automatically downl
 - `/etc/oidc-auth/` directory for configuration
 - `/var/run/oidc-auth/` directory for runtime files (sockets, PIDs)
 - `/var/log/oidc-auth/` directory for logs (optional)
-- `/lib/security/` directory for PAM module
+- `/var/lib/oidc-pam/` directory for broker state (issued SSH keys, write locks)
+- the directory this host's libpam loads modules from, for `pam_oidc.so` —
+  `/lib/<triplet>/security` on Debian/Ubuntu, `/lib64/security` on RHEL-family.
+  There is no `/lib/security` on either (#208); `scripts/install.sh` detects the
+  right one and refuses to install if it cannot
 - `/usr/local/bin/` directory for binaries
 
 ### User Permissions
 - Root privileges required for:
-  - Installing PAM module to `/lib/security/`
+  - Installing PAM module into libpam's module directory
   - Configuring PAM in `/etc/pam.d/`
   - Installing systemd service files
   - Creating system directories

--- a/cmd/pam-module/configs_test.go
+++ b/cmd/pam-module/configs_test.go
@@ -276,6 +276,18 @@ func TestShippedPAMStacksUseDocumentedControlFlags(t *testing.T) {
 	}
 }
 
+// printsAdvice matches a shell line whose only effect is to put text on the
+// operator's terminal: one of this repo's print_* helpers, or echo/printf, with no
+// redirection or pipe that could send the text into a file instead.
+//
+// Such a line may name a host-wide stack. Telling an operator to put `@include
+// common-auth` back into /etc/pam.d/sshd — which is what scripts/uninstall.sh does
+// when it has no pre-install backup to restore — is the correct instruction, and it
+// is the opposite of the defect TestInstallScriptsDoNotTouchAggregatePAMStacks
+// exists to catch: it restores the distribution's own include in a *service* file
+// rather than editing the aggregate one.
+var printsAdvice = regexp.MustCompile(`^\s*(print_(info|warn|error|success|step)|echo|printf)\b[^|>]*$`)
+
 // No install path may wire pam_oidc.so into a host-wide stack.
 //
 // scripts/install.sh used to insert `@include common-auth` at the top of
@@ -299,6 +311,12 @@ func TestInstallScriptsDoNotTouchAggregatePAMStacks(t *testing.T) {
 		}
 		for i, line := range strings.Split(string(content), "\n") {
 			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				continue
+			}
+			// A line that only prints is guidance, not an edit. Anything that
+			// redirects, pipes, or calls sed/cp/tee still trips this, because those
+			// are the shapes that can write to a file.
+			if printsAdvice.MatchString(line) {
 				continue
 			}
 			for name, distro := range aggregatePAMStacks {

--- a/configs/pam/README.md
+++ b/configs/pam/README.md
@@ -30,6 +30,28 @@ print the verification URL on and a user waiting in front of it, and whether a
 given service's PAM conversation displays `PAM_TEXT_INFO` at all is a property of
 that service. Test them on a host you can still get back into.
 
+### What the installers wire, and what they leave alone
+
+`scripts/install.sh` and `scripts/install-release.sh --configure-pam` edit
+`/etc/pam.d/sshd` and **nothing else** (#220). They:
+
+- add `auth sufficient pam_oidc.so` **after** any `pam_faillock`/`pam_env`/
+  `pam_nologin` prologue and **before** the first module that authenticates, not
+  at line 1. Inserting first breaks `pam_faillock` failure counting, and it makes
+  a `requisite pam_nologin.so` or `pam_access.so` below it unreachable, because a
+  `sufficient` module that succeeds ends the auth phase there;
+- fence the line in `# BEGIN oidc-pam` / `# END oidc-pam` comments, so
+  `scripts/uninstall.sh` removes exactly what was added;
+- **refuse to edit a stack they do not recognise**, printing the line they would
+  have added so you can place it yourself;
+- never touch `login`, `su` or `sudo`. The console is the recovery path when the
+  broker is down, and `su`/`sudo` are how you repair the host once you are on it.
+
+`login` as shipped here tries `pam_unix.so` **before** `pam_oidc.so` for that
+reason: a local password gets you a console session whether or not the broker is
+running. Install it by hand, and only if you have decided you want OIDC on the
+console.
+
 ### Why no host-wide stack is shipped
 
 `/etc/pam.d/common-auth` (Debian/Ubuntu) and `/etc/pam.d/system-auth` (RHEL,
@@ -54,7 +76,11 @@ put it in the per-service file for the service you actually want it in.
 ### Usage Instructions
 
 #### 1. Prerequisites
-- OIDC PAM module installed: `/lib/security/pam_oidc.so`
+- OIDC PAM module installed in the directory *this host's* libpam loads from —
+  `/lib/<triplet>/security` on Debian/Ubuntu, `/lib64/security` on RHEL-family.
+  `scripts/install.sh` detects it; see
+  [PAM Module Not Found](#2-pam-module-not-found) for how to find it by hand.
+  There is no `/lib/security` on either family (#208)
 - OIDC broker running: `systemctl start oidc-auth-broker`
 - OIDC provider configured in `/etc/oidc-auth/broker.yaml`
 
@@ -293,13 +319,28 @@ curl -k https://your-oidc-provider.com/.well-known/openid-configuration
 ```
 
 #### 2. PAM Module Not Found
-```bash
-# Check if module is installed
-ls -la /lib/security/pam_oidc.so
 
-# Check module permissions
-sudo chmod 644 /lib/security/pam_oidc.so
+PAM only loads modules from the path libpam was built with, and that path differs
+by distribution — there is no `/lib/security` on Debian/Ubuntu or on RHEL-family
+systems (#208). Find the directory the same way the installer does, by looking for
+a module libpam itself ships:
+
+```bash
+# Debian/Ubuntu (the path carries a multiarch triplet)
+dirname "$(dpkg -L libpam-modules | grep -m1 '/pam_permit\.so$')"
+
+# RHEL, Fedora, Amazon Linux
+dirname "$(rpm -ql pam | grep -m1 '/pam_permit\.so$')"
+
+# Then check the module is there, and readable
+moddir="$(dirname "$(dpkg -L libpam-modules 2>/dev/null | grep -m1 '/pam_permit\.so$')")"
+ls -la "$moddir/pam_oidc.so"
+sudo chmod 644 "$moddir/pam_oidc.so"
 ```
+
+A module in the wrong directory is not a no-op: with the stack in `ssh` below,
+the unresolvable `sufficient` line falls through to `auth requisite pam_deny.so`
+and **every** login is refused.
 
 #### 3. Configuration Errors
 ```bash

--- a/configs/pam/login
+++ b/configs/pam/login
@@ -4,7 +4,16 @@
 # on the machine includes.
 #
 # This configuration enables OIDC authentication for console login (tty) while
-# maintaining fallback authentication for emergency access.
+# keeping local Unix authentication ahead of it, because the console is the
+# documented recovery path for every other stack here (see configs/pam/ssh,
+# EMERGENCY ACCESS) and it has to keep working when the broker does not.
+#
+# NEITHER INSTALLER WIRES THIS FILE. scripts/install.sh and
+# scripts/install-release.sh touch /etc/pam.d/sshd and nothing else, deliberately
+# (#220): a console login that goes through the broker first is a console login
+# that fails when the broker is down, which is precisely when it is needed.
+# Install this one by hand, from a host you can still reach another way, and only
+# if you have decided you want OIDC on the console.
 #
 # IMPORTANT: Test this configuration thoroughly on a non-production system first!
 # Always maintain console or SSH access for emergency recovery.
@@ -14,11 +23,33 @@
 # for the verification URL is a property of the service, so verify it from a host
 # you can still reach another way before relying on it.
 
-# Authentication stack
-auth    sufficient  pam_oidc.so
+# Authentication stack.
+#
+# Order is the whole content of this stack, because a 'sufficient' module that
+# succeeds ends the auth phase then and there:
+#
+#  - pam_nologin.so is first, or /etc/nologin is silently ignored for every user
+#    the module admits. It was below pam_oidc.so before, and so was.
+#  - pam_group.so is next, above the deciding modules rather than below them.
+#    Nothing it does depends on the outcome of authentication -- it assigns
+#    supplementary groups from /etc/security/group.conf and returns PAM_IGNORE --
+#    and below a 'sufficient' line it would never run at all, which is what
+#    happened here for as long as this file shipped.
+#  - pam_unix.so before pam_oidc.so, so that a local password still gets you a
+#    console session when the broker is unreachable. A wrong password falls
+#    through to the device flow rather than ending the stack.
+#  - pam_deny.so last, so a login that satisfied neither is refused rather than
+#    reaching the end of the stack with nothing having decided.
+#
+# No numeric jumps ([success=N default=ignore]). They are how Debian's common-auth
+# is written, but N is a count of lines, and this file is one people edit: adding
+# a module silently changes which line a success skips to. Plain flags say what
+# they mean at every line.
 auth    requisite   pam_nologin.so
-auth    required    pam_unix.so try_first_pass nullok_secure
 auth    optional    pam_group.so
+auth    sufficient  pam_unix.so try_first_pass nullok_secure
+auth    sufficient  pam_oidc.so
+auth    required    pam_deny.so
 
 # Account management
 account optional    pam_oidc.so
@@ -42,9 +73,15 @@ password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 # CONFIGURATION NOTES:
 # 1. Console login typically shows device flow instructions to the user
 # 2. The user must complete authentication on another device/browser
-# 3. pam_nologin.so prevents login if /etc/nologin exists
-# 4. pam_time.so can restrict login hours (configure in /etc/security/time.conf)
-# 5. pam_access.so provides additional access controls (configure in /etc/security/access.conf)
+# 3. pam_nologin.so prevents login if /etc/nologin exists -- it must stay above
+#    pam_oidc.so, or an OIDC user's success ends the auth phase before it runs
+# 4. A user with a local password authenticates without OIDC here, and so without
+#    any OIDC policy (group requirements, risk rules, session limits). That is the
+#    trade this file makes on purpose: the console is the way back in. If you do
+#    not want it, take the pam_unix.so line out -- and make sure something else
+#    (SSH public keys, a rescue image) is your break-glass path instead
+# 5. pam_time.so can restrict login hours (configure in /etc/security/time.conf)
+# 6. pam_access.so provides additional access controls (configure in /etc/security/access.conf)
 
 # CONSOLE CONFIGURATION:
 # The getty service configuration may need adjustment:
@@ -89,9 +126,13 @@ password required   pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 # 5. Consider using pam_limits.so for resource restrictions
 
 # EMERGENCY ACCESS:
-# If OIDC authentication fails, maintain emergency access via:
-# 1. Root account with traditional authentication
-# 2. Emergency user account with Unix password
-# 3. Single-user mode boot
-# 4. SSH access with public key authentication
-# 5. Console access with traditional authentication (if configured)
+# With the stack above, a console login with a local Unix password works whether
+# or not the broker is running -- that is the point of the ordering, and it is the
+# recovery path configs/pam/ssh points at. Keep it working:
+# 1. A local account with a password that is not managed by the IdP (root, or an
+#    emergency admin), tested from the console before you rely on it
+# 2. SSH public key authentication (sshd's pubkey path consults no PAM auth stack)
+# 3. Single-user mode boot, or a rescue image
+#
+# If you remove the pam_unix.so line above, this file no longer provides any of
+# that, and the console stops being a recovery path.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -371,11 +371,8 @@ func LoadConfig(configPath string) (*Config, error) {
 	v.SetEnvPrefix("OIDC_AUTH")
 	bindSafeEnvironmentVariables(v)
 
-	// Check config file permissions
-	if info, err := os.Stat(configPath); err == nil {
-		if mode := info.Mode().Perm(); mode&0137 != 0 {
-			log.Printf("WARNING: config file %s has permissions %04o, which are more permissive than recommended 0640", configPath, mode)
-		}
+	if err := checkConfigFilePermissions(configPath); err != nil {
+		return nil, err
 	}
 
 	// Try to read config file
@@ -401,6 +398,46 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 
 	return &config, nil
+}
+
+// configFilePermissionMask is the set of permission bits that must be clear on
+// the broker configuration: every group and other bit, plus owner-execute.
+//
+// (#209) The mask used to be 0137, which permits group-read — on a host whose
+// config is chown'd to a service group, that is the whole file readable by that
+// group. 0177 leaves exactly 0600 (and 0400) acceptable.
+const configFilePermissionMask = 0177
+
+// checkConfigFilePermissions refuses a configuration file that anyone but root
+// can read.
+//
+// This file holds the AES-256 token encryption key and every client secret, and
+// the multi-user host is the host this product exists for. Both installers used
+// to write it 0644, and this check only logged a WARNING to stderr and let the
+// broker serve — validating the key for strength and then publishing it to every
+// local user. A file mode is not something the operator can be warned about
+// once at startup and expected to notice, so it is fatal.
+//
+// A missing file is not an error here: LoadConfig falls back to defaults and the
+// environment, and ReadInConfig reports it.
+func checkConfigFilePermissions(configPath string) error {
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return nil
+	}
+
+	mode := info.Mode().Perm()
+	if mode&configFilePermissionMask == 0 {
+		return nil
+	}
+
+	if isDevelopmentMode() {
+		log.Printf("WARNING: config file %s has permissions %04o, which let processes other than root read the token encryption key and every client secret (development mode)", configPath, mode)
+		return nil
+	}
+
+	return fmt.Errorf("config file %s has permissions %04o: it holds the token encryption key and every client secret, so it must not be readable by anyone but root (chown root:root %s && chmod 600 %s); set OIDC_AUTH_DEV=true to override for development",
+		configPath, mode, configPath, configPath)
 }
 
 // AllowUnknownKeysEnv names the environment variable that turns the unknown-key

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -33,7 +33,7 @@ authentication:
   max_concurrent_sessions: 10
 `
 
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
@@ -79,7 +79,7 @@ authentication:
   refresh_threshold: "5m"
   max_concurrent_sessions: 5
 `
-	if err := os.WriteFile(validConfigPath, []byte(validContent), 0644); err != nil {
+	if err := os.WriteFile(validConfigPath, []byte(validContent), 0600); err != nil {
 		t.Fatalf("Failed to write config: %v", err)
 	}
 
@@ -405,7 +405,7 @@ oidc:
       client_id: "test-client"
       scopes: ["openid"]
 `
-	if err := os.WriteFile(configPath, []byte(minimalContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(minimalContent), 0600); err != nil {
 		t.Fatalf("Failed to write config: %v", err)
 	}
 
@@ -567,7 +567,7 @@ authentication:
   refresh_threshold: "5m"
   max_concurrent_sessions: 10
 `
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
 	}
 
@@ -630,6 +630,66 @@ authentication:
 			t.Error("require_pkce should be overridden by env var in dev mode")
 		}
 	})
+}
+
+// TestLoadConfigRejectsWorldReadableFile is the gate for #209.
+//
+// Both installers wrote /etc/oidc-auth/broker.yaml at mode 0644 -- the AES-256
+// token encryption key and every client secret, readable by every local user on
+// exactly the kind of multi-user host this product exists for -- and this check
+// only logged one WARNING line to stderr and then served. Group-read was not even
+// caught: the mask was 0137.
+func TestLoadConfigRejectsWorldReadableFile(t *testing.T) {
+	const content = `
+oidc:
+  providers:
+    - name: "test"
+      issuer: "https://test.example.com"
+      client_id: "test-client"
+`
+
+	cases := []struct {
+		name      string
+		mode      os.FileMode
+		devMode   string
+		wantError bool
+	}{
+		{name: "world readable", mode: 0644, wantError: true},
+		{name: "group readable", mode: 0640, wantError: true},
+		{name: "world writable", mode: 0666, wantError: true},
+		{name: "owner only", mode: 0600, wantError: false},
+		{name: "owner read only", mode: 0400, wantError: false},
+		{name: "world readable in development mode", mode: 0644, devMode: "true", wantError: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OIDC_AUTH_DEV", tc.devMode)
+
+			path := filepath.Join(t.TempDir(), "broker.yaml")
+			if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+			// Written 0600 then chmod'd, because the umask applies to WriteFile.
+			if err := os.Chmod(path, tc.mode); err != nil {
+				t.Fatalf("failed to chmod config: %v", err)
+			}
+
+			_, err := LoadConfig(path)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("LoadConfig accepted a config at mode %04o; it must refuse anything readable by more than its owner", tc.mode)
+				}
+				if !strings.Contains(err.Error(), "permissions") {
+					t.Errorf("error should name the permissions problem, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig rejected a config at mode %04o: %v", tc.mode, err)
+			}
+		})
+	}
 }
 
 func TestResolveSecretReferences(t *testing.T) {

--- a/pkg/config/shipped_configs_test.go
+++ b/pkg/config/shipped_configs_test.go
@@ -67,6 +67,11 @@ func TestShippedConfigsLoad(t *testing.T) {
 			if !isWholeConfig(t, file) {
 				path = wrapProviderFragment(t, file)
 			}
+			// LoadConfig refuses a configuration anyone but root can read (#209),
+			// and a file in the repository is 0644. What this gate is about is the
+			// content, so it is read from a copy with the mode the installers now
+			// give it; TestLoadConfigRejectsWorldReadableFile covers the mode.
+			path = copyAt0600(t, path)
 
 			cfg, err := config.LoadConfig(path)
 			if err != nil {
@@ -194,6 +199,22 @@ func TestNoMisspelledCertificatePinningKey(t *testing.T) {
 // unknown key is always reported first and tolerating this cannot hide one.
 func isUnresolvableSecret(err error) bool {
 	return strings.Contains(err.Error(), "failed to resolve secret references")
+}
+
+// copyAt0600 copies a configuration to a temporary file the broker will accept,
+// i.e. one only its owner can read.
+func copyAt0600(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	dst := filepath.Join(t.TempDir(), filepath.Base(path))
+	if err := os.WriteFile(dst, data, 0600); err != nil {
+		t.Fatalf("failed to write %s: %v", dst, err)
+	}
+	return dst
 }
 
 func yamlFilesUnder(t *testing.T, root string) []string {

--- a/scripts/build-releases.sh
+++ b/scripts/build-releases.sh
@@ -62,11 +62,6 @@ for platform in "${PLATFORMS[@]}"; do
     for binary_info in "${BINARIES[@]}"; do
         IFS=':' read -r binary_name binary_path <<< "$binary_info"
         
-        output_name="${binary_name}"
-        if [[ "$os" == "windows" ]]; then
-            output_name="${binary_name}.exe"
-        fi
-        
         output_path="${BINARY_DIR}/${binary_name}-${os}-${arch}"
         if [[ "$os" == "windows" ]]; then
             output_path="${output_path}.exe"

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -13,12 +13,27 @@
 #   sudo ./install-release.sh --configure-pam   # additionally wire pam_oidc.so into sshd
 #
 # PAM is NOT modified unless --configure-pam is passed, so an install cannot
-# lock you out of SSH on its own.
+# lock you out of SSH on its own. Console login, su and sudo are never wired:
+# the console is the recovery path when the broker is down.
+#
+# Environment:
+#   PAM_MODULE_DIR=<dir>   where to install pam_oidc.so, if detection gets it
+#                          wrong. It must be a directory libpam itself loads
+#                          modules from, or the module will never run.
 
 set -euo pipefail
 
 INSTALL_DIR="/usr/local/bin"
-PAM_DIR="/lib/security"
+# Where libpam loads modules from. Deliberately empty: resolve_pam_dir() detects
+# it before anything is installed (#208). It used to be hardcoded to
+# /lib/security, which exists on neither Debian/Ubuntu (/lib/<triplet>/security)
+# nor RHEL-family systems (/lib64/security), so the install aborted part-way
+# through -- after the binaries were in place -- on every distribution this
+# project supports.
+PAM_DIR=""
+# The PAM service directory, overridable only so the logic below can be tested
+# against a temporary tree instead of the host's real stack.
+PAM_D_DIR="${PAM_D_DIR:-/etc/pam.d}"
 CONFIG_DIR="/etc/oidc-auth"
 RUN_DIR="/var/run/oidc-auth"
 LOG_DIR="/var/log/oidc-auth"
@@ -29,6 +44,9 @@ STATE_DIR="/var/lib/oidc-pam"
 SYSTEMD_DIR="/etc/systemd/system"
 
 CONFIGURE_PAM=0
+# Set when PAM wiring was declined or refused, so the summary can say so rather
+# than implying the host is configured.
+PAM_WIRING_SKIPPED=0
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -42,12 +60,21 @@ print_error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 # Resolve the directory this script lives in so it works regardless of CWD.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Print the header block only. The comments further down explain implementation
+# rather than usage, and grepping every '^#' in the file put all of them in --help.
+print_usage() {
+    awk 'NR == 1 { next }
+         /^#/    { seen = 1; sub(/^#[[:space:]]?/, ""); print; next }
+         seen    { exit }
+         { next }' "${BASH_SOURCE[0]}"
+}
+
 parse_args() {
     for arg in "$@"; do
         case "$arg" in
             --configure-pam) CONFIGURE_PAM=1 ;;
             -h|--help)
-                grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+                print_usage
                 exit 0
                 ;;
             *) print_error "Unknown argument: $arg" ;;
@@ -61,21 +88,236 @@ check_root() {
     fi
 }
 
+# The auth line this installer adds, and the sentinel comments that fence it.
+#
+# The fence is what makes the uninstaller safe (#207): it used to delete every
+# line matching pam_oidc.so, which on the stack this project itself ships
+# (configs/pam/ssh: 'sufficient pam_oidc.so' followed by 'requisite
+# pam_deny.so') left pam_deny.so as the entire auth phase and refused every
+# login, for every user, permanently.
+#
+# 'sufficient' with nothing added after it means a broker that is down or a
+# module that cannot be loaded falls through to the rest of the existing stack.
+PAM_SENTINEL_BEGIN="# BEGIN oidc-pam -- added by the oidc-pam installer; removed by scripts/uninstall.sh"
+PAM_SENTINEL_END="# END oidc-pam"
+PAM_AUTH_LINE="auth    sufficient  pam_oidc.so"
+
+# Locate the directory libpam loads modules from (#208).
+#
+# pam_permit.so ships with libpam itself, so a directory holding it is a
+# directory PAM loads from. Ask the package manager first -- Debian's path
+# carries a multiarch triplet not worth guessing -- then probe the known
+# layouts. Prints the directory, or returns 1 having printed nothing.
+detect_pam_dir() {
+    local candidate dir arch
+
+    if command -v dpkg >/dev/null 2>&1; then
+        candidate="$(dpkg -L libpam-modules 2>/dev/null | grep -m1 '/pam_permit\.so$' || true)"
+        if [[ -n "$candidate" && -f "$candidate" ]]; then
+            dirname "$candidate"
+            return 0
+        fi
+    fi
+
+    if command -v rpm >/dev/null 2>&1; then
+        candidate="$(rpm -ql pam 2>/dev/null | grep -m1 '/pam_permit\.so$' || true)"
+        if [[ -n "$candidate" && -f "$candidate" ]]; then
+            dirname "$candidate"
+            return 0
+        fi
+    fi
+
+    arch="$(uname -m)"
+    for dir in /lib64/security /usr/lib64/security \
+               "/lib/${arch}-linux-gnu/security" "/usr/lib/${arch}-linux-gnu/security" \
+               /lib/security /usr/lib/security; do
+        if [[ -f "$dir/pam_permit.so" ]]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Resolve PAM_DIR, and refuse to install if it cannot be found. A module written
+# outside PAM's module path never loads: with configs/pam/ssh that means every
+# SSH login is refused by pam_deny.so, and on a stack with a password fallback it
+# means OIDC silently never runs while the operator believes it is enforced.
+resolve_pam_dir() {
+    local arch
+    arch="$(uname -m)"
+
+    if [[ -n "${PAM_MODULE_DIR:-}" ]]; then
+        if [[ ! -d "$PAM_MODULE_DIR" ]]; then
+            print_error "PAM_MODULE_DIR=$PAM_MODULE_DIR is not a directory"
+        fi
+        PAM_DIR="$PAM_MODULE_DIR"
+        print_warn "Using PAM_MODULE_DIR=$PAM_DIR. PAM only loads modules from its own compiled-in path; if this is not that path, pam_oidc.so will never run."
+        return
+    fi
+
+    PAM_DIR="$(detect_pam_dir || true)"
+    if [[ -z "$PAM_DIR" ]]; then
+        print_warn "Could not find the directory PAM loads modules from."
+        print_warn "Looked for pam_permit.so via dpkg/rpm and in: /lib64/security, /usr/lib64/security, /lib/${arch}-linux-gnu/security, /usr/lib/${arch}-linux-gnu/security, /lib/security, /usr/lib/security"
+        print_warn "Install your distribution's PAM modules (libpam-modules on Debian/Ubuntu, pam on RHEL-family), or set PAM_MODULE_DIR to the directory holding pam_unix.so."
+        print_error "Refusing to install: a module written outside PAM's module path never loads."
+    fi
+
+    print_info "PAM module directory: $PAM_DIR"
+}
+
+# Decide where pam_oidc.so belongs in an existing auth stack -- or refuse (#220).
+#
+# Both installers used to insert at line 1 unconditionally. Ahead of a
+# pam_faillock.so preauth entry that breaks failure counting on RHEL-family
+# systems; ahead of pam_nologin.so, pam_access.so or pam_securetty.so it makes
+# those gates unreachable, because a 'sufficient' module that succeeds ends the
+# auth phase before them.
+#
+# So: walk the auth phase, allow the known prologue modules to stay in front, and
+# insert immediately before the first thing that authenticates or terminates
+# (pam_unix.so and friends, pam_deny.so, or an include/substack of a shared
+# stack). Anything unrecognised means this is not a stack we understand, and an
+# installer that does not understand a stack has no business editing it.
+#
+# Prints "INSERT <line> <kind> <target>" (insert before that 1-based line) or
+# "REFUSE <reason>".
+pam_plan_insertion() {
+    awk '
+    function insert(n, kind, target) { print "INSERT " n " " kind " " target; done = 1; exit 0 }
+    function refuse(reason)          { print "REFUSE " reason;                done = 1; exit 0 }
+
+    BEGIN {
+        # Modules that may legitimately precede OIDC: they gate or annotate a
+        # login rather than deciding it, and several of them MUST run first.
+        gates = "pam_env.so pam_faillock.so pam_tally.so pam_tally2.so pam_faildelay.so"
+        gates = gates " pam_nologin.so pam_securetty.so pam_sepermit.so pam_access.so"
+        gates = gates " pam_time.so pam_warn.so pam_keyinit.so pam_selinux.so"
+        gates = gates " pam_namespace.so pam_shells.so pam_group.so pam_limits.so"
+        gates = gates " pam_umask.so pam_issue.so pam_motd.so pam_mail.so pam_lastlog.so"
+        gates = gates " pam_loginuid.so pam_xauth.so pam_debug.so"
+        split(gates, g, " ")
+        for (i in g) gate[g[i]] = 1
+
+        # Modules that decide an authentication, or end the stack. The OIDC line
+        # goes in front of the first of these.
+        deciders = "pam_unix.so pam_unix2.so pam_unix_auth.so pam_pwdfile.so pam_deny.so"
+        deciders = deciders " pam_permit.so pam_sss.so pam_sss_gss.so pam_ldap.so"
+        deciders = deciders " pam_ldapd.so pam_krb5.so pam_winbind.so pam_localuser.so"
+        deciders = deciders " pam_succeed_if.so pam_google_authenticator.so pam_oath.so"
+        deciders = deciders " pam_u2f.so pam_yubico.so pam_radius_auth.so"
+        deciders = deciders " pam_ssh_agent_auth.so pam_gnome_keyring.so pam_kwallet5.so"
+        deciders = deciders " pam_ecryptfs.so pam_fscrypt.so pam_mount.so"
+        deciders = deciders " pam_systemd_home.so pam_oidc.so"
+        split(deciders, a, " ")
+        for (i in a) authn[a[i]] = 1
+    }
+
+    {
+        if (NF == 0 || $1 ~ /^#/) next
+
+        # A continuation line cannot be reasoned about one line at a time.
+        if ($0 ~ /\\[ \t]*$/) refuse("line " NR " continues onto the next line")
+
+        type = tolower($1)
+        sub(/^-/, "", type)
+
+        # A whole-file include. Debian delegates sshd auth with "@include common-auth".
+        if (type == "@include") {
+            if ($2 ~ /auth/) insert(NR, "include", $2)
+            if (seen_auth) refuse("the auth phase of this file has no module that can authenticate")
+            next
+        }
+
+        if (type != "auth") {
+            if (seen_auth) refuse("the auth phase of this file has no module that can authenticate")
+            next
+        }
+        seen_auth = 1
+
+        # Control may be a single keyword or a bracketed [value=action ...] list.
+        if ($2 ~ /^\[/) {
+            control = "["
+            for (i = 2; i <= NF; i++) if ($i ~ /\]$/) break
+            i++
+        } else {
+            control = tolower($2)
+            i = 3
+        }
+        if (i > NF) refuse("cannot parse auth line " NR)
+
+        if (control == "include" || control == "substack") insert(NR, control, $i)
+
+        module = $i
+        sub(/.*\//, "", module)
+        if (module in gate) next
+        if (module in authn) insert(NR, "module", module)
+        refuse("unrecognised auth module " module " on line " NR)
+    }
+
+    END { if (!done) refuse("this file has no auth phase") }
+    ' "$1"
+}
+
+# Explain a refusal, and print the line the operator has to add by hand (#220).
+pam_print_manual_instructions() {
+    local file="$1" reason="$2"
+
+    print_warn "Not modifying $file: $reason."
+    print_warn "Add this line yourself, after any pam_faillock/pam_env prologue and before the first module that authenticates:"
+    print_warn "    $PAM_AUTH_LINE"
+    print_warn "See configs/pam/README.md and configs/pam/ssh for the full stack, and keep a session open while testing."
+}
+
+# Insert the fenced OIDC block before line $2 of $1, preserving mode and owner.
+pam_insert_block() {
+    local file="$1" at="$2" tmp
+    tmp="$(mktemp "${file}.oidc.XXXXXX")"
+
+    awk -v at="$at" -v begin="$PAM_SENTINEL_BEGIN" -v body="$PAM_AUTH_LINE" -v end="$PAM_SENTINEL_END" '
+        NR == at { print begin; print body; print end }
+        { print }
+    ' "$file" > "$tmp"
+
+    # A PAM file is itself an access control; do not widen it by rewriting it.
+    chmod --reference="$file" "$tmp" 2>/dev/null || chmod 0644 "$tmp"
+    chown --reference="$file" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$file"
+}
+
 create_directories() {
     print_info "Creating required directories..."
-    install -d -m 0755 "$CONFIG_DIR" "$RUN_DIR" "$LOG_DIR"
+    install -d -m 0755 "$CONFIG_DIR"
+    # 0750, and root-owned: write access to the directory holding the broker's
+    # socket is enough to unlink(2) the socket and bind(2) an impostor at the same
+    # path, which every PAM login then talks to (#200). The systemd unit's
+    # RuntimeDirectory=/RuntimeDirectoryMode= reassert this on every start; this is
+    # what the directory looks like before the first one.
+    install -d -m 0750 "$RUN_DIR" "$LOG_DIR"
     # 0700: these are private keys and lock files belonging to the root broker.
     install -d -m 0700 "$STATE_DIR" "$STATE_DIR/ssh-keys" "$STATE_DIR/locks"
 }
 
-create_user() {
-    if ! id "oidc-auth" &>/dev/null; then
-        useradd -r -s /bin/false -d /var/lib/oidc-auth -c "OIDC Auth Service" oidc-auth
-        print_info "Created service user oidc-auth"
-    else
-        print_info "Service user oidc-auth already exists"
+# Take the socket and log directories back to root.
+#
+# There is deliberately no oidc-auth account any more, and nothing is chowned to
+# one. The broker runs as User=root -- it has to, since its job on a successful
+# login is to write into an arbitrary account's ~/.ssh and hand the file over --
+# so an unprivileged account owning a directory it writes into is a privilege
+# boundary pointing the wrong way. This function used to create that account and
+# chown the socket and log directories to it (#200; see scripts/install.sh for the
+# full description of what that allowed).
+#
+# An existing host upgraded in place is repaired here rather than left as it was.
+fix_directory_ownership() {
+    chown -R root:root "$RUN_DIR" "$LOG_DIR"
+    chmod 0750 "$RUN_DIR"
+
+    if id "oidc-auth" &>/dev/null; then
+        print_warn "The oidc-auth account exists from an earlier install and nothing runs as it; nothing is owned by it any more."
     fi
-    chown -R oidc-auth:oidc-auth "$RUN_DIR" "$LOG_DIR"
 }
 
 install_binaries() {
@@ -89,6 +331,9 @@ install_binaries() {
     [[ -f "$broker"  ]] || print_error "oidc-auth-broker not found next to this script"
     [[ -f "$helper"  ]] || print_error "oidc-pam-helper not found next to this script"
     [[ -f "$pam_mod" ]] || print_error "pam_oidc.so not found next to this script"
+
+    # resolve_pam_dir() runs first in main(), before anything is written.
+    [[ -n "$PAM_DIR" ]] || print_error "internal error: PAM module directory not resolved"
 
     install -m 0755 "$broker" "$INSTALL_DIR/oidc-auth-broker"
     install -m 0755 "$helper" "$INSTALL_DIR/oidc-pam-helper"
@@ -109,13 +354,18 @@ install_config() {
     local example_cfg="$SCRIPT_DIR/configs/examples/broker.yaml"
     local unit="$SCRIPT_DIR/configs/systemd/oidc-auth-broker.service"
 
-    if [[ -f "$example_cfg" ]]; then
-        if [[ -f "$CONFIG_DIR/broker.yaml" ]]; then
-            print_warn "$CONFIG_DIR/broker.yaml already exists, leaving it untouched"
-        else
-            install -m 0644 "$example_cfg" "$CONFIG_DIR/broker.yaml"
-            print_info "Installed example broker config to $CONFIG_DIR/broker.yaml"
-        fi
+    # 0600 root:root, not 0644 (#209): this file holds the AES-256 token
+    # encryption key and every client secret, and the hosts this product exists
+    # for are multi-user. The broker now refuses to start if it is readable by
+    # anyone but root, so a mode set here is a mode the broker will hold us to.
+    if [[ -f "$CONFIG_DIR/broker.yaml" ]]; then
+        print_warn "$CONFIG_DIR/broker.yaml already exists, leaving its contents untouched"
+        chown root:root "$CONFIG_DIR/broker.yaml"
+        chmod 0600 "$CONFIG_DIR/broker.yaml"
+        print_info "Tightened $CONFIG_DIR/broker.yaml to 0600 root:root"
+    elif [[ -f "$example_cfg" ]]; then
+        install -m 0600 -o root -g root "$example_cfg" "$CONFIG_DIR/broker.yaml"
+        print_info "Installed example broker config to $CONFIG_DIR/broker.yaml (0600 root:root)"
     else
         print_warn "Example broker config not found, skipping"
     fi
@@ -130,25 +380,55 @@ install_config() {
 }
 
 configure_pam() {
+    local file="$PAM_D_DIR/sshd"
+    local backup plan verdict at kind target
+
     if [[ "$CONFIGURE_PAM" -ne 1 ]]; then
         print_warn "PAM not modified. Re-run with --configure-pam, or add 'auth sufficient pam_oidc.so' to the relevant /etc/pam.d/ service yourself."
+        PAM_WIRING_SKIPPED=1
         return
     fi
 
     print_info "Configuring PAM for sshd..."
-    if [[ ! -f /etc/pam.d/sshd ]]; then
-        print_warn "/etc/pam.d/sshd not found, skipping PAM wiring"
+    if [[ ! -f "$file" ]]; then
+        print_warn "$file not found, skipping PAM wiring"
+        PAM_WIRING_SKIPPED=1
         return
     fi
 
-    cp "/etc/pam.d/sshd" "/etc/pam.d/sshd.backup.$(date +%Y%m%d-%H%M%S)"
-    if grep -q "pam_oidc.so" /etc/pam.d/sshd; then
-        print_info "pam_oidc.so already present in /etc/pam.d/sshd"
-    else
-        sed -i '1iauth sufficient pam_oidc.so' /etc/pam.d/sshd
-        print_info "Added pam_oidc.so to /etc/pam.d/sshd (backup saved)"
+    # sshd and nothing else. Console login (/etc/pam.d/login) is the documented
+    # recovery path when the broker is down, and su/sudo are how an operator
+    # repairs the host, so none of them is wired here (#220).
+    if grep -q "pam_oidc.so" "$file"; then
+        print_info "pam_oidc.so already present in $file"
+        print_warn "Review $file and keep an emergency session open before logging out."
+        return
     fi
-    print_warn "Review /etc/pam.d/sshd and keep an emergency session open before logging out."
+
+    plan="$(pam_plan_insertion "$file")"
+    if [[ "$plan" != INSERT* ]]; then
+        pam_print_manual_instructions "$file" "${plan#REFUSE }"
+        PAM_WIRING_SKIPPED=1
+        return
+    fi
+    read -r verdict at kind target <<<"$plan"
+    : "$verdict"
+
+    # Backup first, with the mode intact, and name it so the uninstaller can find
+    # it (#207): scripts/uninstall.sh restores from $file.backup.* when removing
+    # the OIDC lines would leave a stack that refuses every login.
+    backup="$file.backup.$(date +%Y%m%d-%H%M%S)"
+    cp -p "$file" "$backup"
+
+    pam_insert_block "$file" "$at"
+    print_info "Added pam_oidc.so to $file before line $at ($kind $target); backup: $backup"
+
+    if [[ "$kind" != "module" ]] && ! grep -q "pam_faillock.so" "$file"; then
+        print_warn "$file delegates its auth phase to '$target'. If that stack starts with a pam_faillock.so preauth entry, move the OIDC line below it or faillock will stop counting failures (#220)."
+    fi
+
+    print_warn "Review $file and keep an emergency session open before logging out:"
+    grep -n '^[[:space:]]*\(-\?auth\|@include\)' "$file" | sed 's/^/    /'
 }
 
 print_summary() {
@@ -158,12 +438,19 @@ print_summary() {
 OIDC PAM Installation Complete
 ========================================
 
+Installed:
+- Module:  $PAM_DIR/pam_oidc.so
+- Config:  $CONFIG_DIR/broker.yaml (0600 root:root -- the broker refuses to start otherwise)
+
 Next steps:
 1. Note: local accounts must already exist (oidc-pam does not create users and ships no NSS module).
 2. Configure your OIDC provider in $CONFIG_DIR/broker.yaml
 3. Start the broker:  systemctl start oidc-auth-broker
 4. Check logs:        journalctl -u oidc-auth-broker -f
-$( [[ "$CONFIGURE_PAM" -ne 1 ]] && echo "5. Wire PAM:          re-run with --configure-pam (or edit /etc/pam.d/<service>)" )
+$( [[ "$PAM_WIRING_SKIPPED" -eq 1 ]] && echo "5. Wire PAM:          nothing authenticates through OIDC yet -- see the [WARN] lines above" )
+
+Console login, su and sudo are deliberately left alone: the console is the
+recovery path when the broker is down. See configs/pam/README.md.
 
 See README.md and DEPLOYMENT.md for full guidance.
 EOF
@@ -173,8 +460,11 @@ main() {
     parse_args "$@"
     print_info "Installing OIDC PAM from release tarball..."
     check_root
+    # Before anything is written: a module installed outside PAM's module path is
+    # worse than no install at all (#208).
+    resolve_pam_dir
     create_directories
-    create_user
+    fix_directory_ownership
     install_binaries
     install_config
     configure_pam
@@ -182,4 +472,9 @@ main() {
     print_info "Done."
 }
 
-main "$@"
+# Sourcing this file defines the functions and runs nothing, so the PAM logic
+# above can be exercised against a temporary PAM_D_DIR
+# (test/scripts/test-pam-wiring.sh) rather than the host's real stack.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,36 @@
 #!/bin/bash
 
-# OIDC PAM Installation Script
-# This script installs the OIDC PAM authentication system
+# OIDC PAM installer, building from source in this working tree.
+#
+# For a prebuilt release tarball, use scripts/install-release.sh instead.
+#
+# Usage:
+#   sudo ./scripts/install.sh                  # build and install; PAM untouched
+#   sudo ./scripts/install.sh --configure-pam  # additionally wire pam_oidc.so into sshd
+#
+# PAM is NOT modified unless --configure-pam is passed, so an install cannot lock
+# you out of SSH on its own. Console login, su and sudo are never wired: the
+# console is the recovery path when the broker is down.
+#
+# Environment:
+#   PAM_MODULE_DIR=<dir>   where to install pam_oidc.so, if detection gets it
+#                          wrong. It must be a directory libpam itself loads
+#                          modules from, or the module will never run.
 
 set -e
 
 # Configuration
 INSTALL_DIR="/usr/local/bin"
-PAM_DIR="/lib/security"
+# Where libpam loads modules from. Deliberately empty: resolve_pam_dir() detects
+# it before anything is installed (#208). It used to be hardcoded to
+# /lib/security, which exists on neither Debian/Ubuntu (/lib/<triplet>/security)
+# nor RHEL-family systems (/lib64/security), so the install either aborted
+# half-way through or -- once an operator created the directory to get past that
+# -- wrote the module somewhere PAM never looks. Override with PAM_MODULE_DIR.
+PAM_DIR=""
+# The PAM service directory, overridable only so the logic below can be tested
+# against a temporary tree instead of the host's real stack.
+PAM_D_DIR="${PAM_D_DIR:-/etc/pam.d}"
 CONFIG_DIR="/etc/oidc-auth"
 RUN_DIR="/var/run/oidc-auth"
 LOG_DIR="/var/log/oidc-auth"
@@ -42,6 +65,236 @@ check_root() {
     if [[ $EUID -ne 0 ]]; then
         print_error "This script must be run as root"
     fi
+}
+
+# The auth line this installer adds, and the sentinel comments that fence it.
+#
+# The fence is what makes the uninstaller safe (#207): it used to delete every
+# line matching pam_oidc.so, which on the stack this project itself ships
+# (configs/pam/ssh: 'sufficient pam_oidc.so' followed by 'requisite
+# pam_deny.so') left pam_deny.so as the entire auth phase and refused every
+# login, for every user, permanently.
+#
+# 'sufficient' with nothing added after it means a broker that is down or a
+# module that cannot be loaded falls through to the rest of the existing stack.
+# An install must not be able to lock the operator out.
+PAM_SENTINEL_BEGIN="# BEGIN oidc-pam -- added by the oidc-pam installer; removed by scripts/uninstall.sh"
+PAM_SENTINEL_END="# END oidc-pam"
+PAM_AUTH_LINE="auth    sufficient  pam_oidc.so"
+
+# Whether to wire pam_oidc.so into /etc/pam.d/sshd at all. Off by default, so an
+# install cannot cost you the session you ran it from; --configure-pam turns it on.
+CONFIGURE_PAM=0
+
+# Set when PAM wiring was declined, so the summary can say so rather than
+# implying the host is configured.
+PAM_WIRING_SKIPPED=0
+
+# Print the header block only, as scripts/install-release.sh does: the comments
+# further down explain implementation rather than usage.
+print_usage() {
+    awk 'NR == 1 { next }
+         /^#/    { seen = 1; sub(/^#[[:space:]]?/, ""); print; next }
+         seen    { exit }
+         { next }' "${BASH_SOURCE[0]}"
+}
+
+parse_args() {
+    for arg in "$@"; do
+        case "$arg" in
+            --configure-pam) CONFIGURE_PAM=1 ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *) print_error "Unknown argument: $arg" ;;
+        esac
+    done
+}
+
+# Locate the directory libpam loads modules from (#208).
+#
+# pam_permit.so ships with libpam itself, so a directory holding it is a
+# directory PAM loads from. Ask the package manager first -- Debian's path
+# carries a multiarch triplet not worth guessing -- then probe the known
+# layouts. Prints the directory, or returns 1 having printed nothing.
+detect_pam_dir() {
+    local candidate dir arch
+
+    if command -v dpkg >/dev/null 2>&1; then
+        candidate="$(dpkg -L libpam-modules 2>/dev/null | grep -m1 '/pam_permit\.so$' || true)"
+        if [[ -n "$candidate" && -f "$candidate" ]]; then
+            dirname "$candidate"
+            return 0
+        fi
+    fi
+
+    if command -v rpm >/dev/null 2>&1; then
+        candidate="$(rpm -ql pam 2>/dev/null | grep -m1 '/pam_permit\.so$' || true)"
+        if [[ -n "$candidate" && -f "$candidate" ]]; then
+            dirname "$candidate"
+            return 0
+        fi
+    fi
+
+    arch="$(uname -m)"
+    for dir in /lib64/security /usr/lib64/security \
+               "/lib/${arch}-linux-gnu/security" "/usr/lib/${arch}-linux-gnu/security" \
+               /lib/security /usr/lib/security; do
+        if [[ -f "$dir/pam_permit.so" ]]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Resolve PAM_DIR, and refuse to install if it cannot be found. A module written
+# outside PAM's module path never loads: with configs/pam/ssh that means every
+# SSH login is refused by pam_deny.so, and on a stack with a password fallback it
+# means OIDC silently never runs while the operator believes it is enforced.
+resolve_pam_dir() {
+    local arch
+    arch="$(uname -m)"
+
+    if [[ -n "${PAM_MODULE_DIR:-}" ]]; then
+        if [[ ! -d "$PAM_MODULE_DIR" ]]; then
+            print_error "PAM_MODULE_DIR=$PAM_MODULE_DIR is not a directory"
+        fi
+        PAM_DIR="$PAM_MODULE_DIR"
+        print_warn "Using PAM_MODULE_DIR=$PAM_DIR. PAM only loads modules from its own compiled-in path; if this is not that path, pam_oidc.so will never run."
+        return
+    fi
+
+    PAM_DIR="$(detect_pam_dir || true)"
+    if [[ -z "$PAM_DIR" ]]; then
+        print_warn "Could not find the directory PAM loads modules from."
+        print_warn "Looked for pam_permit.so via dpkg/rpm and in: /lib64/security, /usr/lib64/security, /lib/${arch}-linux-gnu/security, /usr/lib/${arch}-linux-gnu/security, /lib/security, /usr/lib/security"
+        print_warn "Install your distribution's PAM modules (libpam-modules on Debian/Ubuntu, pam on RHEL-family), or set PAM_MODULE_DIR to the directory holding pam_unix.so."
+        print_error "Refusing to install: a module written outside PAM's module path never loads."
+    fi
+
+    print_info "PAM module directory: $PAM_DIR"
+}
+
+# Decide where pam_oidc.so belongs in an existing auth stack -- or refuse (#220).
+#
+# Both installers used to insert at line 1 unconditionally. Ahead of a
+# pam_faillock.so preauth entry that breaks failure counting on RHEL-family
+# systems; ahead of pam_nologin.so, pam_access.so or pam_securetty.so it makes
+# those gates unreachable, because a 'sufficient' module that succeeds ends the
+# auth phase before them.
+#
+# So: walk the auth phase, allow the known prologue modules to stay in front, and
+# insert immediately before the first thing that authenticates or terminates
+# (pam_unix.so and friends, pam_deny.so, or an include/substack of a shared
+# stack). Anything unrecognised means this is not a stack we understand, and an
+# installer that does not understand a stack has no business editing it.
+#
+# Prints "INSERT <line> <kind> <target>" (insert before that 1-based line) or
+# "REFUSE <reason>".
+pam_plan_insertion() {
+    awk '
+    function insert(n, kind, target) { print "INSERT " n " " kind " " target; done = 1; exit 0 }
+    function refuse(reason)          { print "REFUSE " reason;                done = 1; exit 0 }
+
+    BEGIN {
+        # Modules that may legitimately precede OIDC: they gate or annotate a
+        # login rather than deciding it, and several of them MUST run first.
+        gates = "pam_env.so pam_faillock.so pam_tally.so pam_tally2.so pam_faildelay.so"
+        gates = gates " pam_nologin.so pam_securetty.so pam_sepermit.so pam_access.so"
+        gates = gates " pam_time.so pam_warn.so pam_keyinit.so pam_selinux.so"
+        gates = gates " pam_namespace.so pam_shells.so pam_group.so pam_limits.so"
+        gates = gates " pam_umask.so pam_issue.so pam_motd.so pam_mail.so pam_lastlog.so"
+        gates = gates " pam_loginuid.so pam_xauth.so pam_debug.so"
+        split(gates, g, " ")
+        for (i in g) gate[g[i]] = 1
+
+        # Modules that decide an authentication, or end the stack. The OIDC line
+        # goes in front of the first of these.
+        deciders = "pam_unix.so pam_unix2.so pam_unix_auth.so pam_pwdfile.so pam_deny.so"
+        deciders = deciders " pam_permit.so pam_sss.so pam_sss_gss.so pam_ldap.so"
+        deciders = deciders " pam_ldapd.so pam_krb5.so pam_winbind.so pam_localuser.so"
+        deciders = deciders " pam_succeed_if.so pam_google_authenticator.so pam_oath.so"
+        deciders = deciders " pam_u2f.so pam_yubico.so pam_radius_auth.so"
+        deciders = deciders " pam_ssh_agent_auth.so pam_gnome_keyring.so pam_kwallet5.so"
+        deciders = deciders " pam_ecryptfs.so pam_fscrypt.so pam_mount.so"
+        deciders = deciders " pam_systemd_home.so pam_oidc.so"
+        split(deciders, a, " ")
+        for (i in a) authn[a[i]] = 1
+    }
+
+    {
+        if (NF == 0 || $1 ~ /^#/) next
+
+        # A continuation line cannot be reasoned about one line at a time.
+        if ($0 ~ /\\[ \t]*$/) refuse("line " NR " continues onto the next line")
+
+        type = tolower($1)
+        sub(/^-/, "", type)
+
+        # A whole-file include. Debian delegates sshd auth with "@include common-auth".
+        if (type == "@include") {
+            if ($2 ~ /auth/) insert(NR, "include", $2)
+            if (seen_auth) refuse("the auth phase of this file has no module that can authenticate")
+            next
+        }
+
+        if (type != "auth") {
+            if (seen_auth) refuse("the auth phase of this file has no module that can authenticate")
+            next
+        }
+        seen_auth = 1
+
+        # Control may be a single keyword or a bracketed [value=action ...] list.
+        if ($2 ~ /^\[/) {
+            control = "["
+            for (i = 2; i <= NF; i++) if ($i ~ /\]$/) break
+            i++
+        } else {
+            control = tolower($2)
+            i = 3
+        }
+        if (i > NF) refuse("cannot parse auth line " NR)
+
+        if (control == "include" || control == "substack") insert(NR, control, $i)
+
+        module = $i
+        sub(/.*\//, "", module)
+        if (module in gate) next
+        if (module in authn) insert(NR, "module", module)
+        refuse("unrecognised auth module " module " on line " NR)
+    }
+
+    END { if (!done) refuse("this file has no auth phase") }
+    ' "$1"
+}
+
+# Explain a refusal, and print the line the operator has to add by hand (#220).
+pam_print_manual_instructions() {
+    local file="$1" reason="$2"
+
+    print_warn "Not modifying $file: $reason."
+    print_warn "Add this line yourself, after any pam_faillock/pam_env prologue and before the first module that authenticates:"
+    print_warn "    $PAM_AUTH_LINE"
+    print_warn "See configs/pam/README.md and configs/pam/ssh for the full stack, and keep a session open while testing."
+}
+
+# Insert the fenced OIDC block before line $2 of $1, preserving mode and owner.
+pam_insert_block() {
+    local file="$1" at="$2" tmp
+    tmp="$(mktemp "${file}.oidc.XXXXXX")"
+
+    awk -v at="$at" -v begin="$PAM_SENTINEL_BEGIN" -v body="$PAM_AUTH_LINE" -v end="$PAM_SENTINEL_END" '
+        NR == at { print begin; print body; print end }
+        { print }
+    ' "$file" > "$tmp"
+
+    # A PAM file is itself an access control; do not widen it by rewriting it.
+    chmod --reference="$file" "$tmp" 2>/dev/null || chmod 0644 "$tmp"
+    chown --reference="$file" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$file"
 }
 
 # Check system requirements
@@ -112,8 +365,10 @@ create_directories() {
     mkdir -p "$RUN_DIR"
     chmod 755 "$RUN_DIR"
     
+    # 0750, not 0755: the broker's own log is the delivery mechanism for anything
+    # it debug-logs about a login in progress, so it is not world-readable.
     mkdir -p "$LOG_DIR"
-    chmod 755 "$LOG_DIR"
+    chmod 750 "$LOG_DIR"
 
     mkdir -p "$STATE_DIR/ssh-keys" "$STATE_DIR/locks"
     chmod 700 "$STATE_DIR" "$STATE_DIR/ssh-keys" "$STATE_DIR/locks"
@@ -121,20 +376,40 @@ create_directories() {
     print_info "Directories created"
 }
 
-# Create oidc-auth user
-create_user() {
-    print_info "Creating oidc-auth user..."
-    
-    if ! id "oidc-auth" &>/dev/null; then
-        useradd -r -s /bin/false -d /var/lib/oidc-auth -c "OIDC Auth Service" oidc-auth
-        print_info "User oidc-auth created"
-    else
-        print_info "User oidc-auth already exists"
+# Take the socket, log and state directories back to root.
+#
+# There is deliberately no oidc-auth account any more, and nothing is chowned to
+# one. The broker runs as User=root -- it has to, because its job on a successful
+# login is to write into an arbitrary account's ~/.ssh and hand the file over --
+# so an unprivileged account owning any directory it writes to is a privilege
+# boundary pointing the wrong way.
+#
+# This function used to create the account and then `chown -R oidc-auth:oidc-auth`
+# the socket and log directories. Write access to the directory holding the socket
+# is enough to unlink(2) that socket and bind(2) an impostor at the same path: the
+# real broker keeps serving on its now-unlinked inode and stays green in
+# `systemctl status`, while every PAM login reaches the impostor, which can answer
+# {"success":true} and -- with `auth sufficient pam_oidc.so` -- log anyone in as
+# anyone, root included (#200). The log directory was the same shape: a root
+# process appending to a file an unprivileged account can replace with a symlink.
+#
+# The broker now refuses to bind under a directory anyone but root or itself can
+# write to, so an installed host that still has the old ownership fails to start
+# rather than serving from a hijackable path, and the systemd unit's
+# RuntimeDirectory=/RuntimeDirectoryMode= reassert root:root 0750 on every start.
+# This is the part that stops the wrong ownership being created in the first place.
+#
+# An existing host upgraded in place is repaired here rather than left as it was.
+fix_directory_ownership() {
+    print_info "Setting directory ownership to root..."
+
+    chown -R root:root "$RUN_DIR" "$LOG_DIR"
+    chmod 0750 "$RUN_DIR"
+
+    if id "oidc-auth" &>/dev/null; then
+        print_warn "The oidc-auth account exists from an earlier install and nothing runs as it."
+        print_warn "Nothing is owned by it any more; remove it with 'userdel oidc-auth' once you have checked no other software uses it."
     fi
-    
-    # Set ownership
-    chown -R oidc-auth:oidc-auth "$RUN_DIR"
-    chown -R oidc-auth:oidc-auth "$LOG_DIR"
 }
 
 # Install binaries
@@ -154,28 +429,37 @@ install_binaries() {
         print_error "PAM module bin/pam_oidc.so not found. Please run 'make build' first."
     fi
     
+    # resolve_pam_dir() runs first in main(), before anything is written.
+    if [[ -z "$PAM_DIR" ]]; then
+        print_error "internal error: PAM module directory not resolved"
+    fi
+
     # Install binaries
-    cp bin/oidc-auth-broker "$INSTALL_DIR/"
-    cp bin/oidc-pam-helper "$INSTALL_DIR/"
-    cp bin/pam_oidc.so "$PAM_DIR/"
-    
-    # Set permissions
-    chmod 755 "$INSTALL_DIR/oidc-auth-broker"
-    chmod 755 "$INSTALL_DIR/oidc-pam-helper"
-    chmod 644 "$PAM_DIR/pam_oidc.so"
-    
-    print_info "Binaries installed"
+    install -m 0755 bin/oidc-auth-broker "$INSTALL_DIR/oidc-auth-broker"
+    install -m 0755 bin/oidc-pam-helper "$INSTALL_DIR/oidc-pam-helper"
+    install -m 0644 bin/pam_oidc.so "$PAM_DIR/pam_oidc.so"
+
+    print_info "Binaries installed ($PAM_DIR/pam_oidc.so)"
 }
 
 # Install configuration files
 install_config() {
     print_info "Installing configuration files..."
     
-    # Install broker configuration
-    if [[ -f "configs/examples/broker.yaml" ]]; then
-        cp configs/examples/broker.yaml "$CONFIG_DIR/"
-        chmod 644 "$CONFIG_DIR/broker.yaml"
-        print_info "Broker configuration installed"
+    # Install broker configuration.
+    #
+    # 0600 root:root, not 0644 (#209): this file holds the AES-256 token
+    # encryption key and every client secret, and the hosts this product exists
+    # for are multi-user. The broker now refuses to start if it is readable by
+    # anyone but root, so a mode set here is a mode the broker will hold us to.
+    if [[ -f "$CONFIG_DIR/broker.yaml" ]]; then
+        print_warn "$CONFIG_DIR/broker.yaml already exists, leaving its contents untouched"
+        chown root:root "$CONFIG_DIR/broker.yaml"
+        chmod 0600 "$CONFIG_DIR/broker.yaml"
+        print_info "Tightened $CONFIG_DIR/broker.yaml to 0600 root:root"
+    elif [[ -f "configs/examples/broker.yaml" ]]; then
+        install -m 0600 -o root -g root configs/examples/broker.yaml "$CONFIG_DIR/broker.yaml"
+        print_info "Broker configuration installed (0600 root:root)"
     else
         print_warn "Broker configuration not found, skipping"
     fi
@@ -198,29 +482,62 @@ install_config() {
 # device flow in one of those makes each of them wait up to 90 s for a human with
 # a phone, several with no way to show that human the verification URL (#172).
 configure_pam() {
-    print_info "Configuring PAM..."
+    local file="$PAM_D_DIR/sshd"
+    local backup plan verdict at kind target
 
-    if [[ ! -f "/etc/pam.d/sshd" ]]; then
-        print_warn "/etc/pam.d/sshd not found, skipping PAM configuration"
+    # Opt-in, as in scripts/install-release.sh, and for the same reason: an
+    # install that edits the host's SSH auth stack without being asked is an
+    # install that can cost you the session you ran it from. The two installers
+    # used to disagree about this -- the release one asked, this one did not --
+    # and a divergence like that gets one of them fixed and the other forgotten.
+    if [[ "$CONFIGURE_PAM" -ne 1 ]]; then
+        print_warn "PAM not modified. Re-run with --configure-pam, or add 'auth sufficient pam_oidc.so' to $PAM_D_DIR/sshd yourself."
+        PAM_WIRING_SKIPPED=1
         return
     fi
 
-    # Backup existing PAM configuration
-    cp "/etc/pam.d/sshd" "/etc/pam.d/sshd.backup.$(date +%Y%m%d-%H%M%S)"
+    print_info "Configuring PAM..."
 
-    # Check if OIDC PAM is already configured
-    if grep -q "pam_oidc.so" /etc/pam.d/sshd; then
-        print_info "OIDC PAM already configured in SSH"
-    else
-        # Add OIDC PAM to SSH configuration. 'sufficient' with no pam_deny.so
-        # after it, so the rest of the existing sshd stack still decides if OIDC
-        # is unavailable: an install must not be able to lock the operator out.
-        sed -i '1i# OIDC PAM Authentication' /etc/pam.d/sshd
-        sed -i '2iauth sufficient pam_oidc.so' /etc/pam.d/sshd
-        print_info "OIDC PAM configured for SSH"
+    if [[ ! -f "$file" ]]; then
+        print_warn "$file not found, skipping PAM configuration"
+        PAM_WIRING_SKIPPED=1
+        return
     fi
 
-    print_warn "PAM configuration updated. Please review /etc/pam.d/sshd"
+    # Console login (/etc/pam.d/login) is deliberately NOT wired (#220): it is the
+    # documented recovery path when the broker is down, and it has to keep working
+    # without the broker. Same for su and sudo -- an operator who cannot escalate
+    # cannot repair anything. See configs/pam/README.md.
+    if grep -q "pam_oidc.so" "$file"; then
+        print_info "OIDC PAM already configured in $file"
+        print_warn "Review $file and keep an emergency session open."
+        return
+    fi
+
+    plan="$(pam_plan_insertion "$file")"
+    if [[ "$plan" != INSERT* ]]; then
+        pam_print_manual_instructions "$file" "${plan#REFUSE }"
+        PAM_WIRING_SKIPPED=1
+        return
+    fi
+    read -r verdict at kind target <<<"$plan"
+    : "$verdict"
+
+    # Backup first, with the mode intact, and name it so the uninstaller can find
+    # it (#207): scripts/uninstall.sh restores from $file.backup.* when removing
+    # the OIDC lines would leave a stack that refuses every login.
+    backup="$file.backup.$(date +%Y%m%d-%H%M%S)"
+    cp -p "$file" "$backup"
+
+    pam_insert_block "$file" "$at"
+    print_info "Added pam_oidc.so to $file before line $at ($kind $target); backup: $backup"
+
+    if [[ "$kind" != "module" ]] && ! grep -q "pam_faillock.so" "$file"; then
+        print_warn "$file delegates its auth phase to '$target'. If that stack starts with a pam_faillock.so preauth entry, move the OIDC line below it or faillock will stop counting failures (#220)."
+    fi
+
+    print_warn "PAM configuration updated. Please review $file:"
+    grep -n '^[[:space:]]*\(-\?auth\|@include\)' "$file" | sed 's/^/    /'
     print_warn "Keep an emergency session open. Wire pam_oidc.so per service only, never into the"
     print_warn "host-wide stack every service includes -- see configs/pam/README.md."
 }
@@ -243,15 +560,20 @@ enable_services() {
 post_install() {
     print_info "Running post-installation tasks..."
     
-    # Create log file
+    # Create log file. 0640, not 0644: see the note on $LOG_DIR above. root-owned,
+    # because the broker that appends to it runs as root -- a log file an
+    # unprivileged account owns is one it can replace with a symlink.
     touch "$LOG_DIR/broker.log"
-    chown oidc-auth:oidc-auth "$LOG_DIR/broker.log"
-    chmod 644 "$LOG_DIR/broker.log"
-    
-    # Create socket directory
+    chown root:root "$LOG_DIR/broker.log"
+    chmod 640 "$LOG_DIR/broker.log"
+
+    # Create the socket directory: root-owned and 0750, not 0755. Write access here
+    # is enough to unlink the broker's socket and bind an impostor at the same path
+    # (#200). systemd's RuntimeDirectory= recreates it with these same values on
+    # every start; this is what it looks like before the first one.
     mkdir -p "$RUN_DIR"
-    chown oidc-auth:oidc-auth "$RUN_DIR"
-    chmod 755 "$RUN_DIR"
+    chown root:root "$RUN_DIR"
+    chmod 750 "$RUN_DIR"
     
     print_info "Post-installation tasks completed"
 }
@@ -270,35 +592,52 @@ print_summary() {
     echo "4. Test authentication: oidc-pam-helper --user testuser"
     echo ""
     echo "Configuration files:"
-    echo "- Broker: $CONFIG_DIR/broker.yaml"
-    echo "- PAM: /etc/pam.d/sshd"
+    echo "- Broker: $CONFIG_DIR/broker.yaml (0600 root:root -- the broker refuses to start otherwise)"
+    echo "- PAM: $PAM_D_DIR/sshd"
+    echo "- Module: $PAM_DIR/pam_oidc.so"
     echo "- Service: $SYSTEMD_DIR/oidc-auth-broker.service"
     echo ""
     echo "Log files:"
     echo "- Broker: $LOG_DIR/broker.log"
     echo "- System: journalctl -u oidc-auth-broker"
     echo ""
+    if [[ "$PAM_WIRING_SKIPPED" -eq 1 ]]; then
+        echo "PAM was NOT wired: nothing on this host authenticates through OIDC yet."
+        echo "See the [WARN] lines above for the line to add and where to add it."
+        echo ""
+    fi
+    echo "Console login, su and sudo are deliberately left alone: the console is the"
+    echo "recovery path when the broker is down. See configs/pam/README.md."
+    echo ""
     echo "For more information, see README.md and REQUIREMENTS.md"
 }
 
 # Main installation function
 main() {
+    parse_args "$@"
     print_info "Starting OIDC PAM installation..."
-    
+
     check_root
     check_requirements
+    # Before anything is written: a module installed outside PAM's module path is
+    # worse than no install at all (#208).
+    resolve_pam_dir
     install_dependencies
     create_directories
-    create_user
+    fix_directory_ownership
     install_binaries
     install_config
     configure_pam
     enable_services
     post_install
     print_summary
-    
+
     print_info "Installation completed successfully!"
 }
 
-# Run main function
-main "$@"
+# Sourcing this file defines the functions and runs nothing, so the PAM logic
+# above can be exercised against a temporary PAM_D_DIR
+# (test/scripts/test-pam-wiring.sh) rather than the host's real stack.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -35,7 +35,8 @@ check_requirements() {
     fi
     
     # Check Go version
-    local go_version=$(go version | awk '{print $3}' | sed 's/go//')
+    local go_version
+    go_version=$(go version | awk '{print $3}' | sed 's/go//')
     local required_version="1.21"
     
     if ! printf '%s\n' "$required_version" "$go_version" | sort -V | head -n1 | grep -q "$required_version"; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,16 +2,54 @@
 
 # OIDC PAM Uninstallation Script
 # This script removes the OIDC PAM authentication system
+#
+# The one thing this script must never do is leave a host nobody can log in to.
+# It used to (#207): it deleted every line matching pam_oidc.so from
+# /etc/pam.d/sshd, and on the stack this project itself ships (configs/pam/ssh,
+# 'auth sufficient pam_oidc.so' followed by 'auth requisite pam_deny.so') that
+# left pam_deny.so as the entire auth phase -- every SSH authentication refused,
+# for every user, permanently -- while printing "Uninstallation completed
+# successfully!". The same edit applied to su and sudo would have taken away the
+# operator's way to repair it.
+#
+# So, in order:
+#   1. remove the OIDC lines from *every* /etc/pam.d file that references them,
+#      the fenced block the installer added by preference;
+#   2. check the resulting auth phase still has something that can authenticate,
+#      and if it does not, restore the backup the installer took before it edited;
+#   3. if there is no usable backup either, leave the file exactly as it was, say
+#      so loudly, and leave pam_oidc.so installed so the stack keeps working.
+#
+# The check in step 2 is a static read of the stack (see
+# pam_auth_phase_authenticates); it cannot prove a login succeeds. Test one
+# before you close your last session.
 
-set -e
+set -euo pipefail
 
 # Configuration
 INSTALL_DIR="/usr/local/bin"
-PAM_DIR="/lib/security"
 CONFIG_DIR="/etc/oidc-auth"
 RUN_DIR="/var/run/oidc-auth"
 LOG_DIR="/var/log/oidc-auth"
+# The broker's own state: the SSH keys it issued and the per-user write locks.
+STATE_DIR="/var/lib/oidc-pam"
 SYSTEMD_DIR="/etc/systemd/system"
+# The PAM service directory, overridable only so the logic below can be tested
+# against a temporary tree instead of the host's real stack.
+PAM_D_DIR="${PAM_D_DIR:-/etc/pam.d}"
+
+# One timestamp for the whole run. It used to be recomputed per use, so the
+# "backup written" message tested for a filename that differed from the one
+# written whenever the second ticked over between the two lines.
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+
+# Set when a PAM file could not be cleaned up safely, or the module had to be
+# left installed. Both make this an incomplete uninstall, and the summary says so.
+PAM_CLEANUP_INCOMPLETE=0
+MODULE_LEFT_INSTALLED=0
+# Set when a pre-v0.5.1 oidc-auth account was found and kept, so the summary only
+# mentions it on the hosts that actually have one.
+USER_LEFT_BEHIND=0
 
 # Colors for output
 RED='\033[0;31m'
@@ -40,136 +78,478 @@ check_root() {
     fi
 }
 
+# Every directory pam_oidc.so could have been installed into: what this host's
+# libpam actually loads from, plus the layouts of the distributions this project
+# supports, plus /lib/security -- which is where releases up to v0.4.2 put it
+# (#208), and which is therefore exactly where a stale copy will be.
+pam_module_candidate_dirs() {
+    local arch dir
+    arch="$(uname -m)"
+
+    if [[ -n "${PAM_MODULE_DIR:-}" ]]; then
+        printf '%s\n' "$PAM_MODULE_DIR"
+    fi
+
+    if command -v dpkg >/dev/null 2>&1; then
+        dir="$(dpkg -L libpam-modules 2>/dev/null | grep -m1 '/pam_permit\.so$' || true)"
+        [[ -n "$dir" ]] && dirname "$dir"
+    fi
+
+    if command -v rpm >/dev/null 2>&1; then
+        dir="$(rpm -ql pam 2>/dev/null | grep -m1 '/pam_permit\.so$' || true)"
+        [[ -n "$dir" ]] && dirname "$dir"
+    fi
+
+    printf '%s\n' /lib64/security /usr/lib64/security \
+        "/lib/${arch}-linux-gnu/security" "/usr/lib/${arch}-linux-gnu/security" \
+        /lib/security /usr/lib/security
+    return 0
+}
+
+# The PAM service files that reference pam_oidc.so.
+#
+# Every one of them, not just sshd: the old script edited sshd alone, so a host
+# that had followed configs/pam/README.md was left with /etc/pam.d/sudo, su and
+# login pointing at a module that had just been deleted, each backed by
+# 'requisite pam_deny.so' -- sudo and su then denying everyone, so the operator
+# could not escalate to repair sshd.
+#
+# Backups and package-manager leftovers are skipped: they are not live stacks,
+# and a backup that still mentions pam_oidc.so must not make this script think
+# the module is still in use.
+pam_service_files() {
+    local f name
+    for f in "$PAM_D_DIR"/*; do
+        [[ -f "$f" ]] || continue
+        name="$(basename "$f")"
+        case "$name" in
+            *.backup.*|*.bak|*.orig|*.save|*.rpmsave|*.rpmnew|*.dpkg-*|*.ucf-*|*~) continue ;;
+            *.oidc-uninstall.*|*.oidc.*) continue ;;
+        esac
+        grep -q "pam_oidc.so" "$f" && printf '%s\n' "$f"
+    done
+    return 0
+}
+
+# Write $1 to stdout with the OIDC lines taken out: the fenced block the
+# installer added, any line naming pam_oidc.so in any phase, and the bare
+# "# OIDC PAM Authentication" comment older installers wrote.
+pam_strip_oidc() {
+    awk '
+    /^[ \t]*#[ \t]*BEGIN oidc-pam/ { inblock = 1; next }
+    /^[ \t]*#[ \t]*END oidc-pam/   { inblock = 0; next }
+    inblock { next }
+    /^[ \t]*#[ \t]*OIDC PAM Authentication[ \t]*$/ { next }
+    {
+        if ($0 ~ /^[ \t]*#/) { print; next }
+        for (i = 1; i <= NF; i++) {
+            m = $i
+            sub(/.*\//, "", m)
+            if (m == "pam_oidc.so") next
+        }
+        print
+    }
+    ' "$1"
+}
+
+# Does the auth phase of $1 still have something that can authenticate?
+#
+# This is the check that was missing in #207. "Something that can authenticate"
+# means: a module that is not one of the known prologue/bookkeeping modules and
+# is not pam_deny.so, reached before any required/requisite pam_deny.so, or an
+# include/substack of a shared stack (which we do not follow -- a distribution's
+# common-auth is assumed to authenticate).
+#
+# It is deliberately generous about modules it does not know: the failure being
+# guarded against is a stack with nothing left in it but pam_deny.so.
+pam_auth_phase_authenticates() {
+    awk '
+    BEGIN {
+        gates = "pam_env.so pam_faillock.so pam_tally.so pam_tally2.so pam_faildelay.so"
+        gates = gates " pam_nologin.so pam_securetty.so pam_sepermit.so pam_access.so"
+        gates = gates " pam_time.so pam_warn.so pam_keyinit.so pam_selinux.so"
+        gates = gates " pam_namespace.so pam_shells.so pam_group.so pam_limits.so"
+        gates = gates " pam_umask.so pam_issue.so pam_motd.so pam_mail.so pam_lastlog.so"
+        gates = gates " pam_loginuid.so pam_xauth.so pam_debug.so"
+        split(gates, g, " ")
+        for (i in g) gate[g[i]] = 1
+    }
+
+    {
+        if (NF == 0 || $1 ~ /^#/) next
+
+        type = tolower($1)
+        sub(/^-/, "", type)
+
+        if (type == "@include") {
+            if ($2 ~ /auth/) { ok = 1; exit }
+            next
+        }
+        if (type != "auth") next
+
+        if ($2 ~ /^\[/) {
+            control = "["
+            for (i = 2; i <= NF; i++) if ($i ~ /\]$/) break
+            i++
+        } else {
+            control = tolower($2)
+            i = 3
+        }
+        if (i > NF) next
+
+        if (control == "include" || control == "substack") { ok = 1; exit }
+
+        module = $i
+        sub(/.*\//, "", module)
+
+        # A hard deny reached before anything that authenticates refuses every
+        # login, whatever follows it.
+        if (module == "pam_deny.so") {
+            if (control == "required" || control == "requisite" || control == "[") exit
+            next
+        }
+        # pam_oidc.so does not count: it is what is being removed, and after
+        # removal the module file will not even be there.
+        if (module == "pam_oidc.so") next
+        if (module in gate) next
+
+        ok = 1
+        exit
+    }
+
+    END { exit(ok ? 0 : 1) }
+    ' "$1"
+}
+
+# The newest $1.backup.* that predates OIDC (does not mention pam_oidc.so) and
+# has a working auth phase. This is the backup the installer takes before it
+# edits; the old uninstaller wrote one and then never used it.
+pam_pre_install_backup() {
+    local file="$1" b
+    local -a candidates=()
+
+    for b in "$file".backup.*; do
+        [[ -f "$b" ]] || continue
+        [[ "$b" == *.backup.uninstall.* ]] && continue
+        candidates+=("$b")
+    done
+    [[ ${#candidates[@]} -eq 0 ]] && return 1
+
+    # The names carry a %Y%m%d-%H%M%S stamp, which sorts lexicographically.
+    while IFS= read -r b; do
+        grep -q "pam_oidc.so" "$b" && continue
+        pam_auth_phase_authenticates "$b" || continue
+        printf '%s\n' "$b"
+        return 0
+    done < <(printf '%s\n' "${candidates[@]}" | sort -r)
+
+    return 1
+}
+
+# Take OIDC out of one PAM service file, or leave it alone and say why.
+remove_pam_config_from_file() {
+    local file="$1" service
+    local backup="$file.backup.uninstall.$TIMESTAMP"
+    local candidate restored
+    service="$(basename "$file")"
+
+    cp -p "$file" "$backup"
+
+    candidate="$(mktemp "${file}.oidc-uninstall.XXXXXX")"
+    pam_strip_oidc "$file" > "$candidate"
+
+    if pam_auth_phase_authenticates "$candidate"; then
+        # Preserve mode and owner: a PAM file is itself an access control.
+        chmod --reference="$file" "$candidate" 2>/dev/null || chmod 0644 "$candidate"
+        chown --reference="$file" "$candidate" 2>/dev/null || true
+        mv -f "$candidate" "$file"
+        print_info "Removed pam_oidc.so from $file (backup: $backup)"
+        return 0
+    fi
+    rm -f "$candidate"
+
+    print_warn "$file: deleting its pam_oidc.so lines would leave an auth phase that refuses every login."
+
+    restored="$(pam_pre_install_backup "$file" || true)"
+    if [[ -n "$restored" ]]; then
+        cp -p "$restored" "$file"
+        print_info "Restored $file from $restored, the copy taken before pam_oidc.so was added."
+        print_warn "Test a login through $service before you close your last session: the check here reads the stack, it does not authenticate."
+        return 0
+    fi
+
+    print_warn "There is no pre-install backup of $file to restore, so it has been left exactly as it was."
+    print_warn "Its auth phase has no authentication other than OIDC -- most likely it is a copy of configs/pam/$service, whose 'auth requisite pam_deny.so' refuses anything OIDC did not accept."
+    print_warn "Finish by hand, with a session already open, and re-run this script:"
+    print_warn "  Debian/Ubuntu:  replace the auth phase of $file with '@include common-auth'"
+    print_warn "  RHEL-family:    replace it with 'auth  substack  system-auth'"
+    print_warn "  or copy your own pre-OIDC version of the file back."
+    print_warn "pam_oidc.so is being left installed, so $service keeps working until you do."
+    return 1
+}
+
+# Remove PAM configuration
+remove_pam_config() {
+    print_info "Removing OIDC from PAM configuration in $PAM_D_DIR..."
+
+    local -a files=()
+    local f
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && files+=("$f")
+    done < <(pam_service_files)
+
+    if [[ ${#files[@]} -eq 0 ]]; then
+        print_info "No PAM service file references pam_oidc.so"
+        return
+    fi
+
+    for f in "${files[@]}"; do
+        remove_pam_config_from_file "$f" || PAM_CLEANUP_INCOMPLETE=1
+    done
+}
+
 # Stop and disable services
 stop_services() {
     print_info "Stopping services..."
-    
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        print_warn "systemctl not found, skipping service removal"
+        return
+    fi
+
     # Stop service if running
     if systemctl is-active --quiet oidc-auth-broker.service; then
         systemctl stop oidc-auth-broker.service
         print_info "Service stopped"
     fi
-    
+
     # Disable service
-    if systemctl is-enabled --quiet oidc-auth-broker.service; then
+    if systemctl is-enabled --quiet oidc-auth-broker.service 2>/dev/null; then
         systemctl disable oidc-auth-broker.service
         print_info "Service disabled"
     fi
-    
+
     # Remove systemd service file
     if [[ -f "$SYSTEMD_DIR/oidc-auth-broker.service" ]]; then
         rm -f "$SYSTEMD_DIR/oidc-auth-broker.service"
         print_info "Systemd service file removed"
     fi
-    
-    # Reload systemd
-    systemctl daemon-reload
-}
 
-# Remove PAM configuration
-remove_pam_config() {
-    print_info "Removing PAM configuration..."
-    
-    # Backup current PAM configuration
-    if [[ -f "/etc/pam.d/sshd" ]]; then
-        cp "/etc/pam.d/sshd" "/etc/pam.d/sshd.backup.uninstall.$(date +%Y%m%d-%H%M%S)"
-    fi
-    
-    # Remove OIDC PAM from SSH configuration
-    if grep -q "pam_oidc.so" /etc/pam.d/sshd 2>/dev/null; then
-        sed -i '/pam_oidc.so/d' /etc/pam.d/sshd
-        sed -i '/# OIDC PAM Authentication/d' /etc/pam.d/sshd
-        print_info "OIDC PAM removed from SSH configuration"
-    fi
-    
-    # Restore backup if needed
-    if [[ -f "/etc/pam.d/sshd.backup.uninstall.$(date +%Y%m%d-%H%M%S)" ]]; then
-        print_info "PAM configuration backed up"
-    fi
+    systemctl daemon-reload
 }
 
 # Remove binaries
 remove_binaries() {
     print_info "Removing binaries..."
-    
-    # Remove binaries
+
     if [[ -f "$INSTALL_DIR/oidc-auth-broker" ]]; then
         rm -f "$INSTALL_DIR/oidc-auth-broker"
         print_info "Broker binary removed"
     fi
-    
+
     if [[ -f "$INSTALL_DIR/oidc-pam-helper" ]]; then
         rm -f "$INSTALL_DIR/oidc-pam-helper"
         print_info "Helper binary removed"
     fi
-    
-    if [[ -f "$PAM_DIR/pam_oidc.so" ]]; then
-        rm -f "$PAM_DIR/pam_oidc.so"
-        print_info "PAM module removed"
+
+    if [[ -f "$INSTALL_DIR/oidc-admin" ]]; then
+        rm -f "$INSTALL_DIR/oidc-admin"
+        print_info "Admin binary removed"
+    fi
+
+    remove_pam_module
+}
+
+# Remove the PAM module itself -- but never while a live stack still names it.
+#
+# An unresolvable module is not a no-op: in configs/pam/ssh the 'sufficient' line
+# fails and the login falls through to 'auth requisite pam_deny.so', so removing
+# the .so out from under a stack that still references it is the same lockout by
+# another route.
+remove_pam_module() {
+    local -a remaining=()
+    local f dir removed=0
+
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && remaining+=("$f")
+    done < <(pam_service_files)
+
+    if [[ ${#remaining[@]} -gt 0 ]]; then
+        print_warn "Not removing pam_oidc.so: these PAM service files still reference it:"
+        printf '    %s\n' "${remaining[@]}"
+        print_warn "A stack that names a module which is not there fails that module, and with 'auth requisite pam_deny.so' below it that means every login is refused."
+        MODULE_LEFT_INSTALLED=1
+        return
+    fi
+
+    while IFS= read -r dir; do
+        if [[ -f "$dir/pam_oidc.so" ]]; then
+            rm -f "$dir/pam_oidc.so"
+            print_info "PAM module removed: $dir/pam_oidc.so"
+            removed=1
+        fi
+    done < <(pam_module_candidate_dirs)
+
+    if [[ "$removed" -eq 0 ]]; then
+        print_info "No pam_oidc.so found to remove"
     fi
 }
 
 # Remove configuration and data
 remove_config() {
     print_info "Removing configuration and data..."
-    
+
     # Ask user about configuration removal
     read -p "Remove configuration directory $CONFIG_DIR? [y/N]: " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ -d "$CONFIG_DIR" ]]; then
-            rm -rf "$CONFIG_DIR"
+            rm -rf -- "$CONFIG_DIR"
             print_info "Configuration directory removed"
         fi
     else
-        print_info "Configuration directory preserved"
+        print_warn "Configuration directory preserved -- $CONFIG_DIR/broker.yaml holds the token encryption key and your client secrets"
     fi
-    
+
     # Ask user about log removal
     read -p "Remove log directory $LOG_DIR? [y/N]: " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ -d "$LOG_DIR" ]]; then
-            rm -rf "$LOG_DIR"
+            rm -rf -- "$LOG_DIR"
             print_info "Log directory removed"
         fi
     else
         print_info "Log directory preserved"
     fi
-    
+
     # Remove runtime directory
     if [[ -d "$RUN_DIR" ]]; then
-        rm -rf "$RUN_DIR"
+        rm -rf -- "$RUN_DIR"
         print_info "Runtime directory removed"
     fi
 }
 
-# Remove user
-remove_user() {
-    print_info "Removing user..."
-    
-    # Ask user about user removal
-    read -p "Remove oidc-auth user? [y/N]: " -n 1 -r
+# Remove the broker's own state: the SSH private keys it issued to users, and the
+# per-user write locks. The old script never touched this, so every key the broker
+# had ever issued stayed on disk after an uninstall.
+remove_state() {
+    if [[ ! -d "$STATE_DIR" ]]; then
+        return
+    fi
+
+    print_warn "$STATE_DIR holds the SSH private keys the broker issued to users."
+    read -p "Remove $STATE_DIR? [y/N]: " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        if id "oidc-auth" &>/dev/null; then
-            userdel oidc-auth
-            print_info "User oidc-auth removed"
-        fi
+        rm -rf -- "$STATE_DIR"
+        print_info "Broker state directory removed"
     else
-        print_info "User oidc-auth preserved"
+        print_warn "State directory preserved -- the private keys it issued stay on disk"
     fi
 }
 
-# Clean up temporary files
-cleanup() {
-    print_info "Cleaning up temporary files..."
-    
-    # Remove any temporary files
-    rm -f /tmp/oidc-auth-*
-    rm -f /tmp/pam_oidc-*
-    
-    print_info "Cleanup completed"
+# The numeric owner of $1, without following a symlink. Prints nothing on failure.
+path_owner_uid() {
+    stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null || true
+}
+
+# Remove the authorized_keys entries the broker wrote.
+#
+# Broker-issued entries are recognisable exactly as the broker recognises them
+# (pkg/ssh/entry.go): a "<user>@oidc-pam-<unix>" comment on the key line, under a
+# "# Added by OIDC PAM on <time>" provenance line. A key the user put there
+# themselves has neither and is left alone. They also carry expiry-time=, so sshd
+# stops honouring them by itself -- this is about not leaving them behind.
+#
+# This runs as root over paths the account being swept controls, which is the
+# defect class #204/#225 covers on the broker side: `ln -s /etc/shadow
+# ~/.ssh/authorized_keys` would otherwise have root copy that file into the user's
+# home and then overwrite it with the filtered output. So neither ~/.ssh nor the
+# file itself may be a symlink, and both must belong to the account whose keys
+# these are -- the same conditions sshd's own StrictModes applies before reading
+# the file. A shell cannot do this without a check-then-use window (there is no
+# openat(2) here); the window is between the stat and the rewrite of a path only
+# root and that one account can write to, and the alternative is leaving issued
+# keys on disk. `oidc-admin` is the tool to use for a hostile multi-user host.
+sweep_authorized_keys() {
+    local uid home sshdir path backup owner swept=0
+
+    read -p "Remove broker-issued entries from users' authorized_keys files? [y/N]: " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_warn "authorized_keys files left alone -- broker-issued entries remain until their expiry-time= passes"
+        return
+    fi
+
+    # Fields counted from the right for the home directory: uid and gid sit ahead
+    # of GECOS, but GECOS is the one field that can itself contain a colon, so
+    # $6 is not reliably the home directory while $(NF-1) is.
+    while IFS=$'\t' read -r uid home; do
+        [[ -n "$home" && -d "$home" ]] || continue
+        sshdir="$home/.ssh"
+        path="$sshdir/authorized_keys"
+
+        if [[ -L "$sshdir" || -L "$path" ]]; then
+            print_warn "Skipping $path: it or its .ssh directory is a symlink, and following it as root would rewrite whatever it points at"
+            continue
+        fi
+        [[ -f "$path" ]] || continue
+
+        for owner in "$(path_owner_uid "$sshdir")" "$(path_owner_uid "$path")"; do
+            if [[ "$owner" != "$uid" && "$owner" != "0" ]]; then
+                print_warn "Skipping $path: it is owned by uid ${owner:-unknown}, not by uid $uid or root"
+                continue 2
+            fi
+        done
+
+        grep -q "@oidc-pam-" "$path" || continue
+
+        backup="$path.backup.oidc-uninstall.$TIMESTAMP"
+        cp -p "$path" "$backup"
+        if awk '
+            /^[ \t]*#[ \t]*Added by OIDC PAM on/ { next }
+            { for (i = 1; i <= NF; i++) if (index($i, "@oidc-pam-")) next; print }
+        ' "$backup" > "$path"; then
+            print_info "Swept broker-issued keys from $path (backup: $backup)"
+            swept=1
+        else
+            cp -p "$backup" "$path"
+            print_warn "Could not rewrite $path; restored it from $backup"
+        fi
+    done < <(getent passwd | awk -F: 'NF >= 7 { printf "%s\t%s\n", $3, $(NF-1) }')
+
+    if [[ "$swept" -eq 0 ]]; then
+        print_info "No broker-issued authorized_keys entries found"
+    fi
+}
+
+# Remove the leftover oidc-auth service account.
+#
+# Nothing has run as it since #200: the broker runs as root -- it has to, because
+# on a successful login it writes into an arbitrary account's ~/.ssh and hands the
+# file over -- and installers up to v0.4.2 nonetheless created this account and
+# gave it the socket and log directories, which is a privilege boundary pointing
+# the wrong way. Only a host installed by one of those versions has the account,
+# so it is offered for removal rather than assumed to exist.
+remove_user() {
+    if ! id "oidc-auth" &>/dev/null; then
+        return
+    fi
+
+    print_warn "The oidc-auth account exists from an install before v0.5.1. Nothing runs as it and nothing is owned by it any more."
+    read -p "Remove the oidc-auth user? [y/N]: " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        if userdel oidc-auth; then
+            print_info "User oidc-auth removed"
+        else
+            print_warn "userdel failed; check whether any file is still owned by oidc-auth (find / -user oidc-auth)"
+        fi
+    else
+        USER_LEFT_BEHIND=1
+        print_info "User oidc-auth preserved"
+    fi
 }
 
 # Print uninstallation summary
@@ -181,18 +561,30 @@ print_summary() {
     echo ""
     echo "Removed components:"
     echo "- Binaries from $INSTALL_DIR"
-    echo "- PAM module from $PAM_DIR"
+    if [[ "$MODULE_LEFT_INSTALLED" -eq 0 ]]; then
+        echo "- PAM module (pam_oidc.so)"
+    fi
     echo "- Systemd service"
-    echo "- PAM configuration (backed up)"
+    echo "- OIDC lines from the PAM service files that had them (each backed up)"
     echo ""
     echo "Preserved (if chosen):"
     echo "- Configuration: $CONFIG_DIR"
     echo "- Logs: $LOG_DIR"
-    echo "- User: oidc-auth"
+    echo "- Broker state: $STATE_DIR"
+    [[ "$USER_LEFT_BEHIND" -eq 1 ]] && echo "- User: oidc-auth (from an install before v0.5.1; nothing runs as it)"
     echo ""
-    echo "Manual cleanup may be required for:"
-    echo "- Custom PAM configurations"
-    echo "- SSH configuration changes"
+
+    if [[ "$PAM_CLEANUP_INCOMPLETE" -eq 1 || "$MODULE_LEFT_INSTALLED" -eq 1 ]]; then
+        print_warn "THIS UNINSTALL IS NOT FINISHED."
+        [[ "$PAM_CLEANUP_INCOMPLETE" -eq 1 ]] && print_warn "At least one PAM file was left as it was, because taking OIDC out of it would have refused every login. See the [WARN] lines above."
+        [[ "$MODULE_LEFT_INSTALLED" -eq 1 ]] && print_warn "pam_oidc.so is still installed, deliberately: a PAM stack still references it."
+        echo ""
+    fi
+
+    echo "Before you close your last session, test a login for every service you"
+    echo "changed. Manual cleanup may still be needed for:"
+    echo "- PAM stacks this script would not edit (listed above, if any)"
+    echo "- SSH configuration changes (UsePAM, KbdInteractiveAuthentication)"
     echo "- Firewall rules"
     echo ""
     echo "To reinstall, run: ./scripts/install.sh"
@@ -201,9 +593,9 @@ print_summary() {
 # Main uninstallation function
 main() {
     print_info "Starting OIDC PAM uninstallation..."
-    
+
     check_root
-    
+
     # Confirmation
     echo "This will remove OIDC PAM authentication system from your system."
     read -p "Are you sure you want to continue? [y/N]: " -n 1 -r
@@ -212,17 +604,28 @@ main() {
         print_info "Uninstallation cancelled"
         exit 0
     fi
-    
+
     stop_services
+    # PAM first, and the module only once no stack references it: order is the
+    # whole safety property here.
     remove_pam_config
     remove_binaries
     remove_config
+    remove_state
+    sweep_authorized_keys
     remove_user
-    cleanup
     print_summary
-    
+
+    if [[ "$PAM_CLEANUP_INCOMPLETE" -eq 1 || "$MODULE_LEFT_INSTALLED" -eq 1 ]]; then
+        print_warn "Uninstallation finished with manual steps outstanding (see above)."
+        exit 1
+    fi
     print_info "Uninstallation completed successfully!"
 }
 
-# Run main function
-main "$@"
+# Sourcing this file defines the functions and runs nothing, so the PAM logic
+# above can be exercised against a temporary PAM_D_DIR
+# (test/scripts/test-pam-wiring.sh) rather than the host's real stack.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/test/e2e/Dockerfile.broker
+++ b/test/e2e/Dockerfile.broker
@@ -40,7 +40,12 @@ RUN mkdir -p /etc/fakeoidc /etc/oidc-auth \
     && cp /etc/fakeoidc/tls.crt /etc/oidc-auth/fakeoidc.crt
 
 COPY --from=builder /out/oidc-auth-broker /out/oidc-admin /out/fakeoidc /usr/local/bin/
-COPY test/e2e/broker.yaml /etc/oidc-auth/broker.yaml
+# --chmod=600, because COPY's default is 0644 and the broker now refuses to start
+# on a configuration any local process can read (#209) — it holds the token
+# encryption key and every client secret. The harness runs the real check rather
+# than setting OIDC_AUTH_DEV=true to opt out of it: this container is where the
+# broker is started the way a host starts it.
+COPY --chmod=600 test/e2e/broker.yaml /etc/oidc-auth/broker.yaml
 
 # The broker writes SSH keys and its authorized_keys write locks here (locks/ is
 # root-owned and unreachable from the client container, which is the point of

--- a/test/scripts/test-pam-wiring.sh
+++ b/test/scripts/test-pam-wiring.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+#
+# Tests the PAM-editing logic of scripts/install.sh and scripts/uninstall.sh
+# against a throwaway /etc/pam.d, without installing or uninstalling anything.
+#
+# Both scripts only run main() when executed, so this sources them and calls the
+# functions directly with PAM_D_DIR pointed at a temporary directory. Nothing here
+# touches the host's real PAM stack, needs root, or needs a Linux host.
+#
+# The case that matters most is "uninstall refuses to break the OIDC-only stack":
+# scripts/uninstall.sh used to delete every pam_oidc.so line from /etc/pam.d/sshd,
+# which on the stack configs/pam/ssh ships left 'auth requisite pam_deny.so' as
+# the whole auth phase and refused every login, for every user, permanently
+# (#207).
+#
+# Usage: test/scripts/test-pam-wiring.sh
+
+# The assertion predicates are invoked through check(), and the print_* overrides
+# are invoked by the sourced scripts, so shellcheck can see no call site for
+# either. CONFIGURE_PAM and PAM_D_DIR are likewise read by the sourced scripts
+# rather than by anything here.
+# shellcheck disable=SC2329,SC2034
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+FAILURES=0
+CASES=0
+
+check() { # check <description> <command...>
+    local desc="$1"
+    shift
+    CASES=$((CASES + 1))
+    if "$@" >/dev/null 2>&1; then
+        printf '  ok: %s\n' "$desc"
+    else
+        printf '  FAIL: %s\n' "$desc"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Predicates, so every assertion is a command and not a bare condition.
+not()      { ! "$@"; }
+lt()       { [[ "$1" -lt "$2" ]]; }
+gt()       { [[ "$1" -gt "$2" ]]; }
+eq()       { [[ "$1" -eq "$2" ]]; }
+contents() { [[ "$(cat "$1")" == "$2" ]]; }
+exists()   { compgen -G "$1" >/dev/null; }
+line_of()  { grep -n "$1" "$2" | head -1 | cut -d: -f1; }
+
+# Sourcing order matters only for the shared print_* helpers, which are identical
+# in both scripts.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/install.sh"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/uninstall.sh"
+
+# Collect the scripts' output rather than printing it; the assertions read it.
+LOG="$(mktemp)"
+print_info()  { echo "[INFO] $1" >> "$LOG"; }
+print_warn()  { echo "[WARN] $1" >> "$LOG"; }
+print_error() { echo "[ERROR] $1" >> "$LOG"; return 1; }
+
+new_pam_dir() {
+    PAM_D_DIR="$(mktemp -d)"
+    : > "$LOG"
+    # Both installers require --configure-pam before they will touch a PAM stack;
+    # every case below except "the default does not touch PAM" is testing what
+    # happens once the operator has asked for it.
+    CONFIGURE_PAM=1
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+write_ubuntu_sshd() {
+    cat > "$PAM_D_DIR/sshd" <<'EOF'
+# PAM configuration for the Secure Shell service
+
+# Standard Un*x authentication.
+@include common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+@include common-account
+@include common-session
+EOF
+}
+
+write_rhel_style_sshd() {
+    cat > "$PAM_D_DIR/sshd" <<'EOF'
+#%PAM-1.0
+auth        required                                      pam_env.so
+auth        required                                      pam_faillock.so preauth silent deny=4
+auth        [default=1 ignore=ignore success=ok]           pam_succeed_if.so uid >= 1000 quiet
+auth        sufficient                                    pam_unix.so nullok
+auth        required                                      pam_faillock.so authfail deny=4
+auth        required                                      pam_deny.so
+account     required                                      pam_unix.so
+EOF
+}
+
+# --- cases ------------------------------------------------------------------
+
+echo "case: without --configure-pam neither installer touches the stack"
+new_pam_dir
+write_ubuntu_sshd
+original="$(cat "$PAM_D_DIR/sshd")"
+CONFIGURE_PAM=0
+PAM_WIRING_SKIPPED=0
+configure_pam > /dev/null
+check "file untouched" contents "$PAM_D_DIR/sshd" "$original"
+check "no backup written" not exists "$PAM_D_DIR/sshd.backup.*"
+check "wiring reported as skipped" eq "$PAM_WIRING_SKIPPED" 1
+check "told the operator which flag to pass" grep -q -- '--configure-pam' "$LOG"
+
+echo "case: install inserts before the auth phase Ubuntu delegates to common-auth"
+new_pam_dir
+write_ubuntu_sshd
+configure_pam > /dev/null
+check "pam_oidc.so added" grep -q 'pam_oidc.so' "$PAM_D_DIR/sshd"
+check "OIDC line precedes @include common-auth" \
+    lt "$(line_of 'pam_oidc.so' "$PAM_D_DIR/sshd")" "$(line_of '@include common-auth' "$PAM_D_DIR/sshd")"
+check "control is 'sufficient', so a dead broker falls through" \
+    grep -q '^auth[[:space:]]*sufficient[[:space:]]*pam_oidc.so' "$PAM_D_DIR/sshd"
+check "a backup was taken" exists "$PAM_D_DIR/sshd.backup.*"
+
+echo "case: uninstall puts an installer-edited file back byte for byte"
+before="$(cat "$PAM_D_DIR"/sshd.backup.*)"
+PAM_CLEANUP_INCOMPLETE=0
+remove_pam_config
+check "no pam_oidc.so left" not grep -q 'pam_oidc.so' "$PAM_D_DIR/sshd"
+check "file is identical to the pre-install content" contents "$PAM_D_DIR/sshd" "$before"
+check "cleanup reported complete" eq "$PAM_CLEANUP_INCOMPLETE" 0
+
+echo "case: install goes after the pam_faillock preauth prologue, not at line 1 (#220)"
+new_pam_dir
+write_rhel_style_sshd
+configure_pam > /dev/null
+check "OIDC line follows pam_faillock preauth" \
+    gt "$(line_of 'pam_oidc.so' "$PAM_D_DIR/sshd")" "$(line_of 'pam_faillock.so preauth' "$PAM_D_DIR/sshd")"
+check "OIDC line precedes pam_unix.so" \
+    lt "$(line_of 'pam_oidc.so' "$PAM_D_DIR/sshd")" "$(line_of 'pam_unix.so nullok' "$PAM_D_DIR/sshd")"
+
+echo "case: uninstall refuses to reduce the OIDC-only stack to pam_deny.so (#207)"
+new_pam_dir
+cp "$REPO_ROOT/configs/pam/ssh" "$PAM_D_DIR/sshd"
+cp "$REPO_ROOT/configs/pam/sudo" "$PAM_D_DIR/sudo"
+cp "$REPO_ROOT/configs/pam/su" "$PAM_D_DIR/su"
+original="$(cat "$PAM_D_DIR/sshd")"
+PAM_CLEANUP_INCOMPLETE=0
+remove_pam_config
+check "sshd left exactly as it was" contents "$PAM_D_DIR/sshd" "$original"
+check "cleanup reported incomplete" eq "$PAM_CLEANUP_INCOMPLETE" 1
+check "the operator was told what to do by hand" grep -q 'Finish by hand' "$LOG"
+check "sudo was considered too, not just sshd" grep -q "$PAM_D_DIR/sudo" "$LOG"
+check "su was considered too" grep -q "$PAM_D_DIR/su" "$LOG"
+MODULE_LEFT_INSTALLED=0
+remove_pam_module > /dev/null
+check "the module is left installed while stacks reference it" eq "$MODULE_LEFT_INSTALLED" 1
+
+echo "case: the harness stack (test/e2e/pam-sshd) is refused the same way"
+new_pam_dir
+cp "$REPO_ROOT/test/e2e/pam-sshd" "$PAM_D_DIR/sshd"
+original="$(cat "$PAM_D_DIR/sshd")"
+PAM_CLEANUP_INCOMPLETE=0
+remove_pam_config
+check "left exactly as it was" contents "$PAM_D_DIR/sshd" "$original"
+check "cleanup reported incomplete" eq "$PAM_CLEANUP_INCOMPLETE" 1
+
+echo "case: uninstall falls back to the installer's backup when stripping is unsafe"
+new_pam_dir
+write_ubuntu_sshd
+cp "$PAM_D_DIR/sshd" "$PAM_D_DIR/sshd.backup.20260101-000000"
+# An OIDC-only stack, as if the operator had later copied configs/pam/ssh over it.
+cp "$REPO_ROOT/configs/pam/ssh" "$PAM_D_DIR/sshd"
+PAM_CLEANUP_INCOMPLETE=0
+remove_pam_config
+check "restored from the pre-install backup" grep -q '@include common-auth' "$PAM_D_DIR/sshd"
+check "no pam_oidc.so left" not grep -q 'pam_oidc.so' "$PAM_D_DIR/sshd"
+check "cleanup reported complete" eq "$PAM_CLEANUP_INCOMPLETE" 0
+
+echo "case: install refuses a stack it does not recognise, and prints the line (#220)"
+new_pam_dir
+printf 'auth required pam_something_local.so\nauth required pam_unix.so\n' > "$PAM_D_DIR/sshd"
+original="$(cat "$PAM_D_DIR/sshd")"
+PAM_WIRING_SKIPPED=0
+configure_pam > /dev/null
+check "file untouched" contents "$PAM_D_DIR/sshd" "$original"
+check "no backup written for a file it did not edit" not exists "$PAM_D_DIR/sshd.backup.*"
+check "wiring reported as skipped" eq "$PAM_WIRING_SKIPPED" 1
+check "printed the exact line it would have added" grep -q 'auth    sufficient  pam_oidc.so' "$LOG"
+
+echo "case: a file with no auth phase at all is refused"
+new_pam_dir
+printf 'account required pam_unix.so\nsession required pam_unix.so\n' > "$PAM_D_DIR/sshd"
+PAM_WIRING_SKIPPED=0
+configure_pam > /dev/null
+check "wiring reported as skipped" eq "$PAM_WIRING_SKIPPED" 1
+check "file untouched" not grep -q 'pam_oidc.so' "$PAM_D_DIR/sshd"
+
+echo "case: installing twice is a no-op"
+new_pam_dir
+write_ubuntu_sshd
+configure_pam > /dev/null
+after_first="$(cat "$PAM_D_DIR/sshd")"
+configure_pam > /dev/null
+check "second run changed nothing" contents "$PAM_D_DIR/sshd" "$after_first"
+check "only one pam_oidc.so line" eq "$(grep -c 'pam_oidc.so' "$PAM_D_DIR/sshd")" 1
+
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo "all $CASES assertions passed"
+    exit 0
+fi
+echo "$FAILURES of $CASES assertions failed"
+exit 1


### PR DESCRIPTION
Four defects in the install path. Each of them ends with a host nobody can log in to, or a secret every local user can read.

Closes #207, closes #208, closes #209, closes #220. **Closes #200** — the broker-side half landed in #239; this is the installer half it was left open for.

## #208 — the module was written where PAM never looks

Every release up to v0.4.2 put `pam_oidc.so` in `/lib/security`. That directory exists on neither Debian/Ubuntu (`/lib/<triplet>/security`) nor RHEL-family systems (`/lib64/security`), so the install aborted part-way through — *after* the binaries were in place — and if an operator created the directory to get past that, the module sat somewhere PAM never loads from.

That is not a no-op. With the stack this project ships, the unresolvable `sufficient` line fails and the login falls through to `auth requisite pam_deny.so`: every login refused. On a stack with a password fallback it means OIDC silently never runs while the operator believes it is enforced.

Both installers now ask dpkg/rpm where `pam_permit.so` is (a module libpam itself ships, so a directory holding it is a directory PAM loads from), fall back to probing the known layouts, and do it **before anything is written**. If they cannot find it they refuse to install. `make install` and `make install-dev` resolve it through the same implementation instead of hardcoding a path. `PAM_MODULE_DIR` overrides, with a warning that PAM only loads from its own compiled-in path.

## #220 — insertion at line 1, unconditionally

Both installers did `sed -i '2iauth sufficient pam_oidc.so'`. Ahead of a `pam_faillock.so preauth` entry that breaks failure counting on RHEL-family systems; ahead of `pam_nologin.so`, `pam_access.so` or `pam_securetty.so` it makes those gates unreachable, because a `sufficient` module that succeeds ends the auth phase before them.

They now walk the auth phase, allow a known prologue to stay in front, insert immediately before the first module that authenticates or terminates (`pam_unix.so` and friends, `pam_deny.so`, or an include/substack of a shared stack), and **refuse outright on a stack they do not recognise** — printing the exact line for the operator to place by hand. The added line is fenced in `# BEGIN oidc-pam` / `# END oidc-pam` so the uninstaller removes exactly what was added.

`scripts/install.sh` also stops editing PAM unless `--configure-pam` is passed. `install-release.sh` already required it; the two disagreeing is how one of them gets fixed and the other forgotten.

## #207 — the uninstaller locked the host out and reported success

`scripts/uninstall.sh` ran `sed -i '/pam_oidc.so/d' /etc/pam.d/sshd`. On the stack this repository itself ships (`configs/pam/ssh`: `auth sufficient pam_oidc.so` followed by `auth requisite pam_deny.so`) that leaves `pam_deny.so` as the entire auth phase — every SSH authentication refused, for every user, permanently — while printing `Uninstallation completed successfully!`. It edited sshd alone, so a host that had followed `configs/pam/README.md` was also left with `su` and `sudo` naming a module that had just been deleted, and no way to escalate and repair it.

It now, in order:

1. removes the OIDC lines from **every** `/etc/pam.d` file that references them, the fenced block by preference;
2. checks the resulting auth phase still has something that can authenticate, and restores the installer's pre-install backup if it does not (the old script wrote a backup and then never used it);
3. if there is no usable backup either, leaves the file **exactly as it was**, says so loudly, exits non-zero, and leaves `pam_oidc.so` installed so the stack keeps working. Removing the `.so` out from under a stack that still names it is the same lockout by another route.

## #209 — the config was world-readable and the check only warned

Both installers wrote `/etc/oidc-auth/broker.yaml` at `0644`: the AES-256 token encryption key and every client secret, readable by every local user on exactly the kind of multi-user host this product exists for. `LoadConfig` did check the mode — and logged one `WARNING` line to stderr and served anyway, having just validated the key for strength before publishing it. Its mask (`0137`) did not even catch group-read.

Now `0600 root:root` at install time, and **fatal** at load time (`OIDC_AUTH_DEV=true` overrides for development). A file mode is not something an operator can be warned about once at startup and expected to notice.

## #200, installer half

Neither installer creates an `oidc-auth` account any more, and nothing is chowned to one. The broker runs as `User=root` — it has to, since on a successful login it writes into an arbitrary account's `~/.ssh` and hands the file over — so an unprivileged account owning the socket directory is a privilege boundary pointing the wrong way: `unlink(2)` + `bind(2)` installs an impostor at the same path that every PAM login then talks to, while the real broker serves on its unlinked inode and stays green in `systemctl status`.

`$LOG_DIR` and `broker.log` were chowned the same way, which is a root process appending to a file an unprivileged account can replace with a symlink. Both are now root-owned. A leftover account from an earlier install produces a warning, not a silent `userdel`.

## Adjacent, and deliberately in the same lines

- **`uninstall.sh` sweeps what the broker left behind** — the `authorized_keys` entries it issued (recognised exactly as `pkg/ssh/entry.go` recognises them) and `/var/lib/oidc-pam`, which holds the private keys. Neither was touched before, so every key the broker had ever issued survived an uninstall. The sweep refuses a `~/.ssh` or `authorized_keys` that is a symlink, or that belongs to neither the account nor root: root following a user-controlled path is #204/#225 by another route. The residual check-then-use window is called out in a comment — a shell has no `openat(2)`.
- **`test/scripts/test-pam-wiring.sh`** exercises both scripts' PAM logic against a throwaway `/etc/pam.d` — no root, no PAM headers, nothing installed — and CI now runs it plus `shellcheck --severity=warning` over `scripts/`. 32 assertions. Neutering `pam_auth_phase_authenticates` makes the #207 case fail, so the guard is not vacuous. Two pre-existing shellcheck warnings in unrelated scripts are fixed so the gate can cover all of `scripts/`.
- **`configs/pam/login`** had `pam_nologin.so` and `pam_group.so` *below* a `sufficient` line, so for any user OIDC admitted, `/etc/nologin` was ignored and `pam_group` never ran at all. Reordered, with plain control flags and no numeric jumps — `[success=N default=ignore]` encodes a line count that silently changes meaning when a line is added, which is the #122/#172 fragility.
- **Docs**: `DEPLOYMENT.md`, `REQUIREMENTS.md` and `configs/pam/README.md` all documented the `/lib/security` path and the `oidc-auth` ownership this change removes, so a host built by following the guide carried both defects.

## Not fixed here

`scripts/build-releases.sh` and `scripts/build-simple.sh` each emit their own installer into a tarball, carrying all four of these defects. Nothing references either script — not the Makefile, not CI, not the docs; `release.yml` packages `scripts/install-release.sh`. Rewriting two dead scripts is worse than filing it, so it is filed separately.

## Verification

- `go build ./... && go vet ./... && go test ./...` clean; `gofmt -s -l .` empty.
- `test/scripts/test-pam-wiring.sh`: 32/32.
- `shellcheck --severity=warning scripts/*.sh test/scripts/*.sh` clean.
- Non-vacuity: with `pam_auth_phase_authenticates` forced to succeed, the #207 case fails on 3 of its 6 assertions; the file was restored byte-exact afterwards (`diff -q`).
- The `make install` recipe expansion was checked with `make -n`, and the resolver verified to abort with the `PAM_MODULE_DIR` advice on a host with no libpam (this macOS one) and to honour the override.