### PR TITLE
fix(auth): keep the device code out of the logs, and bound every provider body

### DIFF
--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -671,12 +671,17 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		// max_session_duration across every matching policy. It was computed on
 		// every login and then discarded, so `max_session_duration: 30m` on a sudo
 		// policy produced a session that lived for the full token_lifetime.
-		ExpiresAt:          b.sessionExpiry(createdAt, createdAt, policyResult.MaxDuration),
-		MaxDuration:        policyResult.MaxDuration,
-		LastAccessed:       createdAt,
-		SourceIP:           req.SourceIP,
-		UserAgent:          req.UserAgent,
-		TokenFingerprint:   deviceFlow.DeviceCode,
+		ExpiresAt:    b.sessionExpiry(createdAt, createdAt, policyResult.MaxDuration),
+		MaxDuration:  policyResult.MaxDuration,
+		LastAccessed: createdAt,
+		SourceIP:     req.SourceIP,
+		UserAgent:    req.UserAgent,
+		// TokenFingerprint is deliberately unset here (#219). A pending session has
+		// no token to fingerprint yet — pollDeviceAuthorization fills it in from the
+		// granted token — and what it held instead was the raw device code, the live
+		// credential for the flow this session is waiting on. The field is documented
+		// and treated everywhere else as a hash that is safe to carry and copy, which
+		// is exactly why putting a credential in it is worse than it looks.
 		IsActive:           false,
 		RequireDeviceTrust: policyResult.Metadata[MetadataRequireDeviceTrust] == true,
 		RiskScore:          policyResult.RiskScore,

--- a/pkg/auth/device_code_secrecy_test.go
+++ b/pkg/auth/device_code_secrecy_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// #219: the device code is the credential that completes a login. Whoever holds
+// one while the flow is open can redeem the token the user is about to approve,
+// from anywhere, with no IdP account of their own — and the user's own login then
+// either succeeds or fails with a used-code error they read as a glitch. The user
+// code, and the verification_uri_complete that embeds it, approve the flow.
+//
+// None of them may be written down. The two places they were: a debug log line in
+// StartDeviceFlow — debug being the level DEPLOYMENT.md tells operators to turn on
+// while a login is failing, which is when a code is live — and the pending
+// session's TokenFingerprint field.
+
+// captureLogsAtDebug points the global logger at a buffer and lowers the level to
+// debug for the duration of the test, so a test can assert on what an operator
+// following the troubleshooting instructions would find in the journal.
+func captureLogsAtDebug(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	savedLogger, savedLevel := log.Logger, zerolog.GlobalLevel()
+	log.Logger = zerolog.New(buf).Level(zerolog.DebugLevel)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = savedLogger
+		zerolog.SetGlobalLevel(savedLevel)
+	})
+	return buf
+}
+
+func TestDeviceFlowLogsNoCodeAtDebugLevel(t *testing.T) {
+	const (
+		deviceCode = "dc-9f41c7a2e6b8d035-live-device-code"
+		userCode   = "WDJB-MJHT"
+	)
+	completeURI := "https://idp.example.com/device?user_code=" + userCode
+
+	logs := captureLogsAtDebug(t)
+
+	flow, err := startDeviceFlowAgainst(t, DeviceAuthResponse{
+		DeviceCode:              deviceCode,
+		UserCode:                userCode,
+		VerificationURI:         "https://idp.example.com/device",
+		VerificationURIComplete: completeURI,
+		ExpiresIn:               600,
+		Interval:                5,
+	})
+	if err != nil {
+		t.Fatalf("StartDeviceFlow: %v", err)
+	}
+
+	// The flow still carries all three — this is about what is written down, not
+	// about what the broker knows.
+	if flow.DeviceCode != deviceCode || flow.DeviceURL != completeURI {
+		t.Fatalf("the flow did not come back with the provider's values: %+v", flow)
+	}
+
+	written := logs.String()
+	for _, secret := range []struct{ what, value string }{
+		{"device code", deviceCode},
+		{"user code", userCode},
+		{"complete verification URI", completeURI},
+	} {
+		if strings.Contains(written, secret.value) {
+			t.Errorf("the %s reached the log at debug level; on the shipped unit that is the "+
+				"journal, readable by every account in systemd-journal (#219). Logged: %s",
+				secret.what, written)
+		}
+	}
+
+	// The line has to remain worth keeping, or the next person debugging a device
+	// flow will put the code back.
+	if !strings.Contains(written, "Device flow initiated") {
+		t.Errorf("the device flow is no longer logged at all, so nothing records that one "+
+			"started: %s", written)
+	}
+	if !strings.Contains(written, "test-provider") {
+		t.Errorf("the log line does not name the provider the flow was started against: %s", written)
+	}
+}
+
+// A pending session waits on a device flow; it has no token yet, so it has no
+// token fingerprint. What it used to hold in that field was the device code
+// itself, unhashed — a live credential in a field the code documents, and
+// TestSessionHoldsNoTokenMaterial asserts, as a safe-to-copy identifier.
+func TestPendingSessionCarriesNoDeviceCode(t *testing.T) {
+	env := newDenialTestEnv(t)
+
+	resp, err := env.broker.Authenticate(&AuthRequest{
+		UserID:    "testuser",
+		SourceIP:  "192.0.2.10",
+		LoginType: "ssh",
+	})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("the login was refused before a device flow started: %+v", resp)
+	}
+	// Let the poll goroutine go before the harness waits on it.
+	defer close(env.broker.stopChan)
+
+	session := env.broker.getSession(resp.SessionID)
+	if session == nil {
+		t.Fatalf("no session was recorded for %q", resp.SessionID)
+	}
+	if !session.IsActive && session.TokenFingerprint != "" {
+		t.Errorf("a pending session carries TokenFingerprint %q. There is no token to "+
+			"fingerprint until the flow completes, and what this held was the raw device "+
+			"code — the credential that completes this login — in the one field the "+
+			"broker treats as safe to copy and record (#219)", session.TokenFingerprint)
+	}
+}

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -67,6 +67,20 @@ const (
 	maxUserCodeLen        = 64
 )
 
+// maxProviderResponseBytes bounds every JSON body the broker reads from a
+// provider: discovery, device authorization, token, refresh and userinfo (#223).
+// The decoders used to be pointed straight at resp.Body, so whatever answered as
+// the provider — after a DNS or TLS trust compromise, or simply an `issuer` typo
+// pointing at a host someone else runs — decided how much the broker allocated.
+// The broker is a long-lived root process that every login on the host depends
+// on, so an allocation it cannot refuse is the whole host's problem.
+//
+// 64 KiB is far above anything real: the largest discovery documents in the wild
+// are a few kilobytes, and a token response is bounded by the size of the JWTs in
+// it. A provider that needs more than this is not one the PAM module can carry a
+// response for anyway (MAX_RESPONSE_SIZE is 16 KiB).
+const maxProviderResponseBytes = 64 << 10
+
 // DeviceFlow represents an OAuth2 device authorization flow
 type DeviceFlow struct {
 	DeviceCode      string
@@ -419,8 +433,8 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 
 	// Parse response
 	var deviceResp DeviceAuthResponse
-	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
-		return nil, fmt.Errorf("failed to decode device authorization response: %w", err)
+	if err := decodeProviderJSON(resp.Body, "device authorization response", &deviceResp); err != nil {
+		return nil, err
 	}
 
 	// Reject implausible ExpiresIn values to prevent integer overflow in duration arithmetic.
@@ -458,11 +472,22 @@ func (p *OIDCProvider) StartDeviceFlow(req *AuthRequest) (*DeviceFlow, error) {
 		deviceFlow.DeviceURL = deviceResp.VerificationURIComplete
 	}
 
+	// Nothing here may carry the codes (#219). The device code is the credential
+	// that finishes this login: whoever holds it can redeem the token the user is
+	// about to approve, from anywhere, for as long as the flow is open. The user
+	// code is what approves the flow, and it is also what verification_uri_complete
+	// embeds, so logging either the code or the complete URI hands the flow to any
+	// reader of the journal — which under the shipped unit is every account in
+	// systemd-journal, plus wherever the journal is shipped. Debug is exactly the
+	// level DEPLOYMENT.md tells an operator to turn on while a login is failing,
+	// i.e. while a code is live. What is left is what someone debugging a device
+	// flow can actually act on. The correlation key everywhere else is the session
+	// ID, which does not exist yet: the broker mints it once this returns.
 	log.Debug().
 		Str("provider", p.Name).
-		Str("device_code", deviceFlow.DeviceCode).
-		Str("user_code", deviceFlow.UserCode).
-		Str("device_url", deviceFlow.DeviceURL).
+		Int("device_url_len", len(deviceFlow.DeviceURL)).
+		Int("expires_in", deviceResp.ExpiresIn).
+		Int("polling_interval", deviceFlow.PollingInterval).
 		Msg("Device flow initiated")
 
 	return deviceFlow, nil
@@ -494,6 +519,28 @@ func validateDeviceAuthLengths(resp *DeviceAuthResponse) error {
 	return nil
 }
 
+// decodeProviderJSON decodes a provider's JSON response body into v, reading no
+// more than maxProviderResponseBytes of it. The read is capped at one byte past
+// the limit, which is the least that distinguishes a body over it from one landing
+// exactly on it. what names the response in the error, e.g. "token response".
+//
+// The over-limit message says "decode" deliberately: classifyPollError buckets
+// poll failures by substring, and this is a decode failure in every way that
+// matters to the operator reading the metric.
+func decodeProviderJSON(body io.Reader, what string, v interface{}) error {
+	data, err := io.ReadAll(io.LimitReader(body, maxProviderResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", what, err)
+	}
+	if len(data) > maxProviderResponseBytes {
+		return fmt.Errorf("refused to decode a %s over the %d-byte limit", what, maxProviderResponseBytes)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("failed to decode %s: %w", what, err)
+	}
+	return nil
+}
+
 // PollDeviceAuthorization polls for device authorization completion.
 // ctx is used for ID token verification so callers can apply deadlines.
 func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode, expectedNonce string) (*Token, error) {
@@ -515,8 +562,8 @@ func (p *OIDCProvider) PollDeviceAuthorization(ctx context.Context, deviceCode, 
 
 	// Parse response
 	var tokenResp TokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	if err := decodeProviderJSON(resp.Body, "token response", &tokenResp); err != nil {
+		return nil, err
 	}
 
 	// Handle error responses
@@ -639,10 +686,12 @@ func (p *OIDCProvider) GetUserInfo(token *Token) (*UserInfo, error) {
 		return nil, fmt.Errorf("userinfo request failed with status %d", resp.StatusCode)
 	}
 
-	// Parse user info — limit body to 1 MB to prevent OOM from a malicious provider.
+	// Parse user info. This body was already bounded, at 1 MB; it shares the
+	// provider-wide limit now so that one number governs every provider response
+	// and an over-limit body is reported the same way wherever it arrives.
 	var userInfoClaims map[string]interface{}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&userInfoClaims); err != nil {
-		return nil, fmt.Errorf("failed to decode userinfo response: %w", err)
+	if err := decodeProviderJSON(resp.Body, "userinfo response", &userInfoClaims); err != nil {
+		return nil, err
 	}
 
 	// Merge the two claim sets, with the ID token winning wherever they disagree
@@ -694,8 +743,8 @@ func (p *OIDCProvider) RefreshToken(ctx context.Context, refreshTokenStr string)
 	defer func() { _ = resp.Body.Close() }()
 
 	var tokenResp TokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return nil, fmt.Errorf("failed to decode token refresh response: %w", err)
+	if err := decodeProviderJSON(resp.Body, "token refresh response", &tokenResp); err != nil {
+		return nil, err
 	}
 
 	if tokenResp.Error != "" {
@@ -868,7 +917,7 @@ func (p *OIDCProvider) getDeviceAuthorizationEndpoint() (string, error) {
 		DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&discoveryResp); err != nil {
+	if err := decodeProviderJSON(resp.Body, "discovery document", &discoveryResp); err != nil {
 		return fallback()
 	}
 

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -522,7 +522,8 @@ func validateDeviceAuthLengths(resp *DeviceAuthResponse) error {
 // decodeProviderJSON decodes a provider's JSON response body into v, reading no
 // more than maxProviderResponseBytes of it. The read is capped at one byte past
 // the limit, which is the least that distinguishes a body over it from one landing
-// exactly on it. what names the response in the error, e.g. "token response".
+// exactly on it. The what argument names the response in the error message, e.g.
+// "token response".
 //
 // The over-limit message says "decode" deliberately: classifyPollError buckets
 // poll failures by substring, and this is a decode failure in every way that

--- a/pkg/auth/provider_response_limit_test.go
+++ b/pkg/auth/provider_response_limit_test.go
@@ -1,0 +1,263 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/internal/testoidc"
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"golang.org/x/oauth2"
+)
+
+// #223: every JSON body the broker reads from a provider used to be decoded
+// straight from resp.Body, so the size of the allocation was the provider's
+// choice. "The provider" is whatever answers as one — an attacker-run host
+// reached through a stolen `issuer`, a DNS or TLS trust compromise — and the
+// broker is a root process the host's logins all depend on, with no MemoryMax in
+// the shipped unit. These tests drive each of the five bodies from a stub that
+// answers one byte over the limit.
+
+// providerJSON returns a JSON object of exactly total bytes carrying fields,
+// grown to size with a member none of the response types read. A body built this
+// way still decodes normally, so a test that expects it to be refused is
+// asserting on the size limit and nothing else.
+func providerJSON(t *testing.T, fields map[string]any, total int) []byte {
+	t.Helper()
+
+	padded := make(map[string]any, len(fields)+1)
+	for k, v := range fields {
+		padded[k] = v
+	}
+	padded["padding"] = ""
+
+	empty, err := json.Marshal(padded)
+	if err != nil {
+		t.Fatalf("marshalling the stub body: %v", err)
+	}
+	if len(empty) > total {
+		t.Fatalf("the fields alone are %d bytes, over the %d asked for", len(empty), total)
+	}
+
+	// "p" is a byte JSON never escapes, so the padding costs exactly its length.
+	padded["padding"] = strings.Repeat("p", total-len(empty))
+	body, err := json.Marshal(padded)
+	if err != nil {
+		t.Fatalf("marshalling the padded stub body: %v", err)
+	}
+	if len(body) != total {
+		t.Fatalf("stub body is %d bytes, want exactly %d", len(body), total)
+	}
+	return body
+}
+
+// providerServing is a stub provider answering every request with body.
+func providerServing(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// providerAt builds a provider that talks to a stub server as its whole world:
+// issuer, device endpoint and HTTP client.
+func providerAt(server *httptest.Server) *OIDCProvider {
+	return &OIDCProvider{
+		Name: "test-provider",
+		Config: config.OIDCProvider{
+			Name:           "test-provider",
+			Issuer:         server.URL,
+			ClientID:       "test-client",
+			Scopes:         []string{"openid"},
+			DeviceEndpoint: server.URL + "/device",
+		},
+		httpClient: server.Client(),
+	}
+}
+
+func TestProviderResponsesOverTheLimitAreRefused(t *testing.T) {
+	oversized := maxProviderResponseBytes + 1
+
+	for _, tc := range []struct {
+		name string
+		// body is what the stub answers with, once the test knows how large that
+		// has to be.
+		body func(t *testing.T) []byte
+		// call makes the request that reads it.
+		call func(t *testing.T, server *httptest.Server) error
+	}{
+		{
+			name: "device authorization response",
+			body: func(t *testing.T) []byte {
+				return providerJSON(t, map[string]any{
+					"device_code":      "device-code",
+					"user_code":        "WDJB-MJHT",
+					"verification_uri": "https://idp.example.com/device",
+					"expires_in":       600,
+					"interval":         5,
+				}, oversized)
+			},
+			call: func(t *testing.T, server *httptest.Server) error {
+				_, err := providerAt(server).StartDeviceFlow(&AuthRequest{UserID: "testuser", LoginType: "ssh"})
+				return err
+			},
+		},
+		{
+			name: "token response",
+			body: func(t *testing.T) []byte {
+				return providerJSON(t, map[string]any{
+					"access_token": "at",
+					"token_type":   "Bearer",
+					"expires_in":   3600,
+				}, oversized)
+			},
+			call: func(t *testing.T, server *httptest.Server) error {
+				// The token endpoint is read out of discovery, so an issuer that
+				// advertises the stub is how a real provider points the poll at it.
+				provider := providerWithEndpointAt(t, "token_endpoint", server.URL)
+				_, err := provider.PollDeviceAuthorization(context.Background(), "device-code", "nonce")
+				return err
+			},
+		},
+		{
+			name: "token refresh response",
+			body: func(t *testing.T) []byte {
+				return providerJSON(t, map[string]any{
+					"access_token": "at",
+					"token_type":   "Bearer",
+					"expires_in":   3600,
+				}, oversized)
+			},
+			call: func(t *testing.T, server *httptest.Server) error {
+				provider := providerAt(server)
+				provider.OAuth2Config = &oauth2.Config{Endpoint: oauth2.Endpoint{TokenURL: server.URL + "/token"}}
+				_, err := provider.RefreshToken(context.Background(), "refresh-token")
+				return err
+			},
+		},
+		{
+			name: "userinfo response",
+			body: func(t *testing.T) []byte {
+				return providerJSON(t, map[string]any{"sub": "user-1"}, oversized)
+			},
+			call: func(t *testing.T, server *httptest.Server) error {
+				provider := providerWithEndpointAt(t, "userinfo_endpoint", server.URL)
+				_, err := provider.GetUserInfo(&Token{AccessToken: "at"})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := providerServing(t, tc.body(t))
+
+			err := tc.call(t, server)
+			if err == nil {
+				t.Fatalf("a %d-byte %s was accepted; the broker allocates whatever the "+
+					"provider sends (#223)", oversized, tc.name)
+			}
+			if !strings.Contains(err.Error(), "over the") || !strings.Contains(err.Error(), "limit") {
+				t.Errorf("error does not say the body was over the limit, so an operator cannot "+
+					"tell this from a malformed response: %v", err)
+			}
+		})
+	}
+}
+
+// providerWithEndpointAt is a provider whose discovery document advertises url
+// for one endpoint, so a call that reads that endpoint from discovery — the poll
+// and userinfo paths both do — reaches the stub.
+func providerWithEndpointAt(t *testing.T, endpoint, url string) *OIDCProvider {
+	t.Helper()
+
+	const clientID = "oidc-pam-test-client"
+	idp := testoidc.New(t, clientID)
+	idp.SetEndpointOverride(endpoint, url)
+
+	provider, err := NewOIDCProvider(config.OIDCProvider{
+		Name:            "testidp",
+		Issuer:          idp.Issuer(),
+		ClientID:        clientID,
+		Scopes:          []string{"openid"},
+		EnabledForLogin: true,
+		UserMapping:     config.UserMapping{UsernameClaim: "preferred_username"},
+	}, config.SecurityConfig{
+		TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+	})
+	if err != nil {
+		t.Fatalf("NewOIDCProvider against the in-process issuer: %v", err)
+	}
+	return provider
+}
+
+// A discovery document over the limit is not a fatal error — the endpoint it
+// would have named is guessed instead — but it must not be read. The stub's
+// document advertises a device endpoint that passes every other check, so the
+// endpoint the broker comes back with says whether it decoded the body.
+func TestOversizedDiscoveryDocumentIsNotRead(t *testing.T) {
+	// The advertised endpoint has to be on the issuer's own host to survive
+	// validateEndpoint, so the body cannot be built until the stub's address is
+	// known. An unstarted server has a listener, and therefore an address, before
+	// it serves anything.
+	server := httptest.NewUnstartedServer(nil)
+	t.Cleanup(server.Close)
+	addr := "http://" + server.Listener.Addr().String()
+
+	body := providerJSON(t, map[string]any{
+		"device_authorization_endpoint": addr + "/discovered-device",
+	}, maxProviderResponseBytes+1)
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	server.Start()
+
+	provider := providerAt(server)
+	provider.Config.DeviceEndpoint = "" // force discovery
+
+	endpoint, err := provider.getDeviceAuthorizationEndpoint()
+	if err != nil {
+		t.Fatalf("getDeviceAuthorizationEndpoint: %v", err)
+	}
+	if endpoint == server.URL+"/discovered-device" {
+		t.Fatalf("the broker used an endpoint out of a %d-byte discovery document, so it decoded "+
+			"the whole of it (#223)", maxProviderResponseBytes+1)
+	}
+	if want := server.URL + "/protocol/openid-connect/auth/device"; endpoint != want {
+		t.Errorf("endpoint = %q, want the guessed fallback %q", endpoint, want)
+	}
+}
+
+// The limit is inclusive: a body of exactly maxProviderResponseBytes is a body
+// the broker reads. A bound that rejects the size it documents turns a legitimate
+// provider's largest response into a login failure nobody can explain.
+func TestProviderResponseExactlyAtTheLimitIsAccepted(t *testing.T) {
+	body := providerJSON(t, map[string]any{
+		"device_code":      "device-code",
+		"user_code":        "WDJB-MJHT",
+		"verification_uri": "https://idp.example.com/device",
+		"expires_in":       600,
+		"interval":         5,
+	}, maxProviderResponseBytes)
+
+	flow, err := providerAt(providerServing(t, body)).StartDeviceFlow(&AuthRequest{
+		UserID:    "testuser",
+		LoginType: "ssh",
+	})
+	if err != nil {
+		t.Fatalf("a body of exactly the %d-byte limit was refused: %v", maxProviderResponseBytes, err)
+	}
+	if flow.DeviceCode != "device-code" {
+		t.Errorf("device code = %q, want the one the provider sent", flow.DeviceCode)
+	}
+	if flow.ExpiresAt.Before(time.Now()) {
+		t.Error("the flow is already expired, so the body was not decoded as sent")
+	}
+}


### PR DESCRIPTION
Fixes #219 in full, and part 1 of #223 (the `pkg/auth` half). Verified against
`6f973f2`, not the `d8ca4b3` the issues name.

## What I confirmed, at the line

**#219 (1) — the device code was logged at debug.** `pkg/auth/device_flow.go:461-466`
(pre-fix) was `log.Debug()` with `Str("device_code", …)`, `Str("user_code", …)` and
`Str("device_url", …)`. `device_url` is `verification_uri_complete` whenever the
provider sends one (`:457-459` overwrites it), so the credential was in that line
twice: once by name, once inside the URI. `DEPLOYMENT.md:1091`, under Troubleshooting
→ Authentication Failures, is where operators are told to set `log_level: "debug"`,
which is the state a host is in exactly when a code is live. Confirmed the leak by
capturing the log — the pre-fix line reads:

```
{"level":"debug","provider":"test-provider","device_code":"dc-9f41c7a2e6b8d035-live-device-code",…}
```

**#219 (2) — the issue understates this one.** It says the device code is "fed to
`TokenFingerprint`". It was not fingerprinted at all: `pkg/auth/broker.go:679`
(pre-fix) was `TokenFingerprint: deviceFlow.DeviceCode` — the raw code, assigned
straight into the field. `generateTokenFingerprint` (`device_flow.go:894`) is only
ever called on an access token (`:585`, `:736`). So the effect is worse than
reported, and for the reason the issue gives: `Session.TokenFingerprint` is
documented, and asserted by `TestSessionHoldsNoTokenMaterial`
(`pkg/auth/session_tokens_test.go:27`), to be a hash that is safe to carry, copy and
record *because it is not the secret*. Nothing reads the field while a session is
pending, and `pollDeviceAuthorization` overwrites it (`broker.go:1598`), so it is now
left unset.

One correction to the issue's fix list: it asks for the session ID to be logged
instead. `StartDeviceFlow` does not have one — `Broker.Authenticate` mints the
session only after the call returns (`broker.go:658`) — so the line carries the
provider, the URI's length and the flow's timings instead.

**#223 (1) — four unbounded decodes, one already bounded.** Pre-fix,
`json.NewDecoder(resp.Body).Decode(...)` with no limit at `device_flow.go:422`
(device authorization), `:518` (token), `:697` (refresh) and `:871` (discovery).
`:644` (/userinfo) was already capped, at 1 MB. Also confirmed there is no
`MemoryMax=` in `configs/systemd/oidc-auth-broker.service` — see "Found, not fixed".

## What changed

One decoder, `decodeProviderJSON`, reads at most `maxProviderResponseBytes` (64 KiB)
and reports an over-limit body as its own error rather than as a truncated-JSON
syntax error. All five provider bodies go through it. `/userinfo` is tightened from
1 MB to the shared limit deliberately: one number now governs every provider
response, and 64 KiB of claims is already far more than the PAM module can carry a
response for (`MAX_RESPONSE_SIZE` is 16 KiB). The read is capped at limit+1 so that
over-the-limit is distinguishable from exactly-at-limit, following
`pkg/ssh/authorized_keys.go:354`. The over-limit message contains "decode" on
purpose: `classifyPollError` (`broker.go:2312`) buckets poll failures by substring,
so an oversized token response is still recorded as `DECODE_ERROR` rather than
falling through to `POLL_FAILED`. No new config knob — the repo keeps bounds of this
kind as constants (`maxRequestSize`, `maxAuthorizedKeysBytes`, `maxVerificationURILen`).

The discovery path is unchanged in behaviour on failure: an over-limit document
takes the same fallback as an unparseable one.

## Non-vacuity

Four guards, four perturbations, each run against only its covering test, each
restored and confirmed byte-identical with `diff -q`:

| Perturbation | Test | Result |
| --- | --- | --- |
| put `Str("device_code", …)` back in the debug line | `TestDeviceFlowLogsNoCodeAtDebugLevel` | FAIL (printed the code) |
| put `TokenFingerprint: deviceFlow.DeviceCode` back | `TestPendingSessionCarriesNoDeviceCode` | FAIL (`"z8tdQcYvYtdqHTxTkKyiqQ"`) |
| `len(data) > maxProviderResponseBytes*1000` | `TestProviderResponsesOverTheLimitAreRefused`, `TestOversizedDiscoveryDocumentIsNotRead` | FAIL, all 4 subtests + discovery |
| `>` → `>=` (exclusive bound) | `TestProviderResponseExactlyAtTheLimitIsAccepted` | FAIL (refused a body of exactly 65536 bytes) |

## Checks

`gofmt -l .` empty; `go build ./...`; `go test ./...` all green; `go test -race
./pkg/auth/` green; `golangci-lint run ./pkg/auth/...` 0 issues. The `//go:build
linux` cgo files are not compilable on this macOS host, as expected.

## Found, not fixed

1. **#223 (2), the IPC off-by-one, appears to be stale or wrong.** The response cap
   is `internal/ipc/response.go:34` (`maxResponseSize = 16384`), and both comparisons
   against it are already inclusive and mutually consistent: `:69` accepts on
   `len(payload)+1 <= maxResponseSize` and `:86` rejects on `len(payload)+1 >
   maxResponseSize`. I found no wrong-direction boundary. Left alone as outside this
   PR's package, but #223 should not be closed on the strength of that claim without
   someone re-checking it.
2. **No `MemoryMax=` in the shipped unit**, as #223 says
   (`configs/systemd/oidc-auth-broker.service`; `Restart=always`, `RestartSec=10s`).
   Bounding the bodies removes the network path to exhaustion, but not the ceiling
   the issue asks for. `cmd/broker/systemd_unit_test.go` is where a test for it would
   go. Left to a change that owns the unit file, this one being scoped to `pkg/auth`.
3. **`pkg/pam` writes the user code and the verification URL to syslog at
   `LOG_NOTICE`, unconditionally** (`pkg/pam/pam.go:178-183`). That is deliberate and
   documented in the comment above it — it is the only channel the user has for
   learning where to authenticate — but it means the *user* code is still in the
   journal by design even after this change, and if a provider sends
   `verification_uri_complete` the URL carries it. The device code, the credential a
   third party can actually redeem a token with, is now nowhere in any log. Whether
   the user-code half is acceptable is a design question for #219's author, not
   something to change quietly here.

Closes #219
Refs #223
