### PR TITLE
fix(pam): bound the broker read in total, and test the decision (#196, #197)

### DIFF
--- a/cmd/pam-module/auth_linux.go
+++ b/cmd/pam-module/auth_linux.go
@@ -129,3 +129,42 @@ func classifyLoginTypeC(service, tty string) string {
 func acctMgmtVerdict() pam.PAMResultCode {
 	return pam.PAMResultCode(C.acct_mgmt_verdict())
 }
+
+// brokerPending is the C module's BROKER_PENDING: classifyBrokerResponse's answer
+// for a device flow that has been started but not finished, which is neither a
+// grant nor a denial. Named from the header rather than written as -1 so the two
+// cannot drift.
+const brokerPending = int(C.BROKER_PENDING)
+
+// classifyBrokerResponse runs the C module's decision over the exact bytes a broker
+// would put on the wire — parse, then classify_response — and returns the PAM result
+// code it reached, or brokerPending.
+//
+// This is the module's whole verdict on a reply, and until now nothing called it:
+// both classify_response and map_error_code are static, the Go tests here drove them
+// only indirectly through a fake broker that a real one resembles, and e2e cannot
+// construct a malformed reply at all. A decision nothing tests is a decision that can
+// be deleted without a single suite noticing (#197).
+func classifyBrokerResponse(response string) int {
+	cResponse := C.CString(response)
+	defer C.free(unsafe.Pointer(cResponse))
+
+	return int(C.classify_response_text(cResponse))
+}
+
+// mapBrokerErrorCode runs the C module's error_code -> PAM result mapping, the
+// second half of the same decision: which kind of denial a refusal becomes.
+//
+// A nil code is the NULL the module is handed whenever error_code is absent or is
+// not a JSON string — the case a Go string cannot express, and the one that has to
+// stay a denial (#197).
+func mapBrokerErrorCode(code *string) pam.PAMResultCode {
+	if code == nil {
+		return pam.PAMResultCode(C.map_error_code((*C.char)(nil)))
+	}
+
+	cCode := C.CString(*code)
+	defer C.free(unsafe.Pointer(cCode))
+
+	return pam.PAMResultCode(C.map_error_code(cCode))
+}

--- a/cmd/pam-module/cgo_bridge.h
+++ b/cmd/pam-module/cgo_bridge.h
@@ -42,6 +42,15 @@
 #define RECV_OK 0
 #define RECV_ERROR (-1)
 #define RECV_RESPONSE_TOO_LARGE (-2)
+
+// Sentinel returned by classify_response_text for a device flow that has been
+// started but not yet completed: the broker said success=true *and*
+// requires_device=true, which is neither a grant nor a denial. Every PAM_* return
+// code is non-negative, so a negative value cannot collide with one.
+//
+// It lives here rather than in cgo_bridge_linux.c so a test can name the value the
+// decision actually returns instead of restating -1 (#197).
+#define BROKER_PENDING (-1)
 // Longest usable Unix socket path, taken from the platform's sockaddr_un
 // (108 bytes on Linux, 104 on Darwin/BSD) so it can never disagree with it.
 #define MAX_SOCKET_PATH (sizeof(((struct sockaddr_un *)0)->sun_path))
@@ -101,6 +110,14 @@ int acct_mgmt_verdict(void);
 int send_auth_request(int sock, const char *username, const char *service, const char *rhost, const char *tty);
 int send_check_session_request(int sock, const char *session_id, const char *username);
 int receive_auth_response(int sock, char *response, size_t response_size);
+// receive_auth_response with the total read budget as a parameter. The module always
+// uses receive_auth_response, which passes RESPONSE_READ_TIMEOUT_MS; a test needs a
+// budget it can wait for to show that the bound is a bound on the whole read (#196).
+int receive_auth_response_within(int sock, char *response, size_t response_size, int total_timeout_ms);
+// The two functions that decide whether a broker reply is a grant or a denial.
+// Declared here so they are reachable from a test — neither had one (#197).
+int classify_response_text(const char *response);
+int map_error_code(const char *error_code);
 int perform_authentication(pam_handle_t *pamh, const char *socket_path, const char *username,
                            const char *service, const char *rhost, const char *tty, int timeout_s);
 int display_message(pam_handle_t *pamh, const char *message);

--- a/cmd/pam-module/cgo_bridge_linux.c
+++ b/cmd/pam-module/cgo_bridge_linux.c
@@ -6,6 +6,13 @@
 #include <json-c/json.h>
 
 // Total time budget for reading a complete broker response, in milliseconds.
+//
+// Total across every poll() and recv() of one read, not per poll — see
+// receive_auth_response_within, where a per-poll reading of this number meant a
+// read could last days (#196). It is well inside sshd's default LoginGraceTime of
+// 120 s, which is the deadline that matters: past that sshd tears the pre-auth
+// child down itself and the user is left with a dropped connection and no reason
+// for it.
 #define RESPONSE_READ_TIMEOUT_MS 30000
 
 // Whether this invocation logs at LOG_DEBUG, taken from the module arguments by
@@ -307,7 +314,25 @@ int send_check_session_request(int sock, const char *session_id, const char *use
     return 0;
 }
 
-// Receive authentication response from broker.
+// Milliseconds on a monotonic clock. The same clock as monotonic_seconds() below,
+// and for the same reason — a wall-clock adjustment mid-login must not extend or
+// collapse a budget — in the unit poll() takes, so that the last poll of a read
+// gets whatever sub-second remainder is left rather than having it rounded down to
+// a non-blocking poll.
+static long long monotonic_millis(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        // Should not happen; degrade to the realtime clock rather than reading with
+        // no deadline at all. long long, because seconds-since-epoch expressed in
+        // milliseconds does not fit a 32-bit long.
+        return (long long)time(NULL) * 1000LL;
+    }
+    return (long long)ts.tv_sec * 1000LL + (long long)ts.tv_nsec / 1000000LL;
+}
+
+// Receive authentication response from broker, with total_timeout_ms as the time
+// budget for the whole read.
 //
 // The broker writes a single newline-delimited JSON object (json.Encoder.Encode
 // appends '\n'). A single recv() can return only the first TCP segment, which
@@ -315,22 +340,61 @@ int send_check_session_request(int sock, const char *session_id, const char *use
 // newline delimiter is seen, the buffer is full, or the connection closes,
 // bounded by a total read timeout so a stalled/hostile broker cannot hang the
 // PAM stack.
-int receive_auth_response(int sock, char *response, size_t response_size) {
+//
+// The deadline is taken once, before the loop, and every poll() gets only what is
+// left of it. Handing the full budget to each poll() is what #196 was: the timeout
+// was per-poll, so a peer that sent one byte just inside each window reset the
+// clock, and the real bound was one window per byte of the buffer —
+// MAX_RESPONSE_SIZE-1 = 16 383 windows of 30 s, about 5.7 days — with a login held
+// open and an sshd pre-auth child pinned for all of it. Bounding the byte count
+// (#162) bounds how many windows there are, not how long they last, and the comment
+// above promised a total bound that the code did not have.
+//
+// The number this has to be measured against is sshd's LoginGraceTime, which
+// defaults to 120 s. Past that sshd kills the pre-auth child itself, so a module
+// that is still waiting produces the worst possible outcome for the user: the
+// connection drops with nothing said about why, and nothing in auth.log naming the
+// broker. A 30 s bound per read (RESPONSE_READ_TIMEOUT_MS) keeps the module inside
+// that: DEFAULT_AUTH_TIMEOUT (90 s) of device-flow polling plus at most one final
+// read is 120 s — at the limit rather than past it — and it keeps the module, not
+// sshd, the one that decides a stalled broker is a denial. Raising `timeout=` above
+// DEFAULT_AUTH_TIMEOUT needs a matching LoginGraceTime, as cgo_bridge.h says where
+// that timeout is defined.
+//
+// The budget is a parameter so a test can drive the bound with a short one rather
+// than waiting out the shipped 30 s; the module itself always reads through
+// receive_auth_response, which supplies the real RESPONSE_READ_TIMEOUT_MS (#196).
+int receive_auth_response_within(int sock, char *response, size_t response_size, int total_timeout_ms) {
     if (response_size == 0) {
         return RECV_ERROR;
     }
 
     size_t total = 0;
     const size_t cap = response_size - 1; // reserve space for NUL
+    const long long deadline = monotonic_millis() + (total_timeout_ms > 0 ? total_timeout_ms : 0);
 
     while (total < cap) {
         struct pollfd pfd;
+        long long remaining_ms = deadline - monotonic_millis();
+
+        // The budget is gone. This is also the EINTR path's bound: a signal used to
+        // send the loop back to a fresh full window (#196).
+        if (remaining_ms <= 0) {
+            log_pam_message(LOG_ERR,
+                            "Broker response read budget of %dms exhausted after %zu bytes; "
+                            "giving up rather than outliving sshd's LoginGraceTime",
+                            total_timeout_ms, total);
+            return RECV_ERROR;
+        }
+
         pfd.fd = sock;
         pfd.events = POLLIN;
 
-        int pr = poll(&pfd, 1, RESPONSE_READ_TIMEOUT_MS);
+        int pr = poll(&pfd, 1, (int)remaining_ms);
         if (pr == 0) {
-            log_pam_message(LOG_ERR, "Timed out waiting for broker response");
+            log_pam_message(LOG_ERR,
+                            "Timed out waiting for broker response (%dms budget, %zu bytes read)",
+                            total_timeout_ms, total);
             return RECV_ERROR;
         }
         if (pr < 0) {
@@ -394,6 +458,13 @@ int receive_auth_response(int sock, char *response, size_t response_size) {
     log_pam_message(LOG_DEBUG, "Received %zu-byte broker response", total);
 
     return RECV_OK;
+}
+
+// Receive a broker response under the module's own read budget. This is the only
+// entry point the module itself uses; RESPONSE_READ_TIMEOUT_MS is the total, not a
+// per-poll allowance (#196).
+int receive_auth_response(int sock, char *response, size_t response_size) {
+    return receive_auth_response_within(sock, response, response_size, RESPONSE_READ_TIMEOUT_MS);
 }
 
 // Display message to user
@@ -534,10 +605,9 @@ void parse_arguments(int argc, const char **argv, pam_oidc_options *opts) {
     }
 }
 
-// Sentinel returned by classify_response for a device flow that has been started
-// but not yet completed. Every PAM_* return code is non-negative, so a negative
-// value cannot collide with one.
-#define BROKER_PENDING (-1)
+// BROKER_PENDING — the sentinel for a device flow that has been started but not yet
+// completed — lives in cgo_bridge.h so that a test can name the same value the
+// decision returns rather than restating -1 (#197).
 
 // Read a string field, or NULL if it is absent, JSON null, or not a JSON string.
 // The result points into obj and is only valid while obj is alive.
@@ -601,7 +671,14 @@ static int response_poll_interval(json_object *obj) {
 // require_groups rejects the user, when device-flow polling fails, and when the
 // session expires, so a poll that can no longer find its session means the
 // authentication was refused.
-static int map_error_code(const char *error_code) {
+//
+// Not static, and declared in cgo_bridge.h, only so that it is linkable from a
+// test: this is one of the two functions that turn a broker reply into a PAM
+// result, and neither had a test of any kind, which means `return PAM_SUCCESS`
+// here was green in every suite in this repository (#197). error_code is NULL
+// whenever the field is absent or is not a JSON string, which is why the NULL
+// case is a denial rather than an accident.
+int map_error_code(const char *error_code) {
     if (error_code == NULL) {
         return PAM_AUTH_ERR;
     }
@@ -682,6 +759,46 @@ static int classify_response(json_object *obj) {
     }
 
     return PAM_SUCCESS;
+}
+
+// Classify a broker reply given the bytes as they arrive on the wire: parse it,
+// then hand it to classify_response. Returns a PAM result code, or BROKER_PENDING
+// while the device flow is still in progress.
+//
+// This exists so classify_response — the module's entire decision about whether a
+// reply is a grant or a denial — is reachable from a test. It had none: both it and
+// map_error_code are static and absent from cgo_bridge.h, the Go tests in this
+// package did not call into them, and e2e drives an honest broker that cannot
+// construct the replies these functions exist to reject, so `classify_response`
+// returning PAM_SUCCESS unconditionally passed everything (#197). Two grants had
+// already gone in unnoticed that way: `"success":"false"` read as a success (#168),
+// and a non-boolean requires_device read as "no device authorization needed" (#201).
+//
+// classify_response takes a json_object, so it cannot be declared in cgo_bridge.h —
+// that header is included by files with no json-c headers available — and a wrapper
+// taking the wire bytes is the closer test anyway. It is not a shortcut around the
+// decision: the parse and the classification are the two steps
+// perform_authentication takes on every reply it receives, in the same order and
+// with the same verdict for a reply that is not JSON at all.
+int classify_response_text(const char *response) {
+    json_object *obj;
+    int result;
+
+    if (response == NULL) {
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    obj = json_tokener_parse(response);
+    if (obj == NULL) {
+        // What perform_authentication does with a reply it cannot parse: no opinion
+        // reached, and the auth stack fails closed.
+        log_pam_message(LOG_ERR, "Failed to parse broker response");
+        return PAM_AUTHINFO_UNAVAIL;
+    }
+
+    result = classify_response(obj);
+    json_object_put(obj);
+    return result;
 }
 
 // Show a message to the user, tolerating a NULL handle so the authentication

--- a/cmd/pam-module/classify_linux_test.go
+++ b/cmd/pam-module/classify_linux_test.go
@@ -1,0 +1,321 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/pam"
+)
+
+// Tests for the two functions that turn a broker reply into a PAM result:
+// classify_response (reached here through classify_response_text) and
+// map_error_code. Between them they are the module's entire decision about whether
+// a login is granted, refused, or still waiting on the device flow, and until now
+// neither had a test of any kind — both are static, and the tests in this package
+// drove them only through a fake broker whose replies resemble a real one's, while
+// e2e drives an honest broker that cannot construct the replies these functions
+// exist to reject. `classify_response` rewritten to `return PAM_SUCCESS`
+// unconditionally was green in every suite in this repository (#197).
+//
+// Two grants had already gone in unnoticed exactly that way, which is the argument
+// for testing the decision directly rather than only end to end:
+//
+//   - `"success":"false"` — a JSON string — read as a success by
+//     json_object_get_boolean, which answers true for any non-empty string (#168).
+//   - a non-boolean `requires_device` read as "no device authorization needed", so
+//     success=true was honored on its own with no device flow, no identity binding
+//     and no require_groups check (#201).
+//
+// Every field these two functions read is covered below with a value of the wrong
+// JSON type: success, requires_device, error_code and error_message. The rule is
+// the same for all of them — with `auth sufficient pam_oidc.so`, PAM_SUCCESS is a
+// login, so a reply the module cannot interpret must never produce one.
+
+// The replies the module is entitled to grant on, and the one it must hold on.
+//
+// A suite made only of denials would pass against a decision that denied
+// everything, which would be a broken module (nobody could log in) with a green
+// test run. These are what keep the tables below from being vacuous.
+func TestClassifyResponseGrantsOnlyACompletedAuthentication(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		reply string
+		want  int
+	}{
+		{
+			// The only shape that is a grant: success=true and the broker has said,
+			// with a real JSON false, that no device step is outstanding.
+			name:  "success with requires_device false",
+			reply: `{"success":true,"session_id":"s","user_id":"testuser","requires_device":false}`,
+			want:  int(pam.PAMSuccess),
+		},
+		{
+			// internal/ipc.Response declares requires_device with no omitempty, so
+			// the real broker always sends it; absent can only come from a different
+			// producer, and is read as "no device step".
+			name:  "success with requires_device absent",
+			reply: `{"success":true,"session_id":"s","user_id":"testuser"}`,
+			want:  int(pam.PAMSuccess),
+		},
+		{
+			// success=true *with* requires_device=true is the broker reporting that
+			// it has only started the device flow. Neither a grant nor a denial: the
+			// user has not visited the device URL yet, and identity binding and
+			// require_groups are still to come.
+			name:  "device flow started",
+			reply: `{"success":true,"session_id":"s","requires_device":true}`,
+			want:  brokerPending,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := classifyBrokerResponse(tc.reply); got != tc.want {
+				t.Fatalf("classify(%s) = %d, want %d: the denial tables in this file prove "+
+					"nothing unless the decision can still reach this answer",
+					tc.reply, got, tc.want)
+			}
+		})
+	}
+}
+
+// Anything the module cannot interpret is not a grant. PAM_AUTHINFO_UNAVAIL is the
+// honest answer — "I could not reach an opinion" — and it fails the auth stack
+// closed.
+func TestClassifyResponseDeniesAnythingItCannotInterpret(t *testing.T) {
+	t.Parallel()
+
+	// Written as raw JSON text throughout: the JSON *type* of the value is the whole
+	// point of each case, and a Go map could not express most of them.
+	cases := []struct {
+		name  string
+		reply string
+	}{
+		// success of the wrong type. json_object_get_boolean answers true for any
+		// non-empty JSON string and for a non-zero number, so each of these used to
+		// be readable as a grant (#168).
+		{"success is the string false", `{"success":"false","error_code":"AUTHENTICATION_FAILED"}`},
+		{"success is the string true", `{"success":"true","user_id":"testuser"}`},
+		{"success is the empty string", `{"success":"","user_id":"testuser"}`},
+		{"success is the number 1", `{"success":1,"user_id":"testuser"}`},
+		{"success is the number 0", `{"success":0}`},
+		{"success is the float 1.0", `{"success":1.0,"user_id":"testuser"}`},
+		{"success is null", `{"success":null,"session_id":"s"}`},
+		{"success is an object", `{"success":{"ok":true},"user_id":"testuser"}`},
+		{"success is an empty object", `{"success":{}}`},
+		{"success is an array", `{"success":[true],"user_id":"testuser"}`},
+		{"success is an empty array", `{"success":[]}`},
+
+		// success absent entirely. A reply with no verdict in it is not a verdict.
+		{"success absent", `{"session_id":"s","user_id":"testuser","requires_device":false}`},
+		{"empty object", `{}`},
+		{"success spelled differently", `{"Success":true,"user_id":"testuser"}`},
+
+		// requires_device of the wrong type, with a real boolean success=true. This
+		// is the dangerous half: anything not a JSON boolean was silently read as
+		// false — "no device authorization needed" — and success=true was then
+		// honored on its own (#201). JSON null is the worst of them, because
+		// json_object_object_get_ex answers TRUE with a NULL object for it, so it
+		// took the "absent" path rather than looking like a value at all.
+		{"requires_device is null", `{"success":true,"session_id":"s","requires_device":null}`},
+		{"requires_device is the string false", `{"success":true,"session_id":"s","requires_device":"false"}`},
+		{"requires_device is the string true", `{"success":true,"session_id":"s","requires_device":"true"}`},
+		{"requires_device is the empty string", `{"success":true,"session_id":"s","requires_device":""}`},
+		{"requires_device is the number 0", `{"success":true,"session_id":"s","requires_device":0}`},
+		{"requires_device is the number 1", `{"success":true,"session_id":"s","requires_device":1}`},
+		{"requires_device is the float 0.0", `{"success":true,"session_id":"s","requires_device":0.0}`},
+		{"requires_device is an empty object", `{"success":true,"session_id":"s","requires_device":{}}`},
+		{"requires_device is an empty array", `{"success":true,"session_id":"s","requires_device":[]}`},
+
+		// Not a JSON object at all. json_object_object_get_ex answers FALSE for
+		// these, which is the "no success field" path — but only because it is
+		// asked; a reply is not obliged to be the shape the module expects.
+		{"top level is an array", `[]`},
+		{"top level is an array of replies", `[{"success":true,"user_id":"testuser"}]`},
+		{"top level is a string", `"success"`},
+		{"top level is the string true", `"true"`},
+		{"top level is a number", `1`},
+		{"top level is a bare true", `true`},
+		{"top level is null", `null`},
+
+		// Not JSON. json_tokener_parse answers NULL, which is where the module's
+		// "Failed to parse broker response" comes from.
+		{"empty text", ``},
+		{"not JSON", `not json at all`},
+		{"truncated object", `{"success":true,"session_id":"s"`},
+		{"only whitespace", `   `},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyBrokerResponse(tc.reply)
+
+			if got == int(pam.PAMSuccess) {
+				t.Fatalf("classify(%s) = PAM_SUCCESS: a reply the module cannot interpret was "+
+					"read as a grant, and with the shipped `auth sufficient pam_oidc.so` a "+
+					"grant is a login", tc.reply)
+			}
+			if got == brokerPending {
+				t.Fatalf("classify(%s) = BROKER_PENDING: an uninterpretable reply is not "+
+					"something to keep polling on", tc.reply)
+			}
+			if got != int(pam.PAMAuthInfoUnavail) {
+				t.Fatalf("classify(%s) = %d, want pam.PAMAuthInfoUnavail (%d)",
+					tc.reply, got, int(pam.PAMAuthInfoUnavail))
+			}
+		})
+	}
+}
+
+// A refusal stays a refusal whatever its error_code looks like. The code only
+// selects which kind of denial it is; it can never turn one into a grant, and it
+// must never turn one into "I could not reach an opinion" either, because that is
+// the answer that tells an operator the broker is down when in fact it answered.
+func TestClassifyResponseDeniesARefusal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		reply string
+		want  pam.PAMResultCode
+	}{
+		{"a recognized rate limit", `{"success":false,"error_code":"RATE_LIMIT_EXCEEDED"}`, pam.PAMMaxTries},
+		{"a policy denial", `{"success":false,"error_code":"POLICY_DENIED"}`, pam.PAMPermDenied},
+		{"an unknown code", `{"success":false,"error_code":"WHO_KNOWS"}`, pam.PAMAuthError},
+		{"no code at all", `{"success":false}`, pam.PAMAuthError},
+
+		// json_object_get_string does not read a string, it renders whatever it is
+		// given: an error_code of 404 came back as the text "404" (#201). A value of
+		// the wrong type is not a code the broker's contract can express, so it maps
+		// as an unrecognized one rather than as text map_error_code might match.
+		{"the code is a number", `{"success":false,"error_code":404}`, pam.PAMAuthError},
+		{"the code is null", `{"success":false,"error_code":null}`, pam.PAMAuthError},
+		{"the code is a bool", `{"success":false,"error_code":true}`, pam.PAMAuthError},
+		{"the code is an object", `{"success":false,"error_code":{"code":"POLICY_DENIED"}}`, pam.PAMAuthError},
+		{"the code is an array", `{"success":false,"error_code":["POLICY_DENIED"]}`, pam.PAMAuthError},
+
+		// error_message is only logged, so the point of these is that reading it
+		// cannot change the verdict or crash on the way to it.
+		{
+			"the message is an object",
+			`{"success":false,"error_code":"POLICY_DENIED","error_message":{"m":1}}`,
+			pam.PAMPermDenied,
+		},
+		{
+			"the message is a number",
+			`{"success":false,"error_code":"POLICY_DENIED","error_message":42}`,
+			pam.PAMPermDenied,
+		},
+		{
+			"the message is null",
+			`{"success":false,"error_code":"POLICY_DENIED","error_message":null}`,
+			pam.PAMPermDenied,
+		},
+		{
+			"the message is an array",
+			`{"success":false,"error_message":["nope"]}`,
+			pam.PAMAuthError,
+		},
+
+		// success is read before requires_device, so a refusal that also asks for a
+		// device step is still a refusal — not a pending device flow to sit and poll
+		// until the login grace time runs out.
+		{"a refusal that also wants a device step", `{"success":false,"requires_device":true}`, pam.PAMAuthError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyBrokerResponse(tc.reply)
+
+			if got == int(pam.PAMSuccess) {
+				t.Fatalf("classify(%s) = PAM_SUCCESS: the broker refused this authentication",
+					tc.reply)
+			}
+			if got == brokerPending {
+				t.Fatalf("classify(%s) = BROKER_PENDING: a refusal is terminal, not something "+
+					"to keep polling on", tc.reply)
+			}
+			if got != int(tc.want) {
+				t.Fatalf("classify(%s) = %d, want %d", tc.reply, got, int(tc.want))
+			}
+		})
+	}
+}
+
+// map_error_code on its own: which denial each broker error code becomes.
+//
+// Every answer here is a denial. The mapping exists so an operator reading auth.log
+// can tell a rate limit from a policy refusal, not to decide whether to let anyone
+// in, and nothing it is given — including NULL — may return PAM_SUCCESS.
+func TestMapErrorCodeAlwaysDenies(t *testing.T) {
+	t.Parallel()
+
+	code := func(s string) *string { return &s }
+
+	cases := []struct {
+		name string
+		code *string
+		want pam.PAMResultCode
+	}{
+		// NULL: what the module has whenever error_code is absent or is not a JSON
+		// string. Reached from classify_response on every malformed refusal.
+		{"NULL", nil, pam.PAMAuthError},
+		{"empty", code(""), pam.PAMAuthError},
+
+		{"RATE_LIMIT_EXCEEDED", code("RATE_LIMIT_EXCEEDED"), pam.PAMMaxTries},
+		// RATE_LIMITED is the code pkg/auth actually emits, and the C side maps it
+		// where the comment above map_error_code says it mirrors
+		// errorCodeToPAMResult in pkg/pam/pam.go — which does not list it, and so
+		// answers PAM_AUTH_ERR for the same reply. Both are denials, so nothing is
+		// unsafe here; the two are simply not in step, and this line pins the C
+		// side's answer rather than papering over the difference.
+		{"RATE_LIMITED", code("RATE_LIMITED"), pam.PAMMaxTries},
+		{"TOO_MANY_CONCURRENT_AUTHS", code("TOO_MANY_CONCURRENT_AUTHS"), pam.PAMMaxTries},
+
+		{"TOO_MANY_SESSIONS", code("TOO_MANY_SESSIONS"), pam.PAMPermDenied},
+		{"POLICY_DENIED", code("POLICY_DENIED"), pam.PAMPermDenied},
+		{"NO_PROVIDER", code("NO_PROVIDER"), pam.PAMPermDenied},
+
+		// The denials the module reaches by way of a vanished session: the broker
+		// deletes the session when identity binding fails, when require_groups
+		// rejects the user, when device-flow polling fails, and when it expires, so
+		// a poll that can no longer find its session was refused.
+		{"SESSION_NOT_FOUND", code("SESSION_NOT_FOUND"), pam.PAMAuthError},
+		{"SESSION_EXPIRED", code("SESSION_EXPIRED"), pam.PAMAuthError},
+		{"FORBIDDEN", code("FORBIDDEN"), pam.PAMAuthError},
+		{"AUTHENTICATION_FAILED", code("AUTHENTICATION_FAILED"), pam.PAMAuthError},
+		{"INVALID_REQUEST", code("INVALID_REQUEST"), pam.PAMAuthError},
+
+		// The comparison is exact, and an unrecognized code is a denial rather than
+		// anything softer, so near-misses need no special handling to be safe.
+		{"unknown", code("SOMETHING_NEW"), pam.PAMAuthError},
+		{"wrong case", code("policy_denied"), pam.PAMAuthError},
+		{"trailing space", code("POLICY_DENIED "), pam.PAMAuthError},
+		{"prefix only", code("POLICY_"), pam.PAMAuthError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapBrokerErrorCode(tc.code)
+
+			if got == pam.PAMSuccess {
+				t.Fatalf("map_error_code(%s) = PAM_SUCCESS: this function is only ever reached "+
+					"because the broker refused the authentication", tc.name)
+			}
+			if got != tc.want {
+				t.Fatalf("map_error_code(%s) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/pam-module/recv_linux.go
+++ b/cmd/pam-module/recv_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package main
+
+// The package's #cgo CFLAGS/LDFLAGS live in bridge_linux.go.
+
+/*
+#include "cgo_bridge.h"
+*/
+import "C"
+
+import "unsafe"
+
+// The RECV_* results receive_auth_response can report, as cgo_bridge.h defines
+// them, so a test names the module's own constants rather than restating -1 and -2.
+const (
+	recvOK               = int(C.RECV_OK)
+	recvError            = int(C.RECV_ERROR)
+	recvResponseTooLarge = int(C.RECV_RESPONSE_TOO_LARGE)
+)
+
+// receiveAuthResponseWithin reads one broker response from fd into a buffer of
+// bufSize bytes, allowing totalTimeoutMS for the whole read, and returns the RECV_*
+// result together with whatever was read.
+//
+// The budget is a parameter only so that a test can use a short one. The module
+// itself always reads through receive_auth_response, which supplies the real
+// RESPONSE_READ_TIMEOUT_MS of 30 s; no test should have to wait 30 s to learn
+// whether the bound holds, and before #196 it would have had to wait rather longer
+// than that — the bound was per-poll, so a peer dribbling one byte per window could
+// hold the read for MAX_RESPONSE_SIZE-1 windows, about 5.7 days. Everything else
+// here is the production read path.
+//
+// bufSize is a parameter for the same reason: it keeps "a full buffer with no end of
+// message in it" reachable without moving 16 KiB through a socket.
+//
+// This wrapper lives in a normal .go file because cgo is not permitted in _test.go
+// files.
+func receiveAuthResponseWithin(fd, bufSize, totalTimeoutMS int) (int, string) {
+	buf := make([]byte, bufSize)
+
+	var into *C.char
+	if bufSize > 0 {
+		into = (*C.char)(unsafe.Pointer(&buf[0]))
+	}
+
+	rc := int(C.receive_auth_response_within(C.int(fd), into, C.size_t(bufSize),
+		C.int(totalTimeoutMS)))
+
+	// The C side NUL-terminates within bufSize, so the response is the bytes up to
+	// that NUL; C.GoString of a nil pointer is the empty string.
+	return rc, C.GoString(into)
+}

--- a/cmd/pam-module/recv_linux_test.go
+++ b/cmd/pam-module/recv_linux_test.go
@@ -1,0 +1,200 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Tests for the read timeout in receive_auth_response.
+//
+// The timeout used to be per-poll: the full RESPONSE_READ_TIMEOUT_MS was handed to
+// every poll() inside the read loop, so a peer that produced one byte just inside
+// each window reset the clock, and the real bound was one window per byte of the
+// buffer — MAX_RESPONSE_SIZE-1 = 16 383 windows of 30 s, about 5.7 days. The
+// function's own comment promised a total bound (#196).
+//
+// What that costs is not abstract. The read happens inside pam_sm_authenticate,
+// which under sshd runs in the pre-auth child, and sshd's LoginGraceTime — 120 s by
+// default — is the point at which sshd kills that child itself. A module still
+// waiting when that happens gives the user a dropped connection with no explanation
+// and leaves nothing in auth.log naming the broker as the cause: the module never
+// got to decide anything, so it never got to say anything. A total bound is what
+// keeps the verdict, and the log line, on this side.
+//
+// These tests supply their own short budget through receive_auth_response_within.
+// Waiting out the shipped 30 s — let alone the 5.7 days the per-poll version allowed
+// — is not something a test suite can do, which is a large part of why this code
+// went untested.
+
+// brokerPeer is one end of a connected socket pair standing in for the broker: a raw
+// blocking file descriptor for the module to read from, and a writer the test uses
+// to decide exactly when — and whether — bytes appear.
+//
+// A socket pair rather than a Unix listener because what is under test is the timing
+// of the bytes, and nothing here needs a broker that speaks the protocol.
+type brokerPeer struct {
+	moduleFD int
+	peer     *os.File
+}
+
+func newBrokerPeer(t *testing.T) *brokerPeer {
+	t.Helper()
+
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+
+	p := &brokerPeer{moduleFD: fds[0], peer: os.NewFile(uintptr(fds[1]), "broker-peer")}
+
+	t.Cleanup(func() {
+		_ = p.peer.Close()
+		_ = syscall.Close(p.moduleFD)
+	})
+
+	return p
+}
+
+// dribble writes data one byte at a time, every interval, until it runs out or the
+// socket is closed under it. This is the hostile shape: every byte lands inside a
+// fresh poll() window, so a per-poll timeout never fires.
+func (p *brokerPeer) dribble(t *testing.T, data string, interval time.Duration) {
+	t.Helper()
+
+	go func() {
+		for i := 0; i < len(data); i++ {
+			time.Sleep(interval)
+			if _, err := p.peer.Write([]byte(data[i : i+1])); err != nil {
+				return // the module gave up and the test closed the socket
+			}
+		}
+	}()
+}
+
+// A peer that keeps sending, never finishes a message, and never lets a single poll
+// time out must still be cut off — by the total budget, which is the only thing
+// bounding it.
+//
+// The numbers are the test: 300 bytes at 20 ms is 6 s of dribbling, and the buffer
+// is large enough to hold all of it, so the per-poll version would have sat here for
+// those 6 s and then reported the buffer full. With the budget as a total, the read
+// ends after ~500 ms with a timeout.
+func TestReceiveAuthResponseBoundsTheWholeReadNotEachPoll(t *testing.T) {
+	t.Parallel()
+
+	const (
+		budgetMS = 500
+		bufSize  = 512
+	)
+
+	peer := newBrokerPeer(t)
+	peer.dribble(t, strings.Repeat("x", 300), 20*time.Millisecond)
+
+	start := time.Now()
+	rc, got := receiveAuthResponseWithin(peer.moduleFD, bufSize, budgetMS)
+	elapsed := time.Since(start)
+
+	if rc != recvError {
+		t.Fatalf("a peer dribbling bytes forever returned rc=%d (%q), want recvError (%d): the "+
+			"read is bounded by the byte count, not by time", rc, got, recvError)
+	}
+	// Generously above the 500 ms budget and far below the 6 s the per-poll version
+	// would have taken, so a slow machine cannot make this pass or fail by accident.
+	if elapsed > 3*time.Second {
+		t.Fatalf("the read took %s against a %dms total budget: each poll() is getting a fresh "+
+			"budget, so a peer that sends one byte per window holds the login open for as long "+
+			"as it likes — which is what sshd's LoginGraceTime then ends, with no explanation "+
+			"to the user", elapsed, budgetMS)
+	}
+}
+
+// The simple case, and the one the old code did get right: a peer that says nothing
+// at all is cut off when the budget runs out. It is here because the deadline
+// arithmetic is what now produces this timeout, and because it pins the other half
+// of the bound — the read must not give up *early* either, or a broker that is
+// merely slow is reported as a broken one.
+func TestReceiveAuthResponseTimesOutOnASilentBroker(t *testing.T) {
+	t.Parallel()
+
+	const budgetMS = 400
+
+	peer := newBrokerPeer(t)
+
+	start := time.Now()
+	rc, got := receiveAuthResponseWithin(peer.moduleFD, 512, budgetMS)
+	elapsed := time.Since(start)
+
+	if rc != recvError {
+		t.Fatalf("a silent broker returned rc=%d (%q), want recvError (%d)", rc, got, recvError)
+	}
+	if elapsed < 300*time.Millisecond {
+		t.Fatalf("gave up after %s of a %dms budget: a broker that is slow to answer must not be "+
+			"reported as one that is not answering", elapsed, budgetMS)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("gave up after %s, well past the %dms budget", elapsed, budgetMS)
+	}
+}
+
+// The deadline must not break the reason the loop exists. A response that arrives in
+// several pieces — which is every response large enough to be split, and the whole
+// point of looping on recv() (#162) — still has to be read in full while there is
+// budget for it.
+func TestReceiveAuthResponseStillReadsAResponseThatArrivesInPieces(t *testing.T) {
+	t.Parallel()
+
+	const reply = `{"success":true,"session_id":"s","requires_device":false}` + "\n"
+
+	peer := newBrokerPeer(t)
+	// One byte every 2 ms: ~115 ms in total, comfortably inside the budget, and
+	// enough separate recv() calls that a single-read implementation could not pass.
+	peer.dribble(t, reply, 2*time.Millisecond)
+
+	rc, got := receiveAuthResponseWithin(peer.moduleFD, 512, 5000)
+	if rc != recvOK {
+		t.Fatalf("a split response returned rc=%d, want recvOK (%d): the deadline is cutting off "+
+			"reads that are making progress, which refuses logins the module could have served",
+			rc, recvOK)
+	}
+	if got != reply {
+		t.Fatalf("read %q, want %q", got, reply)
+	}
+}
+
+// The timeout and the buffer bound are separate bounds and must stay separately
+// reported: an oversized response is a fault in the contract between the broker and
+// this module (PAM_SERVICE_ERR), while a timeout is a broker that did not answer
+// (PAM_AUTHINFO_UNAVAIL). Confusing the two sends an operator to look at the wrong
+// thing (#162).
+func TestReceiveAuthResponseStillReportsAFullBufferWithNoEndOfMessage(t *testing.T) {
+	t.Parallel()
+
+	peer := newBrokerPeer(t)
+	// Promptly, so the budget is nowhere near exhausted, and with no newline in it.
+	if _, err := peer.peer.Write([]byte(strings.Repeat("Q", 64))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	rc, _ := receiveAuthResponseWithin(peer.moduleFD, 16, 5000)
+	if rc != recvResponseTooLarge {
+		t.Fatalf("rc=%d, want recvResponseTooLarge (%d)", rc, recvResponseTooLarge)
+	}
+}
+
+// A zero-length buffer has nowhere to put even the NUL terminator. It cannot happen
+// from inside the module, which always passes sizeof(response); it is here so the
+// bound is checked before the deadline arithmetic rather than after.
+func TestReceiveAuthResponseRejectsAZeroLengthBuffer(t *testing.T) {
+	t.Parallel()
+
+	peer := newBrokerPeer(t)
+
+	if rc, _ := receiveAuthResponseWithin(peer.moduleFD, 0, 5000); rc != recvError {
+		t.Fatalf("rc=%d, want recvError (%d)", rc, recvError)
+	}
+}


### PR DESCRIPTION
Closes #196, closes #197.

## #196 — the timeout was per-poll, not total

`receive_auth_response` passed `RESPONSE_READ_TIMEOUT_MS` to **each** `poll()` inside
`while (total < cap)`. A peer sending one byte just inside each window reset the clock
every time, so the real bound was one window per byte of the buffer:
`MAX_RESPONSE_SIZE-1` = 16 383 windows × 30 s ≈ **5.7 days**, with the login held open
and an sshd pre-auth child pinned for all of it. The function's own comment promised
"bounded by a total read timeout". Bounding the byte count (#162) bounds how many
windows there are, not how long they last.

The deadline is now taken once before the loop and each `poll()` gets only what is
left of it — which also bounds the `EINTR` path, where a signal previously restarted a
full window. `monotonic_millis()` uses `CLOCK_MONOTONIC` for the same reason
`monotonic_seconds()` does: a wall-clock adjustment mid-login must not move the budget.

The number that matters is sshd's `LoginGraceTime` (default 120 s), past which sshd
kills the pre-auth child itself and the user gets a dropped connection with no reason
given and nothing in `auth.log` naming the broker.

## #197 — the two decision functions had no test of any kind

`classify_response` and `map_error_code` were `static` and absent from
`cgo_bridge.h`, no Go test in the package called into them, and e2e drives an honest
broker that cannot construct the replies they exist to reject. `classify_response`
could have been `return PAM_SUCCESS;` and every suite in this repository would have
been green. Two grants had already gone in exactly that way: `"success":"false"` read
as a success (#168), and a non-boolean `requires_device` read as no device
authorization needed (#201).

Both are now reachable — `map_error_code` directly, `classify_response` through
`classify_response_text`, which takes the wire bytes and performs the same parse-then-
classify that `perform_authentication` does, with the same `PAM_AUTHINFO_UNAVAIL`
verdict for a reply that is not JSON (verified against `perform_authentication`'s own
parse-failure branch). This follows the package's established pattern
(`debug_logging_enabled`, `classify_login_type`, `acct_mgmt_verdict`) rather than
adding a C harness; #197 allows either. No Makefile change is needed — `make
verify-linux` already runs these tests.

~70 cases: `success` as string/number/float/null/object/array/absent/misspelled;
`requires_device` wrong-typed in 9 shapes; wrong-typed `error_code`/`error_message`;
non-object top level; non-JSON. The grants and `BROKER_PENDING` are pinned too, so the
denial tables cannot pass against a module nobody can log in through.

## Non-vacuity

Perturbed only the guard added for #196 — `remaining_ms = deadline - monotonic_millis()`
→ `remaining_ms = total_timeout_ms` (the pre-fix per-poll behaviour) — and ran only the
covering test:

```
--- FAIL: TestReceiveAuthResponseBoundsTheWholeReadNotEachPoll (7.19s)
    recv_linux_test.go:109: the read took 7.187312504s against a 500ms total budget
FAIL
```

0.50 s and PASS unperturbed. Restored byte-exact (`diff -q` silent, sha256 equal).

## Verified in a container, not read-verified

`test/docker/Dockerfile.verify`, so the C was actually compiled and run:
`check-cgo-quarantine.sh` OK; `go vet ./...` clean; `go test -count=1 -race
./cmd/pam-module/` ok; `golangci-lint run` 0 issues; `go build -buildmode=c-shared` +
`scripts/verify-pam-module.sh` reports all 6 `pam_sm_*` entry points and libpam linked.

## Found, not fixed

- **The read bound plus the device-flow budget lands exactly on `LoginGraceTime`:**
  `DEFAULT_AUTH_TIMEOUT` (90 s) + one final 30 s read = 120 s, i.e. at sshd's default
  limit rather than inside it, and `MAX_AUTH_TIMEOUT` is 900 s. Documented the
  arithmetic in the comment; shrinking a shipped default is a separate decision.
- **`map_error_code` and `pkg/pam`'s `errorCodeToPAMResult` are not in step**, despite
  the C comment saying they are: the C maps `RATE_LIMITED` — the code
  `pkg/auth/broker.go:539` actually emits — to `PAM_MAXTRIES`, while the Go version has
  no such case and answers `PAM_AUTH_ERR`. Both are denials, so nothing is unsafe. The
  C answer is pinned and the divergence noted inline; a parity test is impossible from
  `cmd/pam-module` while `errorCodeToPAMResult` is unexported.