### PR TITLE
fix(broker): remove the entry before deleting the record that finds it (#228)

### DIFF
--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -316,19 +316,37 @@ func (b *Broker) reconcileIssuedKeys() {
 
 	// One pass per account, not per key: RemoveOIDCKeys clears every broker-issued
 	// entry the account has, so a user with several orphans is handled once.
-	usernames := make(map[string]struct{}, len(infos))
+	//
+	// The store is grouped first and nothing is deleted from it yet, because the order
+	// of these two operations decides what a crash or a failure in the middle leaves
+	// behind (#228). This used to delete every stored record in one loop and only then
+	// remove the authorized_keys entries in a second: the store is the *only* record
+	// naming which accounts hold broker-issued keys, so if the process died in between —
+	// or if RemoveOIDCKeys failed, which the branch below already anticipates — the
+	// entries stayed in authorized_keys with nothing left that would ever revoke them.
+	// The next startup's reconcile has an empty store and does nothing;
+	// sweepExpiredAuthorizedKeys only reaches accounts with a session expiring now, and
+	// these keys belong to no session at all. A user who never logs in again keeps a
+	// working credential forever, which is #171 again by a different route.
+	//
+	// So the entry goes first and the record that lets us find it again is deleted only
+	// once it is gone. The reverse order can leave a live credential nobody can find;
+	// this order can at worst leave a record of a key already removed, which the next
+	// startup retries harmlessly.
+	keyIDs := make(map[string][]string, len(infos))
+	unattributed := make([]string, 0)
 	for _, info := range infos {
-		if info.Username != "" {
-			usernames[info.Username] = struct{}{}
+		if info.Username == "" {
+			// No account to remove an entry from. Deleting the record loses nothing:
+			// there is nothing it could be reconciled against.
+			unattributed = append(unattributed, info.KeyID)
+			continue
 		}
-		if delErr := b.keyManager.DeleteKey(info.KeyID); delErr != nil {
-			log.Warn().Err(delErr).Str("key_id", info.KeyID).
-				Msg("Failed to delete an orphaned stored SSH key at startup")
-		}
+		keyIDs[info.Username] = append(keyIDs[info.Username], info.KeyID)
 	}
 
 	removedTotal := 0
-	for username := range usernames {
+	for username, ids := range keyIDs {
 		removed, remErr := b.authorizedKeysManager.RemoveOIDCKeys(username)
 		if remErr != nil {
 			// Audited, not just logged: an entry that could not be removed is a
@@ -348,20 +366,38 @@ func (b *Broker) reconcileIssuedKeys() {
 			if b.metrics != nil {
 				b.metrics.RecordSSHKeyOp("revoke", "failure")
 			}
+			// The records stay, deliberately: they are what the next startup needs to
+			// know this account still has entries to remove.
 			continue
 		}
 		removedTotal += removed
 		if removed > 0 && b.metrics != nil {
 			b.metrics.RecordSSHKeyOp("revoke", "success")
 		}
+		b.deleteStoredKeys(ids)
 	}
+	b.deleteStoredKeys(unattributed)
 
 	log.Info().
 		Int("stored_keys", len(infos)).
 		Int("unreadable_stored_keys", unreadable).
-		Int("accounts", len(usernames)).
+		Int("accounts", len(keyIDs)).
 		Int("authorized_keys_entries_removed", removedTotal).
 		Msg("Reconciled SSH keys left over from a previous broker run")
+}
+
+// deleteStoredKeys drops key records from the broker's own store. It is called only
+// once the authorized_keys entries those records stand for are gone, so that a
+// failure never leaves an entry behind with no record naming the account that holds
+// it (#228). A record that outlives its entry is harmless; an entry that outlives its
+// record cannot be found again.
+func (b *Broker) deleteStoredKeys(keyIDs []string) {
+	for _, keyID := range keyIDs {
+		if err := b.keyManager.DeleteKey(keyID); err != nil {
+			log.Warn().Err(err).Str("key_id", keyID).
+				Msg("Failed to delete an orphaned stored SSH key at startup")
+		}
+	}
 }
 
 // DroppedAuditEvents returns the cumulative count of audit events dropped by

--- a/pkg/auth/reconcile_order_test.go
+++ b/pkg/auth/reconcile_order_test.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// reconcileIssuedKeys has two things to do per orphaned key: remove the entry from
+// the account's authorized_keys, and delete the record of it from the broker's own
+// key store. The order matters, and only one order is safe.
+//
+// The store is the only record naming which accounts hold broker-issued keys. It used
+// to be emptied first, in its own loop over every key, before a single
+// authorized_keys entry was touched. So a failure in the second loop — which the code
+// already anticipates, audits as ORPHANED_KEYS_NOT_REMOVED, and continues past — left
+// the entry in place with nothing left that could ever find it again. The next startup
+// reconciles an empty store and does nothing; sweepExpiredAuthorizedKeys only reaches
+// accounts with a session expiring now, and an orphan belongs to no session at all. A
+// user who never logs in again keeps a working credential indefinitely, which is #171
+// by a different route (#228).
+func TestAFailedRemovalLeavesTheRecordThatFindsItAgain(t *testing.T) {
+	env := newRevokeTestEnv(t)
+	// Short enough that the contended account fails fast rather than holding the test
+	// for the lock's default patience.
+	env.broker.authorizedKeysManager.SetLockTimeout(150 * time.Millisecond)
+
+	alice := env.provision(t, "alice")
+	bob := env.provision(t, "bob")
+
+	// Both accounts are authorized before the restart this simulates.
+	for _, username := range []string{"alice", "bob"} {
+		if got := env.authorizedKeys(t, username); !strings.Contains(got, "ssh-") {
+			t.Fatalf("%s was not authorized to begin with; file is %q", username, got)
+		}
+	}
+
+	// Stand in for the removal failing: alice's lock is held by someone else, so
+	// RemoveOIDCKeys("alice") times out. This is the branch the old code already knew
+	// could happen — it audits and continues — having already deleted alice's record.
+	release := holdLock(t, env.broker, "alice")
+
+	// No sessions: every stored key is an orphan, which is the startup state.
+	env.broker.reconcileIssuedKeys()
+
+	// bob's removal succeeded, so both halves are done for bob.
+	if got := env.authorizedKeys(t, "bob"); strings.Contains(got, "ssh-") {
+		t.Errorf("bob's orphaned entry survived a successful removal; file is %q", got)
+	}
+	if _, err := env.broker.keyManager.LoadKey(bob.SSHKeyID); err == nil {
+		t.Error("bob's stored key record survived, though its entry was removed")
+	}
+
+	// alice's removal failed, so her entry is still there — that much is unavoidable.
+	if got := env.authorizedKeys(t, "alice"); !strings.Contains(got, "ssh-") {
+		t.Fatalf("alice's entry was removed while her lock was held; file is %q", got)
+	}
+
+	// This is the assertion. The record must still be there, because it is the only
+	// thing that will bring the next startup back to alice.
+	if _, err := env.broker.keyManager.LoadKey(alice.SSHKeyID); err != nil {
+		t.Fatalf("alice's stored key record was deleted even though her authorized_keys "+
+			"entry could not be removed: nothing now names her account, so no later "+
+			"reconcile will ever revoke that key and it authorizes logins forever (%v)", err)
+	}
+
+	// And the retry actually works, which is the point of keeping the record.
+	release()
+	env.broker.reconcileIssuedKeys()
+
+	if got := env.authorizedKeys(t, "alice"); strings.Contains(got, "ssh-") {
+		t.Errorf("the retried reconcile did not remove alice's entry; file is %q", got)
+	}
+	if _, err := env.broker.keyManager.LoadKey(alice.SSHKeyID); err == nil {
+		t.Error("alice's stored key record survived the retry that removed her entry")
+	}
+}
+
+// holdLock takes the authorized_keys lock for an account and returns the release, so
+// a test can drive both the failure and the retry that follows it. holdUsersLock in
+// key_sweep_test.go releases only at cleanup, which cannot express a retry.
+func holdLock(t *testing.T, broker *Broker, username string) func() {
+	t.Helper()
+
+	path := broker.authorizedKeysManager.LockPath(username)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600) // #nosec G304 -- test temp dir
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	// flock is held per open file description, so this contends with the broker's own
+	// open of the same path even though both are in this process — and it contends for
+	// root too, which a permission-based failure would not.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock: %v", err)
+	}
+
+	var once sync.Once
+	release := func() {
+		once.Do(func() {
+			_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+			_ = f.Close()
+		})
+	}
+	t.Cleanup(release)
+	return release
+}


### PR DESCRIPTION
Closes #228 (item 3; items 1 and 2 landed earlier in the milestone).

Touches only `pkg/auth/broker.go` and a new test file.

## The defect

`reconcileIssuedKeys` deleted **every** stored key record in one loop, and only then
removed the `authorized_keys` entries in a second. The broker's key store is the only
record naming which accounts hold broker-issued keys, so a failure in that second loop
— which the code already anticipates, audits as `ORPHANED_KEYS_NOT_REMOVED`, and
`continue`s past — left the entry in place with nothing that could ever find it again.

The next startup reconciles an empty store and does nothing.
`sweepExpiredAuthorizedKeys` only reaches accounts with a session expiring now, and an
orphan belongs to no session at all. So for a user who never logs in again, the key
authorizes logins forever. That is #171 reached by another route.

The entry now goes first, and a record is deleted per account only once
`RemoveOIDCKeys` has returned nil for it. On failure the records stay — deliberately —
because they are what brings the next startup back to that account. The reverse order
can leave a live credential nobody can find; this order can at worst leave a record of
a key already removed, which the next startup retries harmlessly. Records naming no
account are deleted outright: there is no `authorized_keys` they could be reconciled
against.

## This corrects the issue's own description, twice

#228 item 3 says `reconcileIssuedKeys` "removes before it adds" and that a login in the
window is refused. Reading the function:

1. **It never adds a key.** It is startup revocation of orphans — list the store,
   delete records, remove per account. There are no live sessions at startup, so no
   account is entitled to a broker key and nobody is locked out. The "legitimate user
   locked out" failure mode does not exist in this function.
2. The real defect is the mirror image, and worse: an **illegitimate credential left
   in**, not a legitimate user shut out.

## Non-vacuity

`TestAFailedRemovalLeavesTheRecordThatFindsItAgain` holds alice's `authorized_keys`
lock so `RemoveOIDCKeys("alice")` times out — the exact branch the old code already
knew could happen — while bob's removal succeeds. It asserts bob is fully cleaned up,
alice's entry survives (unavoidable), **alice's record survives** (the point), and that
releasing the lock and reconciling again completes both halves.

The lock is used rather than a permission failure because flock contends for root too,
so the test is not vacuous under the container-based `make verify-linux`.

Restoring the pre-fix ordering (`deleteStoredKeys` for every account up front):

```
--- FAIL: TestAFailedRemovalLeavesTheRecordThatFindsItAgain (0.29s)
    reconcile_order_test.go:66: alice's stored key record was deleted even though her
    authorized_keys entry could not be removed: nothing now names her account, so no
    later reconcile will ever revoke that key and it authorizes logins forever
FAIL
```

Restored byte-identical (`diff -q` silent). There was no test of `reconcileIssuedKeys`
of any kind before this.

`go build`, `go vet`, `go test -race ./...` and `gofmt -s -l .` all clean, on the
rebased tip.