### PR TITLE
feat(release): sign artifacts with cosign keyless and attest SLSA provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,49 @@ on:
     tags:
       - 'v*'
 
+# The workflow-level default is the narrowest grant every job can live with, and
+# `release` is the only job that widens it (#180). This used to be `contents:
+# write` for the whole workflow, which handed a write-capable token to the job
+# that compiles third-party Go code and to the reusable CI call as well. Do not
+# raise anything here to satisfy one job: add it to that job's `permissions:`.
 permissions:
-  contents: write
+  contents: read
+
+env:
+  # Deliberately NOT named COSIGN_*: cosign reads its own configuration out of
+  # that prefix (COSIGN_PASSWORD, COSIGN_REPOSITORY, and COSIGN_OIDC_ISSUER in
+  # cosign v2, which bound to --oidc-issuer). Naming a value we only pass on the
+  # command line COSIGN_OIDC_ISSUER would put it where a future cosign might read
+  # it as the issuer to *sign* against instead of the one to *verify* against, and
+  # that failure is silent.
+
+  # The Sigstore identity this workflow signs as, and therefore the exact string
+  # an operator passes to `cosign verify-blob --certificate-identity` (#180). On a
+  # tag push `github.ref` is `refs/tags/vX.Y.Z`, so the identity names the
+  # workflow *and* the tag: a signature made by a workflow run on some other ref
+  # will not satisfy it. Kept here because three places need to agree on it — the
+  # signing self-check, the pre-publish re-check, and the verification
+  # instructions written into the release notes — and a copy that drifts turns
+  # into instructions that fail for every user.
+  RELEASE_SIGNER_IDENTITY: ${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
+  # The OIDC issuer that mints this job's token. Fulcio records it in the signing
+  # certificate and `cosign verify-blob` requires it, because "signed by a
+  # GitHub Actions workflow" is only meaningful if the certificate says which
+  # issuer vouched for that claim.
+  RELEASE_SIGNER_OIDC_ISSUER: https://token.actions.githubusercontent.com
+  # One pin for cosign itself, read by both the signing job and the pre-publish
+  # verification job. cosign-installer bootstraps a SHA-verified cosign and uses
+  # it to cosign-verify the release named here, so this version is the one thing
+  # the signing path trusts by name — leaving it at the action's default means it
+  # moves whenever the action is bumped.
+  RELEASE_COSIGN_VERSION: v3.1.3
 
 jobs:
   verify-version:
     name: Verify version sync
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,9 +81,9 @@ jobs:
   # copies of the test set drift and the drift is silent — the release would keep
   # passing a weaker gate than every pull request has to clear.
   #
-  # `contents: read` is deliberately narrower than this workflow's `contents:
-  # write`: nothing CI does needs to write, and a called workflow may only be
-  # granted permissions the caller already has.
+  # `permissions:` is stated rather than inherited: a called workflow may only be
+  # granted permissions the caller already has, so this is the ceiling for
+  # everything CI runs, and nothing CI does needs to write.
   ci:
     name: CI
     needs: verify-version
@@ -59,6 +95,8 @@ jobs:
     name: Build (${{ matrix.arch }})
     runs-on: ${{ matrix.runs_on }}
     needs: [verify-version, ci]
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -157,6 +195,18 @@ jobs:
           # consumers have a canonical entrypoint (see scripts/install-release.sh).
           cp scripts/install-release.sh            ${DIR}/install.sh
           chmod +x                                 ${DIR}/install.sh
+          # A manifest of the payload, *inside* the archive, so install.sh can
+          # refuse to install a binary that does not match what this job built
+          # (#180). The archive's own .sha256 covers the tarball, which nothing
+          # after the download re-checks; this covers the four files that actually
+          # land in /usr/local/bin and /lib/security, checked by the installer
+          # itself at the moment it is about to copy them. Keep the file list in
+          # sync with install-release.sh's verify_payload().
+          (cd ${DIR} && sha256sum \
+            oidc-auth-broker \
+            oidc-admin \
+            pam_oidc.so \
+            oidc-pam-helper > SHA256SUMS)
           tar czf ${DIR}.tar.gz ${DIR}
           sha256sum ${DIR}.tar.gz > ${DIR}.tar.gz.sha256
 
@@ -169,15 +219,33 @@ jobs:
             oidc-pam-*.tar.gz.sha256
           retention-days: 1
 
-  release:
-    name: Create GitHub Release
+  # Signing is a job of its own, deliberately not folded into `release` (#180): no
+  # single job should hold both `id-token: write` (mint a Sigstore signing identity
+  # that speaks for this repository) and `contents: write` (publish a release under
+  # its name). Split, a compromised step here can produce a signature but cannot
+  # publish it, and a compromised step in `release` can publish but cannot forge a
+  # signature over what it publishes. Merging them for convenience gives one
+  # blast radius the ability to do both.
+  sign:
+    name: Sign and attest
     runs-on: ubuntu-latest
     needs: build
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    permissions:
+      # Keyless signing. cosign exchanges this job's OIDC token for a short-lived
+      # Fulcio signing certificate; the identity an operator verifies *is* this
+      # workflow at this tag. Remove `id-token: write` and there is nothing to sign
+      # with — no key is stored in this repository or in its secrets, which is the
+      # property this whole job exists to preserve (#180).
+      id-token: write
+      # actions/attest-build-provenance writes the SLSA provenance attestation into
+      # this repository's attestation store, which is what `gh attestation verify`
+      # reads back. Without this scope the attestation step fails with a 403 and
+      # the release ships signed but with no statement of where it was built.
+      attestations: write
+      contents: read
 
+    steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -186,9 +254,11 @@ jobs:
           path: dist/
 
       # The .sha256 files are computed in the build job, before the upload, but
-      # until now nothing re-checked them after the download — so anything that
-      # substituted an artifact between the two steps went undetected (#221). The
-      # checksums are only evidence if something compares them.
+      # nothing re-checked them after the download — so anything that substituted
+      # an artifact between the two steps went undetected (#221). The checksums are
+      # only evidence if something compares them. This runs before signing for the
+      # obvious reason: a signature over a substituted tarball is worse than no
+      # signature, because it is a true statement about the wrong bytes.
       - name: Verify artifact checksums
         working-directory: dist
         run: |
@@ -208,6 +278,157 @@ jobs:
           sha256sum -c "${sums[@]}"
           echo "Verified ${#tars[@]} artifact(s) against their checksums."
 
+      # One file covering every architecture. The per-arch .tar.gz.sha256 files stay
+      # (README and DEPLOYMENT.md tell users to fetch them, and the build matrix is
+      # where they are produced), but a single signed SHA256SUMS is what lets an
+      # operator check both tarballs against one signature instead of one per
+      # download — and it is what makes the amd64/arm64 asymmetry the issue calls
+      # out impossible to get half-right: if an arch is missing from dist/, it is
+      # missing from the signed manifest too.
+      - name: Build the release checksum manifest
+        working-directory: dist
+        run: |
+          sha256sum ./*.tar.gz | sed 's#\./##' > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: ${{ env.RELEASE_COSIGN_VERSION }}
+
+      # `--yes` because there is no terminal here to accept the transparency-log
+      # notice on; without it cosign blocks and the job dies on the step timeout.
+      #
+      # The output is a Sigstore bundle (.sigstore.json), not the older detached
+      # `.sig` + `.pem` pair: as of cosign v3 `verify-blob` has no `--signature` or
+      # `--certificate` flag at all, so a released .sig/.pem pair would be a
+      # signature current cosign cannot check. The bundle carries the signature,
+      # the Fulcio certificate and the Rekor inclusion proof in one file, which is
+      # also one asset per artifact instead of two or three.
+      #
+      # SHA256SUMS is signed as well as the tarballs, so an operator who trusts one
+      # signature can verify every artifact from it.
+      - name: Sign artifacts with cosign (keyless)
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          for f in *.tar.gz SHA256SUMS; do
+            echo "Signing ${f}"
+            cosign sign-blob --yes --bundle "${f}.sigstore.json" "${f}"
+          done
+
+      # A signature that was never verified is an untested code path, and this one
+      # cannot be tested anywhere but in a real tag run — no pull request can mint
+      # a certificate with this identity in it. So verify here, with exactly the
+      # command the documentation gives users (docs/verifying-releases.md): if the
+      # documented identity or issuer is wrong, this fails the release instead of
+      # shipping instructions that fail for everyone who follows them.
+      - name: Verify the signatures we just produced
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          for f in *.tar.gz SHA256SUMS; do
+            echo "Verifying ${f}"
+            cosign verify-blob \
+              --bundle "${f}.sigstore.json" \
+              --certificate-identity "${RELEASE_SIGNER_IDENTITY}" \
+              --certificate-oidc-issuer "${RELEASE_SIGNER_OIDC_ISSUER}" \
+              "${f}"
+          done
+          echo "All signatures verify against ${RELEASE_SIGNER_IDENTITY}"
+
+      # SLSA v1 build provenance, via GitHub's own action rather than
+      # slsa-framework/slsa-github-generator: the generator is a reusable workflow
+      # that must build the artifacts itself to attest them, which would mean
+      # duplicating the build matrix (including the cgo PAM module and the #140
+      # loadability check) into a second definition — the exact drift #214 removed
+      # from this workflow. attest-build-provenance attests artifacts this workflow
+      # already produced, keeps one build definition, and is what `gh attestation
+      # verify` consumes with no extra asset to download.
+      #
+      # The glob covers both architectures; a subject list that silently matched
+      # only the amd64 tarball is the failure the issue warns about.
+      - name: Generate SLSA build provenance attestations
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: 'dist/*.tar.gz'
+
+      - name: Upload signatures and manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-signatures
+          path: |
+            dist/SHA256SUMS
+            dist/*.sigstore.json
+          retention-days: 1
+          # A release with no signatures is the state this issue exists to end, so
+          # an empty upload here must not pass quietly.
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build, sign]
+
+    permissions:
+      # The only job in this workflow that writes anything. It holds no
+      # `id-token: write`: it publishes signatures made in the `sign` job and
+      # cannot produce new ones (#180).
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: release-linux-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Download signatures and manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-signatures
+          path: dist/
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: ${{ env.RELEASE_COSIGN_VERSION }}
+
+      # Same reasoning as the checksum re-check in `sign` (#221), applied to the
+      # second artifact hand-off this workflow now has: the tarballs and the
+      # signatures over them travel through the artifact store separately and are
+      # reunited here, in the job that publishes them. Checking the pair at the
+      # last moment before `gh release create` means the release either goes out
+      # with signatures that verify or does not go out.
+      - name: Verify signatures and manifest before publishing
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          tars=(*.tar.gz)
+          bundles=(*.sigstore.json)
+          if [ "${#tars[@]}" -eq 0 ]; then
+            echo "::error::no tarballs in dist/"
+            exit 1
+          fi
+          # One bundle per tarball, plus one for SHA256SUMS.
+          if [ "${#bundles[@]}" -ne "$(( ${#tars[@]} + 1 ))" ]; then
+            echo "::error::${#tars[@]} tarball(s) but ${#bundles[@]} signature bundle(s) — expected $(( ${#tars[@]} + 1 )) (one per tarball plus SHA256SUMS). An artifact would be published unsigned."
+            exit 1
+          fi
+          sha256sum -c SHA256SUMS
+          for f in *.tar.gz SHA256SUMS; do
+            cosign verify-blob \
+              --bundle "${f}.sigstore.json" \
+              --certificate-identity "${RELEASE_SIGNER_IDENTITY}" \
+              --certificate-oidc-issuer "${RELEASE_SIGNER_OIDC_ISSUER}" \
+              "${f}"
+          done
+          echo "Verified ${#tars[@]} tarball(s) and SHA256SUMS against ${RELEASE_SIGNER_IDENTITY}"
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -226,8 +447,78 @@ jobs:
             echo "::warning::no CHANGELOG section for ${VERSION}" >&2
             echo "Release ${VERSION}" > release-notes.md
           fi
+
+          # The verification instructions are appended to every release's notes,
+          # not just linked from the docs (#180). The commands need the tag in
+          # them — `--certificate-identity` names this workflow *at this ref* — so
+          # a static document cannot give a user something they can paste, and a
+          # signature nobody is told how to check protects nobody.
+          #
+          # The heredoc is unquoted so ${VERSION}, ${GITHUB_REPOSITORY} and the
+          # $COSIGN_* values from this workflow's env are written out resolved;
+          # \${ARCH} and \${TARBALL} are escaped because they are the reader's to
+          # fill in. Every backtick is escaped for the same reason — unescaped, an
+          # unquoted heredoc would run the fenced block as command substitution.
+          # YAML strips this block's common indentation before bash sees it, which
+          # is why the closing EOF below lines up with the rest of the script and
+          # still lands in column 0.
+          cat >> release-notes.md <<EOF
+
+          ---
+
+          ## Verifying this release
+
+          Artifacts are signed with [cosign](https://docs.sigstore.dev/) keyless
+          signing — there is no oidc-pam signing key; the signer is this
+          repository's release workflow, identified by its GitHub OIDC identity.
+          Every tarball and the \`SHA256SUMS\` manifest have a matching
+          \`.sigstore.json\` bundle, and each tarball also carries a SLSA build
+          provenance attestation. Requires cosign v3 or newer.
+
+          \`\`\`bash
+          ARCH=amd64   # or arm64
+          TARBALL=oidc-pam-${VERSION}-linux-\${ARCH}.tar.gz
+
+          gh release download ${VERSION} --repo ${GITHUB_REPOSITORY} \\
+            --pattern "\${TARBALL}" --pattern "\${TARBALL}.sigstore.json" \\
+            --pattern SHA256SUMS --pattern SHA256SUMS.sigstore.json
+
+          # 1. The signature over the tarball.
+          cosign verify-blob \\
+            --bundle "\${TARBALL}.sigstore.json" \\
+            --certificate-identity "${RELEASE_SIGNER_IDENTITY}" \\
+            --certificate-oidc-issuer ${RELEASE_SIGNER_OIDC_ISSUER} \\
+            "\${TARBALL}"
+
+          # 2. The signed checksum manifest, then the tarball against it.
+          cosign verify-blob \\
+            --bundle SHA256SUMS.sigstore.json \\
+            --certificate-identity "${RELEASE_SIGNER_IDENTITY}" \\
+            --certificate-oidc-issuer ${RELEASE_SIGNER_OIDC_ISSUER} \\
+            SHA256SUMS
+          sha256sum --ignore-missing -c SHA256SUMS
+
+          # 3. The SLSA build provenance: which workflow, commit and builder made it.
+          gh attestation verify "\${TARBALL}" --repo ${GITHUB_REPOSITORY} \\
+            --signer-workflow ${GITHUB_REPOSITORY}/.github/workflows/release.yml
+          \`\`\`
+
+          Each command must print \`Verified OK\` (cosign) or a successful
+          verification summary (\`gh attestation verify\`). If any of them fails, do
+          not install the artifact. See
+          [docs/verifying-releases.md](https://github.com/${GITHUB_REPOSITORY}/blob/${VERSION}/docs/verifying-releases.md)
+          for what each check proves and how to verify offline.
+          EOF
+
+          # Every asset the verification instructions above tell a user to fetch has
+          # to actually be published, or the instructions are a dead end: the
+          # tarballs, the per-arch .sha256 files (README and DEPLOYMENT.md still
+          # document those), the aggregate SHA256SUMS, and one .sigstore.json bundle
+          # per signed file (#180).
           gh release create "${VERSION}" \
             --title "oidc-pam ${VERSION}" \
             --notes-file release-notes.md \
             dist/*.tar.gz \
-            dist/*.sha256
+            dist/*.sha256 \
+            dist/SHA256SUMS \
+            dist/*.sigstore.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,17 @@ jobs:
             fail=1
           fi
 
+          # The README's download snippet must name this version too. It is not a
+          # cosmetic string: every curl, tar and cosign command in that block
+          # interpolates it, so a stale value tells readers to download the wrong
+          # release and to verify a signature it does not have. This drifted to two
+          # versions behind precisely because only the badge was checked (#180).
+          snippet=$(grep -oE '^VERSION=v[0-9][^ ]*' README.md | head -1 | sed 's/^VERSION=v//')
+          if [ "$snippet" != "$VERSION" ]; then
+            echo "::error::README download snippet says VERSION=v$snippet but the tag is '$VERSION'. Use scripts/release.sh to cut releases."
+            fail=1
+          fi
+
           # CHANGELOG must have a section header for this version.
           if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Use scripts/release.sh to cut releases."
@@ -499,8 +510,11 @@ jobs:
           sha256sum --ignore-missing -c SHA256SUMS
 
           # 3. The SLSA build provenance: which workflow, commit and builder made it.
+          #    --repo alone passes for any attestation this repository ever made;
+          #    --signer-workflow pins the workflow and --source-ref the tag.
           gh attestation verify "\${TARBALL}" --repo ${GITHUB_REPOSITORY} \\
-            --signer-workflow ${GITHUB_REPOSITORY}/.github/workflows/release.yml
+            --signer-workflow ${GITHUB_REPOSITORY}/.github/workflows/release.yml \\
+            --source-ref refs/tags/${VERSION}
           \`\`\`
 
           Each command must print \`Verified OK\` (cosign) or a successful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Release artifacts are now signed and carry build provenance (#180).** Until
+  now the only integrity material published was a `.sha256` file uploaded to the
+  same release page as the tarball it describes, which detects a corrupted
+  download and nothing else — anyone able to publish a release could publish a
+  matching checksum. For artifacts that include `pam_oidc.so`, loaded into every
+  authenticating process including `sshd`, and a root-run broker, "where did this
+  binary come from" should be answerable without trusting the release page.
+
+  Each release now publishes, for both `amd64` and `arm64`: the archive, its
+  `.sha256`, a cosign signature bundle (`.sigstore.json`), a single signed
+  `SHA256SUMS` manifest covering every architecture, and a SLSA v1 build
+  provenance attestation per archive (`actions/attest-build-provenance`).
+
+  Signing is cosign *keyless*: the signer is the release workflow's own GitHub
+  Actions OIDC identity, so no key material exists in this repository or in its
+  secrets, and the identity an operator verifies is
+  `https://github.com/scttfrdmn/oidc-pam/.github/workflows/release.yml@refs/tags/<tag>`.
+
+  Signing runs in its own job, which holds `id-token: write` but not
+  `contents: write`; the publishing job holds `contents: write` and cannot mint
+  signatures. The workflow-level default dropped from `contents: write` to
+  `contents: read`. The release workflow verifies its own signatures — with the
+  same command the documentation gives users — before the release is created, and
+  re-verifies them after the artifacts and signatures are reunited for publishing.
+- Release archives now contain a `SHA256SUMS` manifest of the binaries they
+  install, and the bundled `install.sh` verifies it before copying anything into
+  `/usr/local/bin` or `/lib/security`, refusing to install on a mismatch
+  (`OIDC_PAM_SKIP_VERIFY=1` overrides). The archive's own `.sha256` covers only
+  the download; nothing checked the payload that actually reaches PAM.
+
+### Added
+- `docs/verifying-releases.md`: the exact `cosign verify-blob` and
+  `gh attestation verify` commands, including the `--certificate-identity` and
+  `--certificate-oidc-issuer` values for this repository, what each check proves
+  (and what it does not), offline verification, and the pitfalls of matching the
+  signer identity with a regexp. Every release's notes now carry the same
+  commands with the tag substituted in.
+
 ## [0.5.0] - 2026-08-14
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`OIDC_PAM_SKIP_VERIFY=1` overrides). The archive's own `.sha256` covers only
   the download; nothing checked the payload that actually reaches PAM.
 
+### Fixed
+- The README's release-download snippet still read `VERSION=v0.4.0`, two releases
+  stale, and every `curl`, `tar` and verification command below it interpolates
+  that value — so the new signature-verification instructions would have been run
+  against a release that has no signature. `scripts/release.sh` now stamps that
+  line alongside the version badge, and the release workflow's version check fails
+  the release if it disagrees with the tag; previously it read only the badge and
+  the CHANGELOG, which is why this drifted unnoticed.
+- `gh attestation verify` is now given `--source-ref` in the README and in the
+  generated release notes, matching `docs/verifying-releases.md`, which explains
+  why: `--repo` alone is satisfied by any attestation this repository has ever
+  produced.
+- SECURITY.md's supported-versions table still claimed 0.4.x.
+
 ### Added
 - `docs/verifying-releases.md`: the exact `cosign verify-blob` and
   `gh attestation verify` commands, including the `--certificate-identity` and

--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ cd oidc-pam-${VERSION}-linux-${ARCH}
 sudo ./install.sh            # add --configure-pam to wire pam_oidc.so into sshd
 ```
 
+Releases from v0.5.1 on are signed with cosign keyless signing and carry SLSA
+build provenance. The checksum above only detects a corrupted download — to check
+that the tarball came from this repository's release workflow, verify the signature
+and the attestation:
+
+```bash
+cosign verify-blob \
+  --bundle oidc-pam-${VERSION}-linux-${ARCH}.tar.gz.sigstore.json \
+  --certificate-identity "https://github.com/scttfrdmn/oidc-pam/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  oidc-pam-${VERSION}-linux-${ARCH}.tar.gz
+
+gh attestation verify oidc-pam-${VERSION}-linux-${ARCH}.tar.gz \
+  --repo scttfrdmn/oidc-pam \
+  --signer-workflow scttfrdmn/oidc-pam/.github/workflows/release.yml
+```
+
+Both must succeed before you install. See
+[docs/verifying-releases.md](docs/verifying-releases.md) for what each check
+proves, the signed `SHA256SUMS` manifest, and offline verification.
+
 See [DEPLOYMENT.md](DEPLOYMENT.md) for the full deployment guide (including the
 identity model and prerequisites).
 
@@ -183,6 +204,7 @@ There is no cached credential that lets the next `ssh` skip the prompt.
 - [Configuration Guide](configs/CONFIGURATION-GUIDE.md) — provider setup, security best practices, troubleshooting
 - [Requirements](REQUIREMENTS.md)
 - [Security Policy](SECURITY.md)
+- [Verifying a Release](docs/verifying-releases.md) — cosign signature and SLSA provenance checks for release artifacts
 - Provider examples: [`configs/providers/`](configs/providers/) (Okta, Azure AD, Keycloak, AWS IAM Identity Center)
 - [`docs/design/`](docs/design/) — early design and positioning notes, kept for provenance. Aspirational, unmaintained, and not a description of the current system
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ bundled installer. The installer places the binaries, an example config, and the
 systemd unit; it does **not** modify PAM unless you pass `--configure-pam`.
 
 ```bash
-VERSION=v0.4.0
+VERSION=v0.5.0
 ARCH=amd64   # or arm64
 
 curl -fsSLO https://github.com/scttfrdmn/oidc-pam/releases/download/${VERSION}/oidc-pam-${VERSION}-linux-${ARCH}.tar.gz
@@ -95,7 +95,8 @@ cosign verify-blob \
 
 gh attestation verify oidc-pam-${VERSION}-linux-${ARCH}.tar.gz \
   --repo scttfrdmn/oidc-pam \
-  --signer-workflow scttfrdmn/oidc-pam/.github/workflows/release.yml
+  --signer-workflow scttfrdmn/oidc-pam/.github/workflows/release.yml \
+  --source-ref refs/tags/${VERSION}
 ```
 
 Both must succeed before you install. See

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release security patches for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.4.x   | :white_check_mark: |
-| < 0.4.0 | :x:                |
+| 0.5.x   | :white_check_mark: |
+| < 0.5.0 | :x:                |
 
 **Note:** OIDC PAM is pre-1.0 and under active development. Always test thoroughly before deploying to production, and keep an emergency access path when configuring PAM.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,6 +100,35 @@ OIDC PAM includes several security features:
 - **Session Management**: Automatic token expiration and cleanup
 - **Secure Communication**: Unix socket with strict permissions
 
+## Release Integrity and Provenance
+
+From **v0.5.1** onward, every release artifact is signed and carries build
+provenance. There is **no oidc-pam signing key** and none is stored in this
+repository or in its secrets: signing is
+[cosign](https://docs.sigstore.dev/) *keyless*, so the signer is the release
+workflow's own GitHub Actions OIDC identity and the certificate is short-lived.
+
+Each release publishes, for both `amd64` and `arm64`:
+
+- the archive and its `.sha256`
+- a cosign signature bundle (`.sigstore.json`) for the archive
+- a single signed `SHA256SUMS` manifest covering every architecture
+- a **SLSA v1 build provenance attestation** per archive, verifiable with
+  `gh attestation verify`
+
+Each archive also carries an internal `SHA256SUMS` of the binaries it installs;
+the bundled `install.sh` verifies it and refuses to install on a mismatch.
+
+**Verify before you install.** `pam_oidc.so` is loaded into `sshd` and the broker
+runs as root, so the checksum alone — published to the same page as the archive it
+describes — is not evidence of origin. The exact
+`cosign verify-blob --certificate-identity ... --certificate-oidc-issuer ...` and
+`gh attestation verify` commands, what each one proves, and how to verify offline
+are in **[docs/verifying-releases.md](docs/verifying-releases.md)**.
+
+Releases up to and including v0.5.0 are unsigned and cannot be signed
+retroactively.
+
 ## Security Scanning
 
 This project uses automated security scanning:

--- a/docs/verifying-releases.md
+++ b/docs/verifying-releases.md
@@ -1,0 +1,194 @@
+# Verifying a release
+
+`oidc-pam` ships `pam_oidc.so`, which is loaded into every authenticating process
+on the host — including `sshd` — and a broker that runs as root. "Where did this
+binary come from" should be answerable without trusting the GitHub release page,
+so from **v0.5.1** every release artifact is signed and carries build provenance
+(see [#180](https://github.com/scttfrdmn/oidc-pam/issues/180)).
+
+There is **no oidc-pam signing key**. Signing is
+[cosign](https://docs.sigstore.dev/) *keyless*: the release workflow signs with a
+short-lived certificate issued to its own GitHub Actions OIDC identity. Nothing
+secret is stored in this repository or in its secrets, and the thing you verify is
+not "somebody who had the key" but "this repository's release workflow, running on
+this tag".
+
+## What each release publishes
+
+For each architecture (`amd64`, `arm64`):
+
+| Asset | What it is |
+| --- | --- |
+| `oidc-pam-<version>-linux-<arch>.tar.gz` | the release archive |
+| `oidc-pam-<version>-linux-<arch>.tar.gz.sha256` | its checksum, on its own (integrity of the download only) |
+| `oidc-pam-<version>-linux-<arch>.tar.gz.sigstore.json` | cosign signature bundle for the archive |
+
+and once per release:
+
+| Asset | What it is |
+| --- | --- |
+| `SHA256SUMS` | checksums of **every** architecture's archive, in one file |
+| `SHA256SUMS.sigstore.json` | cosign signature bundle for that manifest |
+
+Each archive additionally has a **SLSA v1 build provenance attestation**, stored
+in GitHub's attestation store rather than as a release asset, and fetched by
+`gh attestation verify`.
+
+Inside each archive there is one more `SHA256SUMS`, covering the four binaries the
+archive installs. `install.sh` checks it before copying anything into
+`/usr/local/bin` and `/lib/security`, and refuses to install if it does not match.
+That manifest travels inside the archive it describes, so it is only meaningful
+*after* you have verified the archive's signature — it protects against a
+half-written extraction, not against a hostile tarball.
+
+## Requirements
+
+- **cosign v3.0 or newer** — <https://docs.sigstore.dev/cosign/system_config/installation/>.
+  The signatures are Sigstore bundles; cosign v3's `verify-blob` reads them with
+  `--bundle`. (Releases deliberately do **not** ship the older detached `.sig` +
+  `.pem` pair: cosign v3 removed `verify-blob --signature`/`--certificate`, so
+  such a pair would be a signature current cosign cannot check.)
+- **`gh` (GitHub CLI)** for the provenance attestation.
+
+## Verify
+
+Substitute the version and architecture you are installing.
+
+```bash
+VERSION=v0.5.1
+ARCH=amd64   # or arm64
+REPO=scttfrdmn/oidc-pam
+TARBALL=oidc-pam-${VERSION}-linux-${ARCH}.tar.gz
+
+# The signer identity is this repository's release workflow AT THIS TAG. A
+# signature made by any other workflow, repository, or ref will not satisfy it.
+IDENTITY="https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/${VERSION}"
+ISSUER="https://token.actions.githubusercontent.com"
+
+gh release download "${VERSION}" --repo "${REPO}" \
+  --pattern "${TARBALL}" --pattern "${TARBALL}.sigstore.json" \
+  --pattern SHA256SUMS --pattern SHA256SUMS.sigstore.json
+```
+
+### 1. The signature over the archive
+
+```bash
+cosign verify-blob \
+  --bundle "${TARBALL}.sigstore.json" \
+  --certificate-identity "${IDENTITY}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${TARBALL}"
+```
+
+Must print `Verified OK`.
+
+### 2. The signed checksum manifest
+
+One signature covers both architectures, so this is the check to use if you
+mirror releases or install more than one arch:
+
+```bash
+cosign verify-blob \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity "${IDENTITY}" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  SHA256SUMS
+
+# --ignore-missing: SHA256SUMS names every arch; you probably downloaded one.
+sha256sum --ignore-missing -c SHA256SUMS
+```
+
+### 3. The build provenance
+
+This is what ties the archive to a commit, a workflow and a builder, rather than
+merely to a signer:
+
+```bash
+gh attestation verify "${TARBALL}" --repo "${REPO}" \
+  --signer-workflow "${REPO}/.github/workflows/release.yml" \
+  --source-ref "refs/tags/${VERSION}"
+```
+
+`--repo` alone will pass for any attestation this repository produced;
+`--signer-workflow` pins it to the release workflow and `--source-ref` to the tag.
+Use all three. Add `--deny-self-hosted-runners` if you want to require a
+GitHub-hosted builder.
+
+### Then install
+
+```bash
+tar -xzf "${TARBALL}"
+cd "oidc-pam-${VERSION}-linux-${ARCH}"
+sudo ./install.sh            # verifies the in-archive SHA256SUMS before installing
+```
+
+**If any check above fails, do not install the artifact**, and please open a
+security report (see [SECURITY.md](../SECURITY.md)) rather than a public issue.
+
+## What each check actually proves
+
+- **`cosign verify-blob` succeeds** — these exact bytes were signed by a workflow
+  run of `.github/workflows/release.yml` in `scttfrdmn/oidc-pam` at this tag,
+  with an identity attested by GitHub's OIDC issuer, and the signature is recorded
+  in Sigstore's public transparency log. Change one byte of the archive and it
+  fails.
+- **`gh attestation verify` succeeds** — GitHub asserts which workflow, which
+  commit and which builder produced the archive, as a SLSA v1 provenance
+  statement.
+- **`sha256sum -c` succeeds** — the archive matches the manifest that the
+  signature in step 2 covers.
+
+What none of them prove: that the source commit is *good*. Provenance answers
+"was this built from this repository by its release workflow", not "is this code
+safe". It makes a swapped or backdoored *artifact* detectable; it does not audit
+the tree it was built from.
+
+## Verifying without network access
+
+Both checks can run offline once the material is on disk.
+
+```bash
+# Provenance: fetch the attestation bundle now (writes a .jsonl file into the
+# current directory, named after the artifact's digest), verify later.
+gh attestation download "${TARBALL}" --repo "${REPO}"
+ls *.jsonl
+
+gh attestation verify "${TARBALL}" --repo "${REPO}" \
+  --signer-workflow "${REPO}/.github/workflows/release.yml" \
+  --bundle <the .jsonl file downloaded above>
+```
+
+`--custom-trusted-root <trusted_root.jsonl>` pins the Sigstore trust root as well,
+for a host that cannot reach GitHub or Sigstore at all. For cosign,
+`verify-blob --trusted-root <file>` does the equivalent — it verifies the bundle
+against a trusted root on disk instead of fetching one over TUF; see
+`cosign trusted-root create --help`.
+
+Air-gapped installs generally want to verify at the boundary and then move the
+verified archive inward, rather than reproducing the Sigstore trust root on every
+host.
+
+## Scripting across versions
+
+If you must accept any tag rather than one specific version, use a regexp — and
+note that this deliberately weakens the check to "some release of this
+repository":
+
+```bash
+cosign verify-blob \
+  --bundle "${TARBALL}.sigstore.json" \
+  --certificate-identity-regexp "^https://github\.com/scttfrdmn/oidc-pam/\.github/workflows/release\.yml@refs/tags/v" \
+  --certificate-oidc-issuer "${ISSUER}" \
+  "${TARBALL}"
+```
+
+Anchor the pattern (`^`) and escape the dots. An unanchored, unescaped pattern
+matches identities you did not intend, which is the usual way an identity check is
+turned into no check at all.
+
+## Releases before v0.5.1
+
+Releases up to and including v0.5.0 have only a `.sha256` file per archive, and no
+signature or provenance. That file is published by the same workflow to the same
+release page as the archive, so it detects a corrupted download and nothing else.
+There is no way to retroactively sign them; verify by other means or upgrade.

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -16,10 +16,22 @@
 # lock you out of SSH on its own. Console login, su and sudo are never wired:
 # the console is the recovery path when the broker is down.
 #
+# The archive ships a SHA256SUMS manifest of its own binaries, written by the
+# release workflow. This script verifies it before installing anything and
+# refuses to continue if it does not match (#180): pam_oidc.so is loaded into
+# every authenticating process on the host, including sshd, so "the bytes in this
+# tarball are the bytes that were built" has to be checked somewhere, and the
+# tarball's own .sha256 covers only the download.
+#
+# The archive and the manifest are both cosign-signed. Verify those signatures
+# before extracting — see docs/verifying-releases.md; a checksum manifest that
+# travelled inside the artifact it describes proves nothing on its own.
+#
 # Environment:
 #   PAM_MODULE_DIR=<dir>   where to install pam_oidc.so, if detection gets it
 #                          wrong. It must be a directory libpam itself loads
 #                          modules from, or the module will never run.
+#   OIDC_PAM_SKIP_VERIFY=1 skip the payload checksum check (see verify_payload).
 
 set -euo pipefail
 
@@ -287,6 +299,38 @@ pam_insert_block() {
     mv -f "$tmp" "$file"
 }
 
+# Verify the archive payload against the manifest the release workflow put in it
+# (#180). Runs before anything is created or copied, so a mismatch leaves the host
+# untouched rather than half-installed.
+#
+# Fails closed on a missing manifest or a missing sha256sum: an archive built by
+# the release workflow always has one, so absence means either a hand-assembled
+# tarball or a tampered one, and "verify unless it is inconvenient" is not
+# verification. Override only if you know why: OIDC_PAM_SKIP_VERIFY=1.
+verify_payload() {
+    local manifest="$SCRIPT_DIR/SHA256SUMS"
+
+    if [[ "${OIDC_PAM_SKIP_VERIFY:-0}" == "1" ]]; then
+        print_warn "OIDC_PAM_SKIP_VERIFY=1: skipping payload checksum verification"
+        return
+    fi
+
+    if [[ ! -f "$manifest" ]]; then
+        print_error "SHA256SUMS not found next to this script. Release archives from v0.5.1 on always contain one; set OIDC_PAM_SKIP_VERIFY=1 to install anyway."
+    fi
+
+    command -v sha256sum >/dev/null 2>&1 \
+        || print_error "sha256sum not found; cannot verify the payload. Install coreutils, or set OIDC_PAM_SKIP_VERIFY=1 to install anyway."
+
+    print_info "Verifying payload against SHA256SUMS..."
+    # --quiet prints only failures. Checked from SCRIPT_DIR because the manifest
+    # names the binaries relative to the archive root.
+    if ! (cd "$SCRIPT_DIR" && sha256sum --quiet -c SHA256SUMS); then
+        print_error "Payload checksum verification FAILED. Do not install this archive: one of its binaries does not match what was built. Re-download and verify its cosign signature (docs/verifying-releases.md)."
+    fi
+    print_info "Payload matches SHA256SUMS"
+}
+
 create_directories() {
     print_info "Creating required directories..."
     install -d -m 0755 "$CONFIG_DIR"
@@ -460,6 +504,9 @@ main() {
     parse_args "$@"
     print_info "Installing OIDC PAM from release tarball..."
     check_root
+    # Before anything is written, and before the host is even inspected: if these
+    # are not the bytes the release workflow built, nothing below should run (#180).
+    verify_payload
     # Before anything is written: a module installed outside PAM's module path is
     # worse than no install at all (#208).
     resolve_pam_dir

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,6 +66,20 @@ perl -0pi -e "s{badge/Version-[^-]*(?:-[^-]*)*?-blue}{badge/Version-${VER}-blue}
 # Simpler, robust replacement of just the version token between 'Version-' and '-blue':
 perl -0pi -e "s{(badge/Version-)([^)]*?)(-blue)}{\${1}${VER}\${3}}g" README.md
 
+# --- stamp the download snippet's VERSION ------------------------------------
+# The README's "From a release" block opens with `VERSION=vX.Y.Z`, and every curl,
+# tar and verify command below it interpolates that. Nothing used to stamp it, so it
+# sat at v0.4.0 through two releases: readers were told to download a version that
+# was no longer current, and — once the cosign instructions landed beneath it — to
+# verify a signature that version does not have (#180). The badge check in
+# verify-version did not catch it because it only reads the badge; that job now
+# checks this line too, so the two cannot disagree again.
+if ! grep -qE '^VERSION=v[0-9]' README.md; then
+  echo "error: could not find the 'VERSION=vX.Y.Z' download snippet in README.md" >&2
+  exit 1
+fi
+perl -0pi -e "s{^VERSION=v[0-9][^\n]*}{VERSION=v${VER}}mg" README.md
+
 # --- roll CHANGELOG: insert a new version section below [Unreleased] ---------
 # Turn:
 #   ## [Unreleased]


### PR DESCRIPTION
Closes #180.

Releases carried one piece of integrity material: a `.sha256` uploaded to the same
release page as the tarball it describes. That detects a corrupted download and
nothing else. For artifacts containing `pam_oidc.so` — loaded into every
authenticating process on the host, `sshd` included — and a root-run broker, "where
did this binary come from" should be answerable without trusting the release page.

## What it does

- **cosign keyless signing.** No key material in the repository or its secrets; the
  signer is the release workflow's own Actions OIDC identity, so what an operator
  verifies is `.../release.yml@refs/tags/<tag>` — a run on any other ref does not
  satisfy it.
- **Split trust.** Signing moved to its own `sign` job holding `id-token: write`
  but **not** `contents: write`; `release` holds `contents: write` and cannot mint
  signatures. The workflow-level default dropped from `contents: write` to
  `contents: read`, so the job that compiles third-party Go code no longer gets a
  write-capable token.
- **Self-verification.** The workflow verifies its own signatures with the exact
  command the docs give users, before publishing, and re-verifies after artifacts
  and signatures are reunited. A documented command that doesn't work now fails the
  release instead of shipping.
- **SLSA v1 provenance** per archive, plus a single signed `SHA256SUMS` covering
  every architecture.
- **In-archive payload manifest.** `install.sh` verifies the four binaries it is
  about to copy into `/usr/local/bin` and `/lib/security` and refuses on mismatch
  (`OIDC_PAM_SKIP_VERIFY=1` overrides).
- `docs/verifying-releases.md`, and the same commands appended to every release's
  notes with the tag substituted in.

## Two deliberate deviations from the issue text

- **Sigstore bundles (`.sigstore.json`), not `.sig` + `.pem`.** cosign v3's
  `verify-blob` has no `--signature`/`--certificate` flag, so a detached pair would
  be a signature current cosign cannot check.
- **`actions/attest-build-provenance`, not `slsa-github-generator`.** The generator
  must rebuild the artifacts itself to attest them, which means a second copy of
  the build matrix — the exact drift #214 removed from this workflow.

## Verification

The keyless signing path **cannot execute before a real tag**: no PR can mint a
certificate with this identity. So it was reviewed line by line, and everything
testable was tested:

- The release-notes heredoc (unquoted, inside YAML, full of backticks and `$`) was
  **extracted from the real workflow file and rendered**: backticks stay literal,
  `${TARBALL}`/`${ARCH}` are left for the reader, tag and identity resolve, nothing
  executes.
- `verify_payload` exercised in four cases against a fake archive — intact (passes),
  tampered binary (fails closed), missing manifest (fails closed), and the
  documented override (warns, proceeds).
- The manifest's four filenames checked against the build job's four `cp`
  destinations.
- Job permissions asserted from the parsed YAML: `sign` = id-token+attestations,
  contents:read; `release` = contents:write only.
- Every `gh attestation verify` flag used confirmed present in gh 2.97.0.
- shellcheck and `bash -n` clean on both scripts touched; Go build/vet/gofmt clean.

## Review follow-ups included

- The README download snippet read `VERSION=v0.4.0`, two releases stale, and every
  command below it interpolates that — the new cosign instructions would have run
  against an unsigned release. Nothing stamped it and nothing checked it, so
  `release.sh` now stamps it and the workflow's version check now fails on
  disagreement. Both directions exercised against a real README.
- `--source-ref` added to `gh attestation verify` in the README and release notes,
  matching the doc's own advice (`--repo` alone passes for any attestation this
  repository ever made).
- SECURITY.md's supported-versions table still said 0.4.x.

## Not done here

- No repository-settings changes (tag protection ruleset, `enforce_admins`,
  required contexts) — those need a separate decision.
- The workflow does not self-verify the *attestation* (only the cosign signatures);
  a flaky check in the publish path is worse than the gap.