### PR TITLE
fix(ipc): count the requests that never reach a handler, and run the tests that prove it (#189)

### DIFF
--- a/internal/ipc/admin_test.go
+++ b/internal/ipc/admin_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/scttfrdmn/oidc-pam/pkg/config"
 )
 
-// newAdminTestServer builds a server over a real broker. The provider uses
-// skip_discovery with explicit endpoints so that constructing it makes no
-// network calls.
+// newAdminTestServer builds a server over a real broker.
 func newAdminTestServer(t *testing.T) (*Server, *auth.Broker) {
 	t.Helper()
 
@@ -28,8 +26,31 @@ func newAdminTestServer(t *testing.T) (*Server, *auth.Broker) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
 
+	broker := newTestBroker(t)
+
+	server, err := NewServer(filepath.Join(tempDir, "ipc.sock"), broker, 0660, "", false, 0, 0)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Stop() })
+
+	return server, broker
+}
+
+// newTestBroker builds a real broker whose provider uses skip_discovery with
+// explicit endpoints, so that constructing it — and every request the tests send
+// through it that does not talk to the provider — makes no network calls.
+//
+// It exists because a nil broker is not good enough for the socket-level tests: a
+// request that survives validation reaches a handler, and a handler dereferences the
+// broker. The one test that was meant to prove the socket rate-limits a flood sent a
+// request that could not survive validation, which is how it came to assert the
+// validator's behaviour while its name claimed the limiter's (#189).
+func newTestBroker(t *testing.T) *auth.Broker {
+	t.Helper()
+
 	cfg := &config.Config{
-		Server: config.ServerConfig{SocketPath: filepath.Join(tempDir, "broker.sock")},
+		Server: config.ServerConfig{SocketPath: filepath.Join(t.TempDir(), "broker.sock")},
 		OIDC: config.OIDCConfig{
 			Providers: []config.OIDCProvider{
 				{
@@ -60,13 +81,7 @@ func newAdminTestServer(t *testing.T) (*Server, *auth.Broker) {
 		t.Fatalf("NewBroker: %v", err)
 	}
 
-	server, err := NewServer(filepath.Join(tempDir, "ipc.sock"), broker, 0660, "", false, 0, 0)
-	if err != nil {
-		t.Fatalf("NewServer: %v", err)
-	}
-	t.Cleanup(func() { _ = server.Stop() })
-
-	return server, broker
+	return broker
 }
 
 // The three admin request types must be routed, not rejected. Before this they

--- a/internal/ipc/peer_creds_linux.go
+++ b/internal/ipc/peer_creds_linux.go
@@ -7,20 +7,22 @@ import (
 	"net"
 )
 
-// verifyPeerCredentials checks that the connecting process is running as root (UID 0).
-// PAM modules always run as root, so non-root connections are rejected.
+// verifyPeerCredentials checks that the connecting process is running as root (UID 0)
+// and returns its uid. PAM modules always run as root, so non-root connections are
+// rejected. The uid is returned so the caller can key a peer's malformed-request
+// budget on it (#189).
 //
 // The kernel lookup itself lives in getPeerCredentials so there is exactly one of
 // it: this function used to carry its own copy of the SO_PEERCRED call, and the two
 // copies drifted — one of them reached the descriptor in a way that disabled the
 // connection's read deadline (#216).
-func verifyPeerCredentials(conn net.Conn) error {
+func verifyPeerCredentials(conn net.Conn) (uint32, error) {
 	uid, _, err := getPeerCredentials(conn)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if uid != 0 {
-		return fmt.Errorf("peer UID %d is not root", uid)
+		return uid, fmt.Errorf("peer UID %d is not root", uid)
 	}
-	return nil
+	return uid, nil
 }

--- a/internal/ipc/peer_creds_other.go
+++ b/internal/ipc/peer_creds_other.go
@@ -10,9 +10,9 @@ import (
 // verifyPeerCredentials is a stub on non-Linux platforms.
 // SO_PEERCRED peer verification is only supported on Linux.
 // Deploy this service on Linux in production.
-func verifyPeerCredentials(conn net.Conn) error {
+func verifyPeerCredentials(conn net.Conn) (uint32, error) {
 	if conn == nil {
-		return fmt.Errorf("nil connection")
+		return 0, fmt.Errorf("nil connection")
 	}
-	return fmt.Errorf("peer credential verification not supported on this platform; deploy on Linux")
+	return 0, fmt.Errorf("peer credential verification not supported on this platform; deploy on Linux")
 }

--- a/internal/ipc/ratelimit.go
+++ b/internal/ipc/ratelimit.go
@@ -1,6 +1,7 @@
 package ipc
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -145,7 +146,7 @@ func NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths int) *RateLimiter {
 		malformedMaxTokens:  malformedPerMinute,
 		malformedRefillRate: malformedPerMinute / 60.0,
 		buckets:             make(map[string]*bucket),
-		maxConcurrentAuths:  int32(maxConcurrentAuths),
+		maxConcurrentAuths:  clampToInt32(maxConcurrentAuths),
 		stopChan:            make(chan struct{}),
 	}
 
@@ -239,6 +240,27 @@ func (rl *RateLimiter) makeRoom() {
 			Int("tracked", len(rl.buckets)).
 			Msg("Rate-limit bucket map full; evicted the least recently used bucket")
 	}
+}
+
+// clampToInt32 narrows n to the range concurrentAuths can actually count in,
+// saturating instead of wrapping.
+//
+// The plain conversion this replaces was a fail-open. maxConcurrentAuths comes
+// from `security.rate_limiting.max_concurrent_auths`, which pkg/config reads as an
+// int and does not bound above; on a 64-bit host a configured 2147483648 wrapped
+// to -2147483648, and AcquireAuth reads any value <= 0 as "limit disabled". So a
+// config asking for a very large cap got *no* cap — the one reading of that number
+// nobody writing it intends. Saturated, an absurd value still gets the largest
+// bound an atomic.Int32 can express.
+func clampToInt32(n int) int32 {
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if n < math.MinInt32 {
+		return math.MinInt32
+	}
+	// #nosec G115 -- the two guards above are the bounds check; n is in int32 range here.
+	return int32(n)
 }
 
 // AcquireAuth attempts to increment the concurrent auth counter. Returns false

--- a/internal/ipc/ratelimit.go
+++ b/internal/ipc/ratelimit.go
@@ -25,6 +25,18 @@ const (
 	// ClassSession is the budget for check_session, refresh_session and
 	// revoke_session: requests about a session that already exists.
 	ClassSession RateClass = "session"
+
+	// ClassMalformed is the budget for requests no handler ever sees: a body that
+	// would not decode, or one validateRequest refused.
+	//
+	// (#189) It is keyed on the peer's uid, not on an account, because a request
+	// that failed validation has no account to key on — its user_id may be absent,
+	// or 64 KiB of anything the sender likes, which is also why the account budgets
+	// cannot simply be charged first: maxTrackedAccounts below relies on
+	// validateRequest having already bounded every key to 32 characters of
+	// [a-z0-9_-], and keying the map on an unvalidated field would let one peer fill
+	// it with keys of its own choosing and length.
+	ClassMalformed RateClass = "malformed"
 )
 
 const (
@@ -38,6 +50,18 @@ const (
 	// property whose absence is the bug: the budget let a login start and then
 	// refused it partway through.
 	pollsPerAuthentication = 20
+
+	// malformedPerAuthentication is the malformed-request budget as a multiple of the
+	// authenticate budget: the same size, deliberately.
+	//
+	// A correct client sends no malformed requests at all — pam_oidc builds its JSON
+	// from fixed fields — so any budget above zero is generous, and every peer shares
+	// this one bucket because every peer's uid is 0 (verifyPeerCredentials rejects
+	// anything else). Sharing is what made the host-wide bucket in #160 a bug, and it
+	// is safe here only because of what is charged to it: a request that decodes and
+	// validates is charged to its own per-account bucket instead, so exhausting this
+	// one cannot refuse a login (#189).
+	malformedPerAuthentication = 1
 
 	// maxTrackedAccounts bounds the bucket map. The keys are attacker-influenced
 	// (a request names the account it wants to log in as), so the map needs a
@@ -76,12 +100,18 @@ type bucket struct {
 // spending the budget of an account they name deliberately; closing that needs a
 // second key the client does not choose (source_ip, #169) and the pending-flow
 // accounting in #163.
+//
+// ClassMalformed is the one exception, and is keyed on the peer's uid: a request
+// that never decoded or never validated names no account that could be used as a
+// key. Before it existed, malformed requests were charged to nothing at all (#189).
 type RateLimiter struct {
 	// Token bucket parameters, per class.
-	maxTokens         float64 // burst size (== MaxRequestsPerMinute)
-	refillRate        float64 // tokens per second
-	sessionMaxTokens  float64
-	sessionRefillRate float64
+	maxTokens           float64 // burst size (== MaxRequestsPerMinute)
+	refillRate          float64 // tokens per second
+	sessionMaxTokens    float64
+	sessionRefillRate   float64
+	malformedMaxTokens  float64
+	malformedRefillRate float64
 
 	mu      sync.Mutex
 	buckets map[string]*bucket
@@ -101,18 +131,22 @@ type RateLimiter struct {
 //
 // maxRequestsPerMinute is the budget for new authentications, per account.
 // Session requests get pollsPerAuthentication times as many, since one
-// authentication is followed by many of them.
+// authentication is followed by many of them. Malformed requests get
+// malformedPerAuthentication times as many, per peer uid.
 func NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths int) *RateLimiter {
 	sessionPerMinute := float64(maxRequestsPerMinute) * pollsPerAuthentication
+	malformedPerMinute := float64(maxRequestsPerMinute) * malformedPerAuthentication
 
 	rl := &RateLimiter{
-		maxTokens:          float64(maxRequestsPerMinute),
-		refillRate:         float64(maxRequestsPerMinute) / 60.0,
-		sessionMaxTokens:   sessionPerMinute,
-		sessionRefillRate:  sessionPerMinute / 60.0,
-		buckets:            make(map[string]*bucket),
-		maxConcurrentAuths: int32(maxConcurrentAuths),
-		stopChan:           make(chan struct{}),
+		maxTokens:           float64(maxRequestsPerMinute),
+		refillRate:          float64(maxRequestsPerMinute) / 60.0,
+		sessionMaxTokens:    sessionPerMinute,
+		sessionRefillRate:   sessionPerMinute / 60.0,
+		malformedMaxTokens:  malformedPerMinute,
+		malformedRefillRate: malformedPerMinute / 60.0,
+		buckets:             make(map[string]*bucket),
+		maxConcurrentAuths:  int32(maxConcurrentAuths),
+		stopChan:            make(chan struct{}),
 	}
 
 	rl.wg.Add(1)
@@ -126,12 +160,10 @@ func NewRateLimiter(maxRequestsPerMinute, maxConcurrentAuths int) *RateLimiter {
 // (maxTokens <= 0), it always returns true.
 //
 // An empty account is a valid key: it is the one every request that names no
-// account shares, and there is no reason to exempt it.
+// account shares, and there is no reason to exempt it. For ClassMalformed the
+// second argument is the peer's uid rather than an account (#189).
 func (rl *RateLimiter) Allow(class RateClass, account string) bool {
-	maxTokens, refillRate := rl.maxTokens, rl.refillRate
-	if class == ClassSession {
-		maxTokens, refillRate = rl.sessionMaxTokens, rl.sessionRefillRate
-	}
+	maxTokens, refillRate := rl.limitsFor(class)
 	if maxTokens <= 0 {
 		return true
 	}
@@ -171,6 +203,20 @@ func (rl *RateLimiter) Allow(class RateClass, account string) bool {
 
 	b.tokens--
 	return true
+}
+
+// limitsFor returns the burst size and refill rate of a class's buckets. A class
+// with no configured budget returns the authenticate budget, so a class added
+// without its own parameters is bounded rather than unlimited.
+func (rl *RateLimiter) limitsFor(class RateClass) (maxTokens, refillRate float64) {
+	switch class {
+	case ClassSession:
+		return rl.sessionMaxTokens, rl.sessionRefillRate
+	case ClassMalformed:
+		return rl.malformedMaxTokens, rl.malformedRefillRate
+	default:
+		return rl.maxTokens, rl.refillRate
+	}
 }
 
 // makeRoom frees a slot in a full bucket map: idle buckets first, and failing

--- a/internal/ipc/ratelimit_test.go
+++ b/internal/ipc/ratelimit_test.go
@@ -2,6 +2,7 @@ package ipc
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -189,6 +190,26 @@ func TestConcurrentAuthLimit(t *testing.T) {
 	// Now should succeed again
 	if !rl.AcquireAuth() {
 		t.Fatal("should succeed after release")
+	}
+}
+
+// A concurrency cap larger than an int32 must still be a cap. `int32(n)` wrapped
+// it to a negative number, and AcquireAuth reads <= 0 as "limit disabled", so the
+// largest values an operator could write in the config were the ones that removed
+// the limit entirely. math.MaxInt64 is not a plausible setting; a fat-fingered extra
+// digit on a five-digit one is, and both take the same path (#189).
+func TestAnOversizedConcurrencyCapIsStillACap(t *testing.T) {
+	for _, configured := range []int{math.MaxInt32 + 1, math.MaxInt64} {
+		rl := NewRateLimiter(0, configured)
+		if rl.maxConcurrentAuths <= 0 {
+			t.Errorf("max_concurrent_auths=%d became %d, which AcquireAuth treats as no limit at all",
+				configured, rl.maxConcurrentAuths)
+		}
+		if !rl.AcquireAuth() {
+			t.Errorf("max_concurrent_auths=%d refused the first authentication", configured)
+		}
+		rl.ReleaseAuth()
+		rl.Stop()
 	}
 }
 

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -32,6 +32,11 @@ type Server struct {
 	wg              sync.WaitGroup
 	stopOnce        sync.Once
 	connSem         chan struct{} // bounds concurrent in-flight connections (L-4)
+
+	// peerVerifier, when non-nil, replaces the platform peer-credential check. See
+	// verifyPeer: it exists so this package's socket-level tests can run as an
+	// ordinary user, and is nil in every Server the constructor builds (#189).
+	peerVerifier func(conn net.Conn) (uid uint32, err error)
 }
 
 // maxConcurrentConnections caps the number of simultaneously handled IPC
@@ -321,6 +326,53 @@ func isTransientAcceptError(err error) bool {
 		errors.Is(err, syscall.EAGAIN)
 }
 
+// verifyPeer identifies the process on the other end of conn and rejects any peer
+// the broker must not serve. It returns the peer's uid, which is what malformed
+// requests are charged against.
+//
+// The indirection through s.peerVerifier is a test seam, and it is here because of
+// what its absence cost. verifyPeerCredentials is a Linux-only kernel lookup that
+// requires the peer to be uid 0, so every test that speaks to the socket had to skip
+// unless the suite was running as root on Linux — which CI is not. The one test that
+// asserted the socket rate-limits a flood therefore skipped on every run the project
+// has ever made, was green because it was absent, and hid an ordering that meant no
+// malformed request was ever counted (#189).
+//
+// The field is unexported and left nil by NewServer, so no production path can
+// substitute the check: a Server that was never told otherwise fails closed through
+// verifyPeerCredentials, which on a non-Linux host refuses every connection.
+func (s *Server) verifyPeer(conn net.Conn) (uint32, error) {
+	if s.peerVerifier != nil {
+		return s.peerVerifier(conn)
+	}
+	return verifyPeerCredentials(conn)
+}
+
+// rejectMalformed answers a request that no handler will ever see — one that would
+// not decode, or that validateRequest refused — and charges it against the sending
+// peer's malformed-request budget. Once that budget is spent the peer is told
+// RATE_LIMIT_EXCEEDED instead, and its next well-formed request is unaffected.
+//
+// The budget is consulted after the request has been recognised as malformed rather
+// than before it is read, and that ordering is deliberate: at the earlier point a
+// valid request is indistinguishable from a malformed one, and every peer shares
+// this bucket (every peer's uid is 0), so gating the read on it would let a flood of
+// garbage refuse real logins — the failure #160 removed, reintroduced from the other
+// side. What it does bound is how long a peer can keep being answered, and it puts a
+// flood in the journal where an operator can see it, instead of leaving malformed
+// requests uncounted forever (#189).
+func (s *Server) rejectMalformed(conn net.Conn, peerUID uint32, errorCode, errorMessage string) {
+	if s.rateLimiter.Allow(ClassMalformed, strconv.FormatUint(uint64(peerUID), 10)) {
+		s.sendErrorResponse(conn, errorCode, errorMessage)
+		return
+	}
+
+	log.Warn().
+		Uint32("peer_uid", peerUID).
+		Msg("Malformed-request budget exhausted for peer; refusing further malformed requests")
+	s.sendErrorResponse(conn, "RATE_LIMIT_EXCEEDED", clientErrorMessage("RATE_LIMIT_EXCEEDED"))
+}
+
 // handleConnection handles a single IPC connection
 func (s *Server) handleConnection(conn net.Conn) {
 	defer s.wg.Done()
@@ -336,7 +388,8 @@ func (s *Server) handleConnection(conn net.Conn) {
 	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Verify peer is root — PAM modules always run as root
-	if err := verifyPeerCredentials(conn); err != nil {
+	peerUID, err := s.verifyPeer(conn)
+	if err != nil {
 		log.Warn().Err(err).Msg("Rejected IPC connection from non-root peer")
 		s.sendErrorResponse(conn, "PERMISSION_DENIED", "Connection rejected")
 		return
@@ -366,10 +419,17 @@ func (s *Server) handleConnection(conn net.Conn) {
 			Msg("Peer credentials verified")
 	}
 
-	// Rate limiting happens in handleRequest, once the request has been decoded and
-	// validated: the limits are keyed on the account a request names, which is not
-	// known before then. It used to happen here, keyed on the peer uid — a value
-	// that can only ever be 0, so the whole host shared one bucket (#160).
+	// Rate limiting for requests that reach a handler happens in handleRequest, once
+	// the request has been decoded and validated: those limits are keyed on the
+	// account a request names, which is not known before then. It used to happen
+	// here, keyed on the peer uid — a value that can only ever be 0, so the whole
+	// host shared one bucket (#160).
+	//
+	// Requests that reach no handler are charged here instead, to the peer that sent
+	// them: see rejectMalformed. They used to be charged to nothing at all, so a
+	// local peer could hold the broker in accept, read, decode and validate as fast
+	// as it could write, and the only limit that exists to bound that work never saw
+	// one of them (#189).
 
 	log.Debug().
 		Str("remote_addr", conn.RemoteAddr().String()).
@@ -383,7 +443,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 		log.Error().
 			Err(err).
 			Msg("Failed to decode IPC request")
-		s.sendErrorResponse(conn, "INVALID_REQUEST", "Failed to decode request")
+		s.rejectMalformed(conn, peerUID, "INVALID_REQUEST", "Failed to decode request")
 		return
 	}
 
@@ -393,7 +453,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 			Err(err).
 			Str("request_type", request.Type).
 			Msg("Invalid IPC request")
-		s.sendErrorResponse(conn, "INVALID_REQUEST", clientErrorMessage("INVALID_REQUEST"))
+		s.rejectMalformed(conn, peerUID, "INVALID_REQUEST", clientErrorMessage("INVALID_REQUEST"))
 		return
 	}
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -32,15 +31,11 @@ func authResponse(t *testing.T, v any) *Response {
 	return response
 }
 
-// skipIfNotRootOnLinux skips the test when running on Linux as a non-root user.
-// The IPC server's verifyPeerCredentials unconditionally requires UID 0 on Linux,
-// so any test that connects to the socket will be rejected when run as non-root.
-func skipIfNotRootOnLinux(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "linux" && os.Getuid() != 0 {
-		t.Skip("verifyPeerCredentials requires UID 0 on Linux; skipping on non-root runner")
-	}
-}
+// There is deliberately no skipIfNotRootOnLinux helper any more. It skipped every
+// test that spoke to the socket unless the suite ran as root on Linux, which no run
+// of this project's CI has ever done, so the trust boundary's own tests were absent
+// rather than passing. startSocketTestServer replaces the peer-credential lookup
+// instead, so they run (#189).
 
 func TestNewServer(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "ipc-test-*")
@@ -108,32 +103,12 @@ func TestServerLifecycle(t *testing.T) {
 	}
 }
 
+// A peer that writes something other than a request does not take the server down.
+//
+// Non-JSON is the case that reaches the new malformed-request accounting first, since
+// it fails at the decode rather than in the validator.
 func TestServerConnection(t *testing.T) {
-	skipIfNotRootOnLinux(t)
-	tempDir, err := os.MkdirTemp("", "ipc-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
-
-	socketPath := filepath.Join(tempDir, "test.sock")
-	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
-	if err != nil {
-		t.Fatalf("Failed to create server: %v", err)
-	}
-
-	// Start server
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	go func() {
-		_ = server.Start(ctx)
-	}()
-
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
-	defer func() { _ = server.Stop() }()
+	_, socketPath := startSocketTestServer(t, createTestBroker(t), 0, 0)
 
 	// Test connection
 	conn, err := net.Dial("unix", socketPath)
@@ -142,42 +117,27 @@ func TestServerConnection(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Write test data
-	testData := []byte("test message")
-	if _, err := conn.Write(testData); err != nil {
-		t.Errorf("Failed to write data: %v", err)
+	if _, err := conn.Write([]byte("test message")); err != nil {
+		t.Fatalf("Failed to write data: %v", err)
 	}
 
-	// Test that connection is handled (server should not crash)
-	time.Sleep(100 * time.Millisecond)
+	// The peer gets an answer, rather than the connection being dropped or the
+	// server going down. This used to sleep and assert nothing at all, which is
+	// what let it keep its root-on-Linux skip unnoticed.
+	var resp Response
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		t.Fatalf("no response to a non-JSON request: %v", err)
+	}
+	if resp.ErrorCode != "INVALID_REQUEST" {
+		t.Errorf("got error_code=%q, want INVALID_REQUEST", resp.ErrorCode)
+	}
+	if resp.Success {
+		t.Error("a request that did not decode was answered with success")
+	}
 }
 
 func TestServerMultipleConnections(t *testing.T) {
-	skipIfNotRootOnLinux(t)
-	tempDir, err := os.MkdirTemp("", "ipc-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
-
-	socketPath := filepath.Join(tempDir, "test.sock")
-	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
-	if err != nil {
-		t.Fatalf("Failed to create server: %v", err)
-	}
-
-	// Start server
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	go func() {
-		_ = server.Start(ctx)
-	}()
-
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
-	defer func() { _ = server.Stop() }()
+	_, socketPath := startSocketTestServer(t, createTestBroker(t), 0, 0)
 
 	// Test multiple simultaneous connections
 	var conns []net.Conn
@@ -281,30 +241,7 @@ func TestServerDoubleStop(t *testing.T) {
 }
 
 func TestServerConnectionHandling(t *testing.T) {
-	skipIfNotRootOnLinux(t)
-	tempDir, err := os.MkdirTemp("", "ipc-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
-
-	socketPath := filepath.Join(tempDir, "test.sock")
-	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
-	if err != nil {
-		t.Fatalf("Failed to create server: %v", err)
-	}
-
-	// Start server
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	go func() {
-		_ = server.Start(ctx)
-	}()
-
-	time.Sleep(100 * time.Millisecond)
-	defer func() { _ = server.Stop() }()
+	_, socketPath := startSocketTestServer(t, createTestBroker(t), 0, 0)
 
 	// Connect and verify connection is handled
 	conn, err := net.Dial("unix", socketPath)

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -516,33 +516,14 @@ func TestServerHandleRevokeSession(t *testing.T) {
 	_ = server.handleRevokeSession(revokeRequest)
 }
 
+// A user_id that is a path rather than a username is refused, with a message that
+// does not repeat the validator's reasoning back to the client.
+//
+// This carried the same root-on-Linux skip as the rate-limit test and so had never
+// run either; it exercises exactly the rejection path this change moved a limiter
+// into, so it runs unprivileged now (#189).
 func TestServerRejectsPathTraversal(t *testing.T) {
-	if runtime.GOOS != "linux" || os.Getuid() != 0 {
-		t.Skip("verifyPeerCredentials requires Linux + root; skipping path traversal test")
-	}
-	tempDir, err := os.MkdirTemp("", "ipc-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
-
-	socketPath := filepath.Join(tempDir, "test.sock")
-	broker := createTestBroker(t)
-	server, err := NewServer(socketPath, broker, 0660, "", false, 0, 0)
-	if err != nil {
-		t.Fatalf("Failed to create server: %v", err)
-	}
-
-	// Start server
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	go func() {
-		_ = server.Start(ctx)
-	}()
-
-	time.Sleep(100 * time.Millisecond)
-	defer func() { _ = server.Stop() }()
+	_, socketPath := startSocketTestServer(t, createTestBroker(t), 0, 0)
 
 	// Connect and send a request with path traversal in UserID
 	conn, err := net.Dial("unix", socketPath)
@@ -658,56 +639,143 @@ func sendRequestOverSocket(t *testing.T, socketPath string, req *Request) *Respo
 	return &resp
 }
 
-func TestServerRateLimitOverSocket(t *testing.T) {
-	if runtime.GOOS != "linux" || os.Getuid() != 0 {
-		t.Skip("verifyPeerCredentials requires Linux + root; skipping rate limit socket test")
-	}
-	tempDir, err := os.MkdirTemp("", "ipc-ratelimit-*")
+// startSocketTestServer starts a Server listening on a socket in a temporary
+// directory, with the peer-credential check replaced, and returns it with its socket
+// path.
+//
+// The substitution is what lets these tests run at all. verifyPeerCredentials asks
+// the kernel for the peer's uid and requires 0, so every test here that speaks to the
+// socket used to skip unless the suite was running as root on Linux. CI runs as an
+// unprivileged user, so they skipped on every run this project has ever made — green
+// because absent — and the socket, which is the whole trust boundary, was in practice
+// untested (#189).
+func startSocketTestServer(t *testing.T, broker *auth.Broker, maxRequestsPerMinute, maxConcurrentAuths int) (*Server, string) {
+	t.Helper()
+
+	// os.MkdirTemp rather than t.TempDir: the latter builds the directory name out of
+	// the test's name, and a socket path over sun_path's 104 bytes fails to bind on
+	// macOS, so a long test name would take the socket away again.
+	tempDir, err := os.MkdirTemp("", "ipc-socket")
 	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
+		t.Fatalf("MkdirTemp: %v", err)
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
 
 	socketPath := filepath.Join(tempDir, "test.sock")
-
-	// maxRequestsPerMinute=2, maxConcurrentAuths=0 (disabled), requirePeerAuth=false
-	server, err := NewServer(socketPath, nil, 0660, "", false, 2, 0)
+	server, err := NewServer(socketPath, broker, 0660, "", false, maxRequestsPerMinute, maxConcurrentAuths)
 	if err != nil {
-		t.Fatalf("Failed to create server: %v", err)
+		t.Fatalf("NewServer: %v", err)
 	}
+	// Stand in for the SO_PEERCRED lookup, reporting the uid every real peer has.
+	server.peerVerifier = func(net.Conn) (uint32, error) { return 0, nil }
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	go func() { _ = server.Start(ctx) }()
-	time.Sleep(100 * time.Millisecond)
-	defer func() { _ = server.Stop() }()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Stop() })
+
+	return server, socketPath
+}
+
+// A peer that sends well-formed requests faster than its account's budget allows is
+// refused over the socket, not just in a direct call to handleRequest.
+//
+// The requests have to be ones that pass validation, which is the whole point: this
+// test used to send a check_session with no session_id, so every one of them was
+// answered INVALID_REQUEST by the validator and the limiter was never reached. Two
+// assertions passed for the wrong reason and the third could not pass at all — and
+// because the test also skipped unless run as root on Linux, nothing ever noticed
+// (#189).
+func TestServerRateLimitOverSocket(t *testing.T) {
+	// The session budget is pollsPerAuthentication times the authenticate budget, so
+	// one request per minute buys exactly that many check_session calls.
+	_, socketPath := startSocketTestServer(t, newTestBroker(t), 1, 0)
+	budget := pollsPerAuthentication
 
 	req := &Request{
-		Type:   "check_session",
-		UserID: "test-user",
+		Type:      "check_session",
+		UserID:    "test-user",
+		SessionID: "no-such-session",
 	}
 
-	// First 2 requests should succeed (not be rate-limited — they'll fail for
-	// other reasons since broker is nil, but they should NOT get RATE_LIMIT_EXCEEDED).
-	for i := 0; i < 2; i++ {
+	for i := 0; i < budget; i++ {
 		resp := sendRequestOverSocket(t, socketPath, req)
 		if resp.ErrorCode == "RATE_LIMIT_EXCEEDED" {
-			t.Fatalf("request %d should not have been rate-limited", i+1)
+			t.Fatalf("request %d of a budget of %d was rate-limited", i+1, budget)
+		}
+		// The request reached the broker, which is what proves the limiter is being
+		// exercised rather than the validator: an unknown session is the answer a
+		// well-formed request gets here.
+		if resp.ErrorCode != "SESSION_NOT_FOUND" {
+			t.Fatalf("request %d got error_code=%q, want SESSION_NOT_FOUND: it never reached "+
+				"a handler, so this test is asserting validation and not rate limiting", i+1, resp.ErrorCode)
 		}
 	}
 
-	// 3rd request should be rate-limited
 	resp := sendRequestOverSocket(t, socketPath, req)
 	if resp.ErrorCode != "RATE_LIMIT_EXCEEDED" {
-		t.Fatalf("expected RATE_LIMIT_EXCEEDED on 3rd request, got error_code=%q", resp.ErrorCode)
+		t.Fatalf("expected RATE_LIMIT_EXCEEDED on request %d, got error_code=%q", budget+1, resp.ErrorCode)
 	}
 	if resp.Success {
 		t.Fatal("rate-limited response should not be successful")
 	}
 }
 
+// Requests that no handler ever sees are counted too.
+//
+// Before this they were free: validateRequest ran before any limiter, so a local peer
+// could send garbage as fast as it could write and the per-peer limit that exists to
+// bound accept, read, decode and validate never saw a single request. Every malformed
+// request was answered INVALID_REQUEST, forever, at no charge (#189).
+func TestMalformedRequestsAreChargedToThePeer(t *testing.T) {
+	// malformedPerAuthentication times the authenticate budget of 2.
+	_, socketPath := startSocketTestServer(t, newTestBroker(t), 2, 0)
+	budget := 2 * malformedPerAuthentication
+
+	// The request from the issue: check_session names no session, so it cannot pass
+	// validation and reaches no handler.
+	malformed := &Request{
+		Type:   "check_session",
+		UserID: "test-user",
+	}
+
+	for i := 0; i < budget; i++ {
+		resp := sendRequestOverSocket(t, socketPath, malformed)
+		if resp.ErrorCode != "INVALID_REQUEST" {
+			t.Fatalf("malformed request %d got error_code=%q, want INVALID_REQUEST", i+1, resp.ErrorCode)
+		}
+	}
+
+	resp := sendRequestOverSocket(t, socketPath, malformed)
+	if resp.ErrorCode != "RATE_LIMIT_EXCEEDED" {
+		t.Fatalf("malformed request %d got error_code=%q, want RATE_LIMIT_EXCEEDED: malformed "+
+			"requests are rejected before any limiter counts them, so a local peer can spin the "+
+			"accept loop, the decode and the validator for free (#189)", budget+1, resp.ErrorCode)
+	}
+
+	// And the peer's well-formed traffic is untouched by the flood it just sent. Every
+	// peer shares the malformed bucket, because every peer's uid is 0; if a spent
+	// malformed budget could refuse a valid request, this would be the host-wide
+	// bucket of #160 in a new place, and any local account could deny every login.
+	valid := &Request{
+		Type:      "check_session",
+		UserID:    "test-user",
+		SessionID: "no-such-session",
+	}
+	if resp := sendRequestOverSocket(t, socketPath, valid); resp.ErrorCode != "SESSION_NOT_FOUND" {
+		t.Fatalf("a well-formed request after an exhausted malformed budget got error_code=%q, "+
+			"want SESSION_NOT_FOUND: malformed traffic from one peer is denying real logins", resp.ErrorCode)
+	}
+}
+
+// The concurrent-auth cap refuses a second authentication while one is in flight.
+//
+// This asserted it through handleRequest and never touched the socket, so the
+// root-on-Linux skip it carried bought nothing and cost the assertion: CI runs
+// unprivileged on Linux, which is precisely where the guard fired (#189).
 func TestServerConcurrentAuthLimitOverSocket(t *testing.T) {
-	skipIfNotRootOnLinux(t)
 	tempDir, err := os.MkdirTemp("", "ipc-authlimit-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)


### PR DESCRIPTION
Closes #189.

## The defect

`handleConnection` validated a request before any limiter saw it, so every request
that failed to decode or failed `validateRequest` was answered `INVALID_REQUEST`
free of charge, forever. A local peer could hold the broker in accept, read, decode
and validate as fast as it could write, and the limiter that exists to bound exactly
that work never counted one of them.

**The fix is not "rate limit before validation."** The issue explicitly declines
that, and it is right to: the account budgets are keyed on `user_id`, and charging
them first would key the bucket map on an unvalidated field of up to 64 KiB —
`maxTrackedAccounts`' own comment relies on `validateRequest` having already bounded
every key to 32 characters of `[a-z0-9_-]`. That would let one peer choose the map's
keys and their length. Validation stays first; malformed requests get their own
`ClassMalformed` bucket keyed on the **peer uid**, which `verifyPeerCredentials`
already knows before any parsing.

The bucket is consulted after a request is recognised as malformed, not before it is
read. Every peer shares it — every peer's uid is 0 — so gating the read on it would
let a garbage flood refuse real logins, which is #160 reintroduced from the other
side. A request that decodes and validates is charged to its own per-account bucket,
so exhausting the malformed budget cannot deny a login. There is a test for that
specific property.

## Why the test that should have caught this didn't

`TestServerRateLimitOverSocket` skipped unless the suite ran as root on Linux. CI
runs unprivileged, so it has skipped on **every run this project has ever made** —
green because absent. When made to run it failed, and not only from the ordering: it
sent a `check_session` with no `session_id`, so all its requests died in the
validator. Two of its assertions passed for the wrong reason and the third could not
pass at all.

`Server.peerVerifier` is an unexported test seam, nil in every `Server` the
constructor builds, so production still fails closed through `verifyPeerCredentials`.
With it, five socket tests run unprivileged and `skipIfNotRootOnLinux` is deleted
along with its last caller.

## Non-vacuity

Each guard perturbed, only the covering test run, then restored (`diff -q` silent):

- Malformed budget → `if true` (the pre-fix behaviour):
  `TestMalformedRequestsAreChargedToThePeer` fails — `malformed request 3 got error_code="INVALID_REQUEST", want RATE_LIMIT_EXCEEDED`.
- Seam removed from `verifyPeer`: `TestServerConnection`, `TestServerRejectsPathTraversal`
  and `TestServerRateLimitOverSocket` all fail with `PERMISSION_DENIED` — proving they
  now exercise the socket rather than skipping past it.

`go build`, `go vet`, `go test -race ./...`, `gofmt -s -l .` and
`golangci-lint run ./internal/ipc/...` all clean.

## Found, not fixed

- An unknown request type (`{"type":"bogus"}`) is still uncharged: `rateClassFor`
  returns `limited=false` for it. It does pass validation, so it is a different hole
  from this one.
- `requirePeerAuth` (`server.go:400`) is now fully redundant.