### PR TITLE
fix(ssh): keep the other sessions' keys when a new login provisions one

### DIFF
--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -1887,8 +1887,9 @@ func (b *Broker) generateSSHKey(session *Session) (*SSHKey, error) {
 		return nil, fmt.Errorf("failed to save SSH key: %w", err)
 	}
 
-	// Install the public key in the user's authorized_keys, as their only
-	// broker-issued key, carrying the expiry sshd will enforce on it (#171).
+	// Install the public key in the user's authorized_keys, carrying the expiry sshd
+	// will enforce on it (#171), alongside the entries the account's other live
+	// sessions are using (#227).
 	if err := b.authorizedKeysManager.AddPublicKey(session.UserID, sshKey.PublicKey, sshKey.ExpiresAt); err != nil {
 		// Best-effort cleanup: remove the stored key if we couldn't authorize it
 		_ = b.keyManager.DeleteKey(session.ID)
@@ -1958,18 +1959,20 @@ func (b *Broker) revokeSSHKey(session *Session) error {
 	// Still best effort — the session is gone either way — but audited as the failure
 	// it is, so an operator can find the host and the file.
 	//
-	// (#171) "Nothing matched" now has a second, innocent cause: a later login for
-	// the same user supersedes the earlier entry, because there is one live
-	// broker-issued key per user. Ask whether the key material still authorizes
-	// anything before raising the alarm, so that the alarm keeps meaning what it says
-	// — the key was already gone, which is the outcome revocation wanted.
+	// (#171) "Nothing matched" has a second, innocent cause: something removed the
+	// entry before this revocation reached it — the expiry sweep, a restart's
+	// reconcile, or a revocation that already ran. (#227 removed the commonest of them:
+	// a later login for the same user no longer takes the earlier session's entry.) Ask
+	// whether the key material still authorizes anything before raising the alarm, so
+	// that the alarm keeps meaning what it says — the key was already gone, which is
+	// the outcome revocation wanted.
 	if !removed {
 		if authorized, checkErr := b.authorizedKeysManager.KeyIsAuthorized(session.UserID, sshKey.PublicKey); checkErr == nil && !authorized {
 			log.Info().
 				Str("session_id", session.ID).
 				Str("user_id", session.UserID).
 				Str("ssh_key_id", session.SSHKeyID).
-				Msg("SSH key was already absent from authorized_keys at revocation (superseded by a later login)")
+				Msg("SSH key was already absent from authorized_keys at revocation")
 
 			if b.auditLogger != nil {
 				b.auditLogger.LogAuthEvent(security.AuditEvent{

--- a/pkg/auth/key_revocation_test.go
+++ b/pkg/auth/key_revocation_test.go
@@ -255,13 +255,18 @@ func TestRevocationThatMatchesNothingIsNotAuditedAsSuccess(t *testing.T) {
 	}
 }
 
-// A second login supersedes the first: one live broker-issued key per account is
-// the invariant, so the earlier entry is gone by the time the earlier session
-// expires. That removal must not then be reported as a failure — it is the
-// intended state, and calling it ssh_key_revocation_incomplete would train
+// A revocation that matches nothing because the entry is genuinely already gone must
+// not be reported as a failure: the credential is absent, which is the outcome
+// revocation wanted, and calling it ssh_key_revocation_incomplete would train
 // operators to ignore the one event that means a credential is still live (#165,
 // #171).
-func TestRevokingASupersededKeyIsNotReportedAsIncomplete(t *testing.T) {
+//
+// (#227) The way an account reached that state used to be a second login, which
+// removed the first login's entry. It does not any more — concurrent sessions each
+// keep their key — so what gets there now is the expiry sweep, a restart's reconcile,
+// or a revocation that already ran once. The removal below stands for all three: what
+// revokeSSHKey sees is the same in every case, an entry that is not there.
+func TestRevokingAKeyThatIsAlreadyGoneIsNotReportedAsIncomplete(t *testing.T) {
 	env := newRevokeTestEnv(t)
 
 	first := env.provision(t, "carol")
@@ -270,12 +275,20 @@ func TestRevokingASupersededKeyIsNotReportedAsIncomplete(t *testing.T) {
 	second := env.provisionSession(t, "carol", "b7e4d5c6a1f09283b7e4d5c6a1f09283b7e4d5c6a1f09283b7e4d5c6a1f09283")
 
 	remaining := env.authorizedKeys(t, "carol")
-	if strings.Contains(remaining, strings.TrimSpace(first.SSHPublicKey)) {
-		t.Fatalf("the first login's key is still authorized after a second login; the account "+
-			"has two live broker keys (#171). File is %q", remaining)
+	for what, key := range map[string]string{"first": first.SSHPublicKey, "second": second.SSHPublicKey} {
+		if !strings.Contains(remaining, strings.TrimSpace(key)) {
+			t.Fatalf("the %s login's key is not authorized, so that session cannot open a "+
+				"connection (#227); file is %q", what, remaining)
+		}
 	}
-	if !strings.Contains(remaining, strings.TrimSpace(second.SSHPublicKey)) {
-		t.Fatalf("the second login's key was not authorized; file is %q", remaining)
+
+	// Something removed the first session's entry before its revocation got there.
+	removed, err := env.broker.authorizedKeysManager.RemovePublicKey("carol", []byte(first.SSHPublicKey))
+	if err != nil {
+		t.Fatalf("RemovePublicKey: %v", err)
+	}
+	if !removed {
+		t.Fatal("the setup removal matched nothing, so the case under test was never reached")
 	}
 
 	// Now the first session expires and its key is revoked. There is nothing left to
@@ -286,21 +299,21 @@ func TestRevokingASupersededKeyIsNotReportedAsIncomplete(t *testing.T) {
 
 	types := env.auditEventTypes(t)
 	if recorded(types, "ssh_key_revocation_incomplete") {
-		t.Errorf("revoking a key that a later login had already superseded was reported as an "+
+		t.Errorf("revoking a key that was already gone from the file was reported as an "+
 			"incomplete revocation; events: %v", types)
 	}
 	if !recorded(types, "ssh_key_revoked") {
-		t.Errorf("revoking a superseded key recorded %v, want ssh_key_revoked", types)
+		t.Errorf("revoking an already-absent key recorded %v, want ssh_key_revoked", types)
 	}
 	if got := env.revokeMetric(t, "failure"); got != 0 {
-		t.Errorf("revoke failure metric = %v for a superseded key, want 0", got)
+		t.Errorf("revoke failure metric = %v for an already-absent key, want 0", got)
 	}
 	if got := env.revokeMetric(t, "success"); got != 1 {
 		t.Errorf("revoke success metric = %v, want 1", got)
 	}
 	// The live login keeps working: revoking the older session must not disturb it.
 	if after := env.authorizedKeys(t, "carol"); !strings.Contains(after, strings.TrimSpace(second.SSHPublicKey)) {
-		t.Errorf("revoking the superseded key removed the live one; file is %q", after)
+		t.Errorf("revoking the older session's key removed the live one; file is %q", after)
 	}
 }
 

--- a/pkg/ssh/authorized_keys.go
+++ b/pkg/ssh/authorized_keys.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -717,8 +718,9 @@ func (akm *AuthorizedKeysManager) SetLockTimeout(d time.Duration) {
 	akm.lockTimeout = d
 }
 
-// AddPublicKey installs the broker's key in a user's authorized_keys, as the
-// user's only broker-issued key, carrying the expiry sshd will enforce on it.
+// AddPublicKey installs the broker's key in a user's authorized_keys, carrying the
+// expiry sshd will enforce on it, alongside the entries the account's other live
+// sessions are using.
 //
 // expiresAt must be in the future: an entry with no expiry, or one already expired,
 // is not something to write into a key list and hope something removes later.
@@ -730,8 +732,9 @@ func (akm *AuthorizedKeysManager) SetLockTimeout(d time.Duration) {
 //     timestamp, so no two logins ever produced one. A user who logged in daily
 //     accumulated one permanently valid key per login, each independently
 //     sufficient to authenticate, and revoking the current session's key left all
-//     the others in place. Now every broker-issued entry for that user is dropped
-//     before the new one is written: one live key, so revoking it revokes access.
+//     the others in place. What bounds that now is the expiry on every entry, the
+//     removal of expired entries below, and maxConcurrentOIDCKeys — not the removal
+//     of entries that still belong to a live session, which is what #227 undid.
 //   - The expiry existed only in the broker's memory and in a comment nothing but
 //     this broker reads. sshd now enforces it itself, which is what makes a key
 //     survive neither a broker restart nor a broker that never gets around to
@@ -783,23 +786,19 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 			return err
 		}
 
-		// Keep everything that is not the broker's. A key the user put there
-		// themselves is none of the broker's business, whatever it authorizes; only
-		// entries carrying the broker's own marker, or a re-add of this very entry,
-		// are dropped.
-		kept := make([]string, 0, len(existing)+2)
-		superseded := 0
-		for _, line := range existing {
-			entry, isEntry := parseKeyEntry(line)
-			if isEntry && (entry.brokerIssued() || entry.isSameEntryAs(newEntry)) {
-				superseded++
-				continue
-			}
-			kept = append(kept, line)
+		plan := akm.planInstall(existing, newEntry, time.Now())
+		if plan.evicted > 0 {
+			// The only case in which this write takes a key a live session may still be
+			// using, so it is said out loud: whoever is holding that session will see its
+			// next connection refused, and this line is the only thing that explains it.
+			log.Warn().
+				Str("username", username).
+				Int("evicted_keys", plan.evicted).
+				Int("limit", maxConcurrentOIDCKeys).
+				Msg("Dropped the oldest broker-issued keys to stay within the per-account limit; " +
+					"sessions holding them cannot open new connections")
 		}
-		kept = dropStrandedBrokerComments(kept)
-
-		kept = append(kept,
+		kept := append(plan.kept,
 			fmt.Sprintf("%s %s", brokerCommentPrefix, time.Now().Format("2006-01-02 15:04:05")),
 			brokerEntryLine(publicKey, expiresAt))
 
@@ -810,12 +809,156 @@ func (akm *AuthorizedKeysManager) AddPublicKey(username string, publicKey []byte
 		log.Info().
 			Str("username", username).
 			Str("authorized_keys_path", authorizedKeysPath).
-			Int("superseded_keys", superseded).
+			Int("replaced_keys", plan.replaced).
+			Int("expired_keys", plan.expired).
+			Int("evicted_keys", plan.evicted).
+			Int("other_live_keys", plan.retained).
 			Time("expires_at", expiresAt).
 			Msg("Public key added to authorized_keys")
 
 		return nil
 	})
+}
+
+// maxConcurrentOIDCKeys is how many broker-issued entries one account may hold at
+// once, and so how many of its sessions can be authorized at the same time.
+//
+// (#227) There used to be one, because an install dropped every broker-issued entry it
+// found before writing its own. That is the ordinary case for anyone with more than one
+// machine: a user logged in from their laptop and then from a jump host, and the second
+// login removed the key the first session was using. The laptop's open connection
+// survived — sshd had already authenticated it — but the next connection was refused,
+// and so was the reconnect a ControlMaster re-dial or a resumed laptop makes, while the
+// broker went on reporting that session as live and unexpired. Nothing in the file, the
+// log or the audit trail said the key had been taken away.
+//
+// "Never evict" is not the answer either. Every login mints a key, so a user who logs
+// in hourly — or a script that logs in in a loop — would grow authorized_keys without
+// limit, and the growth ends somewhere much worse than an untidy file: past
+// maxAuthorizedKeysBytes the broker refuses to read the file at all, at which point no
+// login can be provisioned and no sweep can remove anything for that account until an
+// operator edits it by hand.
+//
+// Sixteen because it is well beyond the number of sessions a person holds at once — a
+// workstation, a laptop, a phone, a handful of jump hosts, each re-authenticating a few
+// times a day — while bounding the broker's own entries to about two kilobytes. Beyond
+// that the account is in a login loop rather than in use, and the newest key is the one
+// worth keeping.
+const maxConcurrentOIDCKeys = 16
+
+// installPlan is what an install decides about the lines already in authorized_keys:
+// the ones that survive it, and a count of each reason the others did not, so that the
+// install can say in its log what it took away.
+type installPlan struct {
+	kept     []string
+	replaced int // this very entry, being rewritten with the current expiry
+	expired  int // broker entries sshd has already stopped honouring
+	evicted  int // live broker entries dropped to stay within maxConcurrentOIDCKeys
+	retained int // broker entries carried through, belonging to the account's other sessions
+}
+
+// planInstall works out which of an account's existing authorized_keys lines survive
+// an install. The new entry is not in the plan: the caller appends it.
+//
+// The rules, in the order they are applied to each line:
+//
+//   - A line that is not an entry the broker installed is kept, whatever it
+//     authorizes. A key the user put there themselves is none of the broker's
+//     business.
+//   - The entry being installed, if it is already in the file, is dropped, because the
+//     line about to be appended is the same entry carrying the current expiry.
+//   - A broker entry whose expiry has passed is dropped. sshd stopped honouring it
+//     already, and an install is a chance to tidy the file without waiting for
+//     RemoveExpiredKeys to reach this account — which only happens when some session
+//     of this user's expires (see the broker's sweepExpiredAuthorizedKeys).
+//   - Every remaining broker entry belongs to one of the account's other sessions and
+//     is kept (#227), up to maxConcurrentOIDCKeys.
+func (akm *AuthorizedKeysManager) planInstall(existing []string, newEntry keyEntry, now time.Time) installPlan {
+	plan := installPlan{kept: make([]string, 0, len(existing)+2)}
+
+	// Which entry to evict cannot be decided a line at a time — it depends on how the
+	// live entries compare with each other — so the first pass only classifies.
+	type liveEntry struct {
+		index    int
+		deadline time.Time
+		dated    bool
+	}
+	drop := make(map[int]bool, len(existing))
+	live := make([]liveEntry, 0, len(existing))
+	for i, line := range existing {
+		entry, isEntry := parseKeyEntry(line)
+		if !isEntry {
+			continue
+		}
+		if entry.isSameEntryAs(newEntry) {
+			drop[i] = true
+			plan.replaced++
+			continue
+		}
+		if !entry.brokerIssued() {
+			continue
+		}
+		deadline, dated := akm.entryDeadline(entry)
+		if dated && now.After(deadline) {
+			drop[i] = true
+			plan.expired++
+			continue
+		}
+		live = append(live, liveEntry{index: i, deadline: deadline, dated: dated})
+	}
+
+	// The entry being installed takes one of the slots, so the existing ones may fill
+	// the rest. The nearest to its expiry goes first: it is the session closest to
+	// ending anyway, and evicting the one with the longest left would take a key that
+	// had the most use still in it.
+	if excess := len(live) - (maxConcurrentOIDCKeys - 1); excess > 0 {
+		sort.SliceStable(live, func(a, b int) bool {
+			if live[a].dated != live[b].dated {
+				// An entry carrying the broker's marker whose expiry cannot be read
+				// either way goes first. RemoveExpiredKeys deliberately retains such an
+				// entry — cleanup fails safe, never early — so if it also outranked keys
+				// known to be live here, a handful of mangled or hand-written lines would
+				// hold the limit permanently and evict every real session's key instead.
+				return !live[a].dated
+			}
+			return live[a].deadline.Before(live[b].deadline)
+		})
+		for _, victim := range live[:excess] {
+			drop[victim.index] = true
+			plan.evicted++
+		}
+		live = live[excess:]
+	}
+	plan.retained = len(live)
+
+	for i, line := range existing {
+		if _, isEntry := parseKeyEntry(line); isEntry && drop[i] {
+			continue
+		}
+		plan.kept = append(plan.kept, line)
+	}
+	// A dropped entry leaves its provenance comment behind, and with several entries in
+	// the file that comment would go on to claim a date for whichever one follows it.
+	plan.kept = pruneBrokerComments(plan.kept)
+	return plan
+}
+
+// entryDeadline returns the moment a broker-issued entry stops authorizing anything,
+// and whether that could be determined at all.
+//
+// It is the entry's own `expiry-time=` option where there is one, because that is what
+// sshd itself honours, and for an entry written by a broker from before that option the
+// issue time in the comment plus the configured lifetime (SetKeyLifetime). An entry
+// that says neither yields false, and every caller treats that as an entry it cannot
+// make claims about.
+func (akm *AuthorizedKeysManager) entryDeadline(entry keyEntry) (time.Time, bool) {
+	if expiry, ok := entry.expiryTime(); ok {
+		return expiry, true
+	}
+	if issued, ok := entry.issuedAt(); ok {
+		return issued.Add(akm.keyLifetime), true
+	}
+	return time.Time{}, false
 }
 
 // RemovePublicKey removes a public key from a user's authorized_keys file. It
@@ -878,7 +1021,7 @@ func (akm *AuthorizedKeysManager) RemovePublicKey(username string, publicKey []b
 
 		// Write filtered content back atomically, refusing to follow symlinks (C-2).
 		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath,
-			dropStrandedBrokerComments(filteredLines), account); err != nil {
+			pruneBrokerComments(filteredLines), account); err != nil {
 			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
 
@@ -980,7 +1123,7 @@ func (akm *AuthorizedKeysManager) RemoveOIDCKeys(username string) (int, error) {
 		if removed == 0 {
 			return nil
 		}
-		return writeAuthorizedKeysLines(sshDir, authorizedKeysPath, dropStrandedBrokerComments(kept), account)
+		return writeAuthorizedKeysLines(sshDir, authorizedKeysPath, pruneBrokerComments(kept), account)
 	})
 	if err != nil {
 		return 0, err
@@ -1050,7 +1193,7 @@ func (akm *AuthorizedKeysManager) RemoveExpiredKeys(username string) error {
 		// Line splitting has stripped every line's newline, so the shared writer is
 		// what puts the file's final one back (#165).
 		if err := writeAuthorizedKeysLines(sshDir, authorizedKeysPath,
-			dropStrandedBrokerComments(filteredLines), account); err != nil {
+			pruneBrokerComments(filteredLines), account); err != nil {
 			return fmt.Errorf("failed to write authorized_keys file: %w", err)
 		}
 
@@ -1071,16 +1214,8 @@ func (akm *AuthorizedKeysManager) entryHasExpired(line string, now time.Time) bo
 	if !ok || !entry.brokerIssued() {
 		return false
 	}
-	// The option is what sshd itself honours, so it wins where both are present.
-	if expiry, ok := entry.expiryTime(); ok {
-		return now.After(expiry)
-	}
-	// An entry from a broker that predates expiry-time=: the comment records when it
-	// was issued, and the configured lifetime says how long that was good for.
-	if issued, ok := entry.issuedAt(); ok {
-		return now.After(issued.Add(akm.keyLifetime))
-	}
-	return false
+	deadline, dated := akm.entryDeadline(entry)
+	return dated && now.After(deadline)
 }
 
 // ListOIDCKeys lists all OIDC PAM keys in a user's authorized_keys file.

--- a/pkg/ssh/concurrent_sessions_test.go
+++ b/pkg/ssh/concurrent_sessions_test.go
@@ -1,0 +1,276 @@
+package ssh
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// (#227) An account gets one broker-issued entry per live session, not one entry
+// full stop.
+//
+// What the single entry cost, on a host where nothing was misconfigured: a user
+// logged in from their laptop and then from a jump host, and the second login's
+// install removed the entry the laptop's session was using. The open connection
+// carried on working, because sshd had already authenticated it, so the loss showed
+// up later and somewhere else — the next `ssh` to the same host refused, a
+// ControlMaster re-dial refused, the reconnect after closing a laptop lid refused —
+// while the broker reported that session as live and unexpired and `CheckSession`
+// agreed. Nothing in authorized_keys, the broker log or the audit trail recorded
+// that the key had been taken away.
+//
+// The tests below pin both halves: concurrent logins each keep their key, and the
+// number of them an account can hold is still bounded.
+
+// liveBrokerEntry renders an entry of exactly the shape an install writes — the
+// expiry-time= option that sshd enforces, in front of a key carrying the broker's
+// marker — so that a planted file is one the broker could itself have produced.
+func liveBrokerEntry(expiresAt time.Time, distinguisher string) string {
+	return brokerEntryLine(brokerKeyLine(expiresAt.Add(-time.Hour), distinguisher), expiresAt)
+}
+
+// brokerComments counts the provenance comments in a file. One per broker-issued
+// entry is right; more than that means an entry's comment outlived it and is now
+// claiming a date for whichever entry follows it.
+func brokerComments(content string) int {
+	return strings.Count(content, brokerCommentPrefix)
+}
+
+// The failure the issue describes, in the smallest form that shows it: two logins,
+// and afterwards both keys must authenticate.
+func TestASecondLoginKeepsTheFirstSessionsKey(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	own := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5MINE personal-laptop"
+	plantLines(t, baseDir, "testuser", own)
+
+	laptop := brokerKeyLine(time.Now().Add(-time.Minute), "LAPTOP")
+	jumphost := brokerKeyLine(time.Now(), "JUMPHOST")
+	if err := akm.AddPublicKey("testuser", laptop, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("AddPublicKey (laptop): %v", err)
+	}
+	if err := akm.AddPublicKey("testuser", jumphost, time.Now().Add(2*time.Hour)); err != nil {
+		t.Fatalf("AddPublicKey (jump host): %v", err)
+	}
+
+	oidcKeys, err := akm.ListOIDCKeys("testuser")
+	if err != nil {
+		t.Fatalf("ListOIDCKeys: %v", err)
+	}
+	if len(oidcKeys) != 2 {
+		t.Errorf("the account holds %d broker-issued keys after two logins, want 2 — one per "+
+			"live session: %q", len(oidcKeys), oidcKeys)
+	}
+	for name, key := range map[string][]byte{"laptop": laptop, "jump host": jumphost} {
+		authorized, err := akm.KeyIsAuthorized("testuser", key)
+		if err != nil {
+			t.Fatalf("KeyIsAuthorized (%s): %v", name, err)
+		}
+		if !authorized {
+			t.Errorf("the %s session's key no longer authorizes anything, so its next connection "+
+				"— or a ControlMaster re-dial — is refused while the broker still calls the "+
+				"session live (#227)", name)
+		}
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if !strings.Contains(content, own) {
+		t.Errorf("the user's own key was removed; the broker only owns its own entries. file is %q", content)
+	}
+	// One provenance comment per entry, not one per login: a comment left behind by an
+	// entry that is gone would date the entry that happens to follow it.
+	if got := brokerComments(content); got != 2 {
+		t.Errorf("the file carries %d broker comments for 2 broker entries; file is %q", got, content)
+	}
+
+	// Each session's key is still revocable on its own — the property that made one
+	// key per account seem safe in the first place, and it does not depend on there
+	// being only one.
+	removed, err := akm.RemovePublicKey("testuser", laptop)
+	if err != nil {
+		t.Fatalf("RemovePublicKey: %v", err)
+	}
+	if !removed {
+		t.Error("revoking the laptop session's key matched nothing, so the revocation is a no-op")
+	}
+	after := readKeys(t, baseDir, "testuser")
+	if strings.Contains(after, "LAPTOP") {
+		t.Errorf("the revoked key still authorizes access; file is %q", after)
+	}
+	if !strings.Contains(after, "JUMPHOST") {
+		t.Errorf("revoking one session's key took the other session's with it; file is %q", after)
+	}
+}
+
+// Keeping the other sessions' keys must not become "keeping everything". An entry
+// sshd has already stopped honouring has to go, whether or not the sweep
+// (RemoveExpiredKeys) ever reaches this account — it only runs for a user who has a
+// session expiring, so for a user whose sessions all ended with the broker that
+// issued them, an install is the next thing that will look at the file.
+func TestAnInstallStillDropsEntriesSSHDHasStoppedHonouring(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	own := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5MINE personal-laptop"
+	plantLines(t, baseDir, "testuser",
+		own,
+		"# Added by OIDC PAM on 2026-01-01 00:00:00",
+		// Expired by its own option, which is the form every current broker writes.
+		liveBrokerEntry(time.Now().Add(-time.Minute), "EXPIREDBYOPTION"),
+		"# Added by OIDC PAM on 2026-01-02 00:00:00",
+		// No option at all: a pre-#171 broker's entry, dated only by its comment, and
+		// older than the configured lifetime.
+		string(brokerKeyLine(time.Now().Add(-48*time.Hour), "EXPIREDBYCOMMENT")),
+		"# Added by OIDC PAM on 2026-01-03 00:00:00",
+		liveBrokerEntry(time.Now().Add(time.Hour), "STILLLIVE"),
+	)
+
+	if err := akm.AddPublicKey("testuser", brokerKeyLine(time.Now(), "NEWLOGIN"), testExpiry()); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	for _, gone := range []string{"EXPIREDBYOPTION", "EXPIREDBYCOMMENT"} {
+		if strings.Contains(content, gone) {
+			t.Errorf("%s survived an install although its expiry has passed; file is %q", gone, content)
+		}
+	}
+	for _, want := range []string{"STILLLIVE", "NEWLOGIN", own} {
+		if !strings.Contains(content, want) {
+			t.Errorf("%s is missing after the install; file is %q", want, content)
+		}
+	}
+	if got := brokerComments(content); got != 2 {
+		t.Errorf("the file carries %d broker comments for 2 broker entries: the comments of the "+
+			"expired entries outlived them. file is %q", got, content)
+	}
+}
+
+// A key per session, with no bound, is a file that grows for as long as the account
+// keeps logging in — and it does not merely get untidy. Past maxAuthorizedKeysBytes
+// the broker refuses to read the file at all, and from then on it can neither
+// provision a login nor sweep anything for that account.
+func TestTheNumberOfLiveKeysAnAccountHoldsIsBounded(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	own := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5MINE personal-laptop"
+	plantLines(t, baseDir, "testuser", own)
+
+	// More logins than the limit, each with a later expiry than the last, as a user
+	// logging in over and over produces.
+	const logins = maxConcurrentOIDCKeys + 4
+	for i := 0; i < logins; i++ {
+		key := brokerKeyLine(time.Now(), fmt.Sprintf("LOGIN%02d", i))
+		if err := akm.AddPublicKey("testuser", key, time.Now().Add(time.Duration(i+1)*time.Hour)); err != nil {
+			t.Fatalf("AddPublicKey (login %d): %v", i, err)
+		}
+	}
+
+	oidcKeys, err := akm.ListOIDCKeys("testuser")
+	if err != nil {
+		t.Fatalf("ListOIDCKeys: %v", err)
+	}
+	if len(oidcKeys) != maxConcurrentOIDCKeys {
+		t.Errorf("%d logins left %d broker-issued keys, want the limit of %d",
+			logins, len(oidcKeys), maxConcurrentOIDCKeys)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	// The newest login is the one that must work: it is the session the user is
+	// sitting in front of.
+	if !strings.Contains(content, fmt.Sprintf("LOGIN%02d", logins-1)) {
+		t.Errorf("the most recent login's key is not in the file; file is %q", content)
+	}
+	// The oldest are the ones that go.
+	for i := 0; i < logins-maxConcurrentOIDCKeys; i++ {
+		if got := fmt.Sprintf("LOGIN%02d", i); strings.Contains(content, got) {
+			t.Errorf("%s is still authorized although %d logins have happened since; file is %q",
+				got, logins-i, content)
+		}
+	}
+	if !strings.Contains(content, own) {
+		t.Errorf("the user's own key was evicted; the limit applies to the broker's own entries "+
+			"only. file is %q", content)
+	}
+	if got := brokerComments(content); got != maxConcurrentOIDCKeys {
+		t.Errorf("the file carries %d broker comments for %d broker entries; file is %q",
+			got, maxConcurrentOIDCKeys, content)
+	}
+}
+
+// Which key the limit takes matters. The one nearest its expiry belongs to the
+// session closest to ending anyway; taking the one with the longest left would cut
+// short the session with the most use still in it.
+func TestTheKeyNearestItsExpiryIsTheOneEvicted(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	// A full complement of live entries, planted out of order so that nothing can pass
+	// this by evicting the first or the last line.
+	lines := make([]string, 0, maxConcurrentOIDCKeys)
+	for _, hours := range []int{5, 1, 9, 3, 7} {
+		lines = append(lines, liveBrokerEntry(time.Now().Add(time.Duration(hours)*time.Hour),
+			fmt.Sprintf("EXPIRESIN%02dH", hours)))
+	}
+	for i := len(lines); i < maxConcurrentOIDCKeys; i++ {
+		lines = append(lines, liveBrokerEntry(time.Now().Add(time.Duration(24+i)*time.Hour),
+			fmt.Sprintf("FILLER%02d", i)))
+	}
+	plantLines(t, baseDir, "testuser", lines...)
+
+	if err := akm.AddPublicKey("testuser", brokerKeyLine(time.Now(), "NEWLOGIN"), testExpiry()); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if strings.Contains(content, "EXPIRESIN01H") {
+		t.Errorf("the entry with the least time left was kept, so something else was evicted "+
+			"instead; file is %q", content)
+	}
+	for _, hours := range []int{3, 5, 7, 9} {
+		if want := fmt.Sprintf("EXPIRESIN%02dH", hours); !strings.Contains(content, want) {
+			t.Errorf("%s was evicted although an entry expiring sooner was available; file is %q",
+				want, content)
+		}
+	}
+	if !strings.Contains(content, "NEWLOGIN") {
+		t.Errorf("the login that caused the eviction did not get its own key; file is %q", content)
+	}
+}
+
+// An entry carrying the broker's marker whose expiry cannot be read either way is the
+// first to go when the limit is reached. RemoveExpiredKeys retains such an entry
+// deliberately — cleanup fails safe, never early — so if it were also preferred to
+// keys known to be live, a handful of mangled lines (the #165 fusion left exactly
+// these) would hold the limit for good and evict every real session's key instead.
+func TestAnEntryWhoseExpiryCannotBeReadIsEvictedFirst(t *testing.T) {
+	baseDir := t.TempDir()
+	akm := newTestManager(t, baseDir)
+
+	// Broker-marked, so it is the broker's to manage, but with nothing in it that says
+	// when it stops working.
+	const undatable = "ssh-rsa AAAAB3NzaC1yc2EUNDATABLE testuser@oidc-pam-not-a-timestamp"
+	lines := []string{undatable}
+	for i := len(lines); i < maxConcurrentOIDCKeys; i++ {
+		lines = append(lines, liveBrokerEntry(time.Now().Add(time.Duration(i+1)*time.Hour),
+			fmt.Sprintf("LIVE%02d", i)))
+	}
+	plantLines(t, baseDir, "testuser", lines...)
+
+	if err := akm.AddPublicKey("testuser", brokerKeyLine(time.Now(), "NEWLOGIN"), testExpiry()); err != nil {
+		t.Fatalf("AddPublicKey: %v", err)
+	}
+
+	content := readKeys(t, baseDir, "testuser")
+	if strings.Contains(content, "UNDATABLE") {
+		t.Errorf("an entry with no readable expiry was kept in preference to a key known to be "+
+			"live; file is %q", content)
+	}
+	if !strings.Contains(content, "LIVE01") {
+		t.Errorf("a live session's key was evicted while an entry the broker cannot date stayed; "+
+			"file is %q", content)
+	}
+}

--- a/pkg/ssh/entry.go
+++ b/pkg/ssh/entry.go
@@ -388,22 +388,40 @@ func isBrokerComment(line string) bool {
 	return strings.HasPrefix(strings.TrimSpace(line), brokerCommentPrefix)
 }
 
-// dropStrandedBrokerComments removes the broker's provenance comments from a set
-// of lines that no longer contains any broker-issued entry. A comment claiming
-// the broker added a key, sitting above the user's own keys because the key it
-// described has been revoked, misleads whoever reads the file next.
-func dropStrandedBrokerComments(lines []string) []string {
-	for _, line := range lines {
-		if entry, ok := parseKeyEntry(line); ok && entry.brokerIssued() {
-			return lines
-		}
-	}
+// pruneBrokerComments removes every provenance comment that no longer describes
+// anything. A comment claiming the broker added a key, sitting above the user's own
+// keys because the key it described has been revoked, misleads whoever reads the file
+// next.
+//
+// The comment belongs to the entry below it, so a comment survives only if the next
+// entry in the file is a broker-issued one and no newer provenance comment has come
+// between the two. (#227) That is finer-grained than the "is there any broker entry
+// left anywhere" test this used to make, which was sufficient only while an account
+// held at most one broker entry: with a live entry per concurrent session, removing one
+// of several entries used to leave its comment behind claiming a date for the entry
+// that happened to follow it.
+func pruneBrokerComments(lines []string) []string {
 	kept := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if isBrokerComment(line) {
+	for i, line := range lines {
+		if isBrokerComment(line) && !describesABrokerEntry(lines[i+1:]) {
 			continue
 		}
 		kept = append(kept, line)
 	}
 	return kept
+}
+
+// describesABrokerEntry reports whether the lines following a provenance comment make
+// it a comment about a broker-issued entry. Blank lines do not separate a comment from
+// its entry; a later provenance comment does, because that one is the entry's own.
+func describesABrokerEntry(rest []string) bool {
+	for _, line := range rest {
+		if isBrokerComment(line) {
+			return false
+		}
+		if entry, ok := parseKeyEntry(line); ok {
+			return entry.brokerIssued()
+		}
+	}
+	return false
 }

--- a/pkg/ssh/reconcile_atomicity_test.go
+++ b/pkg/ssh/reconcile_atomicity_test.go
@@ -28,14 +28,18 @@ import (
 // all-or-nothing — so that correct ordering above is sufficient.
 
 // planted is a key list a previous broker and a user between them left behind: the
-// user's own key, the broker's provenance comment, and one broker-issued entry.
+// user's own key, and two broker-issued entries with their provenance comments — one
+// long past its expiry, one still belonging to a live session (#227), so that a
+// rewrite of this file has both something to remove and something to preserve.
 func plantedKeyList(t *testing.T, baseDir string) string {
 	t.Helper()
 
 	plantLines(t, baseDir, "testuser",
 		"ssh-rsa AAAAB3NzaC1yc2EOWNKEY testuser@laptop",
 		"# Added by OIDC PAM on 2026-01-01 00:00:00",
-		string(brokerKeyLine(time.Now().Add(-time.Hour), "BROKERKEY")),
+		string(brokerKeyLine(time.Now().Add(-48*time.Hour), "STALEKEY")),
+		"# Added by OIDC PAM on 2026-01-02 00:00:00",
+		liveBrokerEntry(time.Now().Add(time.Hour), "LIVEKEY"),
 	)
 	return readKeys(t, baseDir, "testuser")
 }
@@ -84,7 +88,8 @@ func TestAFailedRewriteLeavesTheWholeKeyListInPlace(t *testing.T) {
 	t.Run("expiry sweep", func(t *testing.T) {
 		baseDir := t.TempDir()
 		akm := newTestManager(t, baseDir)
-		akm.SetKeyLifetime(time.Minute) // the planted broker entry is an hour old, so it is stale
+		// The planted legacy entry is two days old, so it is stale under the default
+		// lifetime and there is something for the sweep to try to remove.
 		before := plantedKeyList(t, baseDir)
 		makeUnwritable(t, baseDir)
 
@@ -116,9 +121,10 @@ func TestAFailedRewriteLeavesTheWholeKeyListInPlace(t *testing.T) {
 }
 
 // A successful install must produce the complete set in one step: the new entry
-// present, the superseded broker entry gone, and the user's own key untouched. This is
-// the "compute the desired content and replace" shape stated positively — a file that
-// ever held only some of these is a file some login was refused against.
+// present, the expired broker entry gone, the other session's entry still there
+// (#227), and the user's own key untouched. This is the "compute the desired content
+// and replace" shape stated positively — a file that ever held only some of these is a
+// file some login was refused against.
 func TestAnInstallPublishesTheCompleteDesiredSetAtOnce(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
@@ -136,10 +142,15 @@ func TestAnInstallPublishesTheCompleteDesiredSetAtOnce(t *testing.T) {
 		t.Errorf("the key just installed is not in the file, so the login it authorized cannot be "+
 			"used; file is %q", after)
 	}
-	if strings.Contains(after, "BROKERKEY") {
-		t.Errorf("the superseded broker key is still authorized; file is %q", after)
+	if !strings.Contains(after, "LIVEKEY") {
+		t.Errorf("the entry belonging to the account's other session was removed by this login, "+
+			"so that session cannot open another connection (#227); file is %q", after)
 	}
-	if got := strings.Count(after, "# Added by OIDC PAM on"); got != 1 {
-		t.Errorf("the file carries %d broker comments, not 1; file is %q", got, after)
+	if strings.Contains(after, "STALEKEY") {
+		t.Errorf("the expired broker key is still authorized; file is %q", after)
+	}
+	// One comment per surviving broker entry: the expired entry's comment goes with it.
+	if got := strings.Count(after, "# Added by OIDC PAM on"); got != 2 {
+		t.Errorf("the file carries %d broker comments for 2 broker entries; file is %q", got, after)
 	}
 }

--- a/pkg/ssh/trailing_newline_test.go
+++ b/pkg/ssh/trailing_newline_test.go
@@ -20,9 +20,10 @@ func brokerKeyLine(issuedAt time.Time, distinguisher string) []byte {
 // plantLines writes authorized_keys directly, so a test can set up a state a
 // previous broker left behind.
 //
-// AddPublicKey cannot be used for this any more: it installs one live
-// broker-issued key per user and drops the rest (#171), which is the point of that
-// change and makes it useless for building a file that holds several at once.
+// AddPublicKey cannot be used for this: it writes each entry with the expiry it is
+// given and a comment stamped with the moment of the call, so a file holding an entry
+// a previous broker left behind — expired, undatable, or written before
+// `expiry-time=` existed — is not a file any sequence of installs can produce.
 func plantLines(t *testing.T, baseDir, username string, lines ...string) {
 	t.Helper()
 
@@ -97,9 +98,9 @@ func TestTargetedRemovalLeavesATrailingNewline(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
 
-	// The survivor is the user's own key: since #171 a user has at most one
-	// broker-issued key, so what must be preserved around a targeted removal is the
-	// key the broker did not install.
+	// The survivor is the user's own key, which is what a targeted removal must
+	// preserve whatever else the file holds: the broker's own entries come and go with
+	// the sessions they belong to, and this key does not.
 	doomed := brokerKeyLine(time.Now(), "DOOMED")
 	keeper := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5KEEPER personal-laptop"
 	plantLines(t, baseDir, "testuser", string(doomed), keeper)
@@ -127,9 +128,9 @@ func TestAddSweepAddRevokeRoundTrip(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
 
-	// The survivor is the user's own key. Since #171 the broker keeps at most one of
-	// its own per user, so the file the sweep leaves behind for the next login to
-	// write into is one holding a key that is not the broker's.
+	// The survivor is the user's own key, so the file the sweep leaves behind for the
+	// next login to write into ends in a line the broker does not own — which is what
+	// made the fused line of #165 both permanent and irremovable.
 	stale := brokerKeyLine(time.Now().Add(-48*time.Hour), "STALE")
 	surviving := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5SURVIVING personal-laptop"
 	plantLines(t, baseDir, "testuser", string(stale), surviving)
@@ -180,7 +181,14 @@ func TestAddSweepAddRevokeRoundTrip(t *testing.T) {
 // impossible. A user who logged in daily therefore accumulated one permanently
 // valid key per login, each on its own sufficient to authenticate, so revoking the
 // current session's key left all the earlier ones working (#171).
-func TestASecondLoginSupersedesTheFirstKey(t *testing.T) {
+//
+// What that accumulation is bounded by is now the expiry on each entry and the
+// per-account limit, not the removal of keys that other sessions are still using
+// (#227, and TestASecondLoginKeepsTheFirstSessionsKey). What this test keeps is the
+// file hygiene across repeated logins: whatever the broker keeps, no line may be fused
+// with a comment, no line may be duplicated, and the user's own key is not the
+// broker's to touch.
+func TestRepeatedLoginsLeaveAWellFormedFile(t *testing.T) {
 	baseDir := t.TempDir()
 	akm := newTestManager(t, baseDir)
 
@@ -189,43 +197,40 @@ func TestASecondLoginSupersedesTheFirstKey(t *testing.T) {
 
 	first := brokerKeyLine(time.Now().Add(-time.Minute), "FIRSTLOGIN")
 	second := brokerKeyLine(time.Now(), "SECONDLOGIN")
-	for _, key := range [][]byte{first, second} {
+	for _, key := range [][]byte{first, second, second} {
 		if err := akm.AddPublicKey("testuser", key, testExpiry()); err != nil {
 			t.Fatalf("AddPublicKey: %v", err)
 		}
 	}
 
+	content := readKeys(t, baseDir, "testuser")
+	if fused := fusedLines(content); len(fused) > 0 {
+		t.Errorf("a key line was fused with a login comment, so that key can never be revoked "+
+			"again (#165): %q", fused)
+	}
+	if !strings.HasSuffix(content, "\n") || strings.HasSuffix(content, "\n\n") {
+		t.Errorf("the file does not end in exactly one newline; tail is %q", tail(content))
+	}
+	// Re-installing the same entry replaces it rather than adding a second copy: a
+	// duplicate would survive the revocation of the one the broker knows about.
+	if got := strings.Count(content, "SECONDLOGIN"); got != 1 {
+		t.Errorf("the third install left %d copies of the same entry, not 1; file is %q", got, content)
+	}
 	oidcKeys, err := akm.ListOIDCKeys("testuser")
 	if err != nil {
 		t.Fatalf("ListOIDCKeys: %v", err)
 	}
-	if len(oidcKeys) != 1 {
-		t.Errorf("after two logins the user has %d broker-issued keys, not 1: %q", len(oidcKeys), oidcKeys)
-	}
-
-	content := readKeys(t, baseDir, "testuser")
-	if strings.Contains(content, "FIRSTLOGIN") {
-		t.Error("the first login's key is still in authorized_keys, so it still authenticates " +
-			"after the session that owned it ended")
-	}
-	if !strings.Contains(content, "SECONDLOGIN") {
-		t.Error("the second login's key is missing, so the login cannot be used")
+	if len(oidcKeys) != 2 {
+		t.Errorf("three installs of two distinct keys left %d broker-issued entries, want 2: %q",
+			len(oidcKeys), oidcKeys)
 	}
 	if !strings.Contains(content, own) {
 		t.Errorf("the user's own key was removed; the broker only owns its own entries. file is %q", content)
 	}
-	// The superseded key must no longer authorize anything: that is what makes
-	// revoking the live one a revocation of access.
-	authorized, err := akm.KeyIsAuthorized("testuser", first)
-	if err != nil {
-		t.Fatalf("KeyIsAuthorized: %v", err)
-	}
-	if authorized {
-		t.Error("the first login's key still authorizes access")
-	}
-	// Exactly one provenance comment, not one per login.
-	if got := strings.Count(content, "# Added by OIDC PAM on"); got != 1 {
-		t.Errorf("authorized_keys carries %d broker comments, not 1; file is %q", got, content)
+	// One provenance comment per entry, not one per login.
+	if got := strings.Count(content, "# Added by OIDC PAM on"); got != len(oidcKeys) {
+		t.Errorf("authorized_keys carries %d broker comments for %d broker entries; file is %q",
+			got, len(oidcKeys), content)
 	}
 }
 

--- a/test/e2e/cases.sh
+++ b/test/e2e/cases.sh
@@ -219,19 +219,26 @@ expect_no_module_log() {
 }
 
 expect_oidc_key_for() {
-    local user="$1" keys="/home/$1/.ssh/authorized_keys"
+    expect_oidc_key_count "$1" 1
+}
+
+# expect_oidc_key_count is expect_oidc_key_for for an account with more than one
+# session: since #227 the broker keeps a live entry per session, so the number of
+# them a case expects is the number of logins it has driven.
+expect_oidc_key_count() {
+    local user="$1" want="$2" keys="/home/$1/.ssh/authorized_keys"
     if [[ ! -f "${keys}" ]]; then
         fail "${keys} does not exist: the broker did not install a login key"
         return 1
     fi
     local count
     count="$(grep -c '@oidc-pam-' "${keys}")"
-    if [[ "${count}" -ne 1 ]]; then
-        fail "${keys} has ${count} @oidc-pam- key(s), expected exactly 1"
+    if [[ "${count}" -ne "${want}" ]]; then
+        fail "${keys} has ${count} @oidc-pam- key(s), expected exactly ${want}"
         sed 's/^/      authorized_keys: /' "${keys}"
         return 1
     fi
-    log "${user} has exactly one @oidc-pam- key in authorized_keys"
+    log "${user} has exactly ${want} @oidc-pam- key(s) in authorized_keys"
 }
 
 expect_no_oidc_key_for() {
@@ -244,11 +251,16 @@ expect_no_oidc_key_for() {
     fi
 }
 
-# oidc_key_blob prints the base64 blob of the account's broker-issued key, which
-# is what identifies one issued key against another across logins.
-oidc_key_blob() {
-    awk '/@oidc-pam-/ { for (i = 1; i <= NF; i++) if ($i ~ /^AAAA/) { print $i; exit } }' \
+# oidc_key_blobs prints the base64 blob of every broker-issued entry, one per line,
+# which is what identifies one issued key against another across logins.
+oidc_key_blobs() {
+    awk '/@oidc-pam-/ { for (i = 1; i <= NF; i++) if ($i ~ /^AAAA/) { print $i; next } }' \
         "/home/$1/.ssh/authorized_keys" 2>/dev/null
+}
+
+# oidc_key_blob is oidc_key_blobs for an account with a single broker-issued entry.
+oidc_key_blob() {
+    oidc_key_blobs "$1" | head -1
 }
 
 # PERSONAL_KEY stands in for a key the user put in their own authorized_keys. The
@@ -746,11 +758,18 @@ case_long_verification_uri() {
     expect_no_module_log 'does not fit this module'
 }
 
-# One live broker-issued key per account, however many times the user logs in
-# (#171). The old code appended one on every login and only ever deduplicated
-# byte-identical lines, so an account that logged in daily accumulated a working
-# credential per login, each outliving the session it was issued for.
-case_second_login_supersedes_key() {
+# Two concurrent sessions for one account, both authorized (#227). This case used
+# to assert the opposite — one live key per account, the second login replacing the
+# first — which is the ordinary case for anyone with more than one machine: the
+# laptop's session kept its open connection, because sshd had already authenticated
+# it, and then every new connection and every ControlMaster re-dial from it was
+# refused while the broker went on reporting that session as live and unexpired.
+#
+# What bounds the entries instead is the expiry each one carries (checked below, and
+# the subject of case_orphan_keys_swept), the removal of expired entries by the next
+# login and by the sweep, and a per-account limit far above the number of sessions a
+# person holds at once.
+case_second_login_keeps_the_first_key() {
     reset_state alice || return 1
     plant_personal_key alice
 
@@ -763,6 +782,10 @@ case_second_login_supersedes_key() {
 
     local first
     first="$(oidc_key_blob alice)"
+    if [[ -z "${first}" ]]; then
+        fail "the first login installed no key, so there is nothing for the second to preserve"
+        return 1
+    fi
 
     # A second login, from scratch: a new device flow, a new approval, a new key.
     reset_state alice || return 1
@@ -772,22 +795,31 @@ case_second_login_supersedes_key() {
     reap_login
     expect_login_ok || return 1
 
-    # Exactly one, still.
-    expect_oidc_key_for alice
+    # One entry per session now, not one per account.
+    expect_oidc_key_count alice 2 || return 1
     expect_personal_key_for alice
 
-    local second
-    second="$(oidc_key_blob alice)"
-    if [[ -z "${second}" ]]; then
-        fail "the second login installed no key"
-    elif [[ "${second}" == "${first}" ]]; then
-        fail "the second login reused the first login's key; each session must get its own"
-    else
-        log "the second login replaced the first login's key rather than adding to it"
-    fi
     if grep -qF "${first}" "/home/alice/.ssh/authorized_keys"; then
-        fail "the first login's key is still authorized after a second login (#171)"
+        log "the first session's key is still authorized after a second login"
+    else
+        fail "the second login removed the first session's key: that session cannot open another connection, and neither the file nor the broker says why (#227)"
         sed 's/^/      authorized_keys: /' "/home/alice/.ssh/authorized_keys"
+    fi
+
+    # Distinct key material, so that revoking one session does not revoke the other.
+    local distinct
+    distinct="$(oidc_key_blobs alice | sort -u | wc -l)"
+    if [[ "${distinct}" -ne 2 ]]; then
+        fail "the two sessions share key material (${distinct} distinct blob(s) across 2 entries); revoking either would revoke both"
+    fi
+
+    # Both entries must carry the expiry sshd enforces: with several live at once, that
+    # option is the only thing that removes one if this broker never runs again.
+    if grep '@oidc-pam-' "/home/alice/.ssh/authorized_keys" | grep -qv 'expiry-time="'; then
+        fail "a broker-issued entry has no expiry-time option, so nothing but this broker limits it (#171)"
+        sed 's/^/      authorized_keys: /' "/home/alice/.ssh/authorized_keys"
+    else
+        log "both entries carry the expiry-time option sshd enforces"
     fi
 }
 
@@ -876,7 +908,7 @@ CASES=(
     nonroot_ipc_rejected
     rate_limit_is_per_account
     home_lock_does_not_block_login
-    second_login_supersedes_key
+    second_login_keeps_the_first_key
     orphan_keys_swept
     broker_down
 )


### PR DESCRIPTION
Fixes item 1 of #227. Item 2 (`RefreshSession` extends the session but not the key's `expiry-time=`) is untouched and stays open.

## What the issue claims, and what is actually there

The claim is right. At the base commit, `AddPublicKey`'s critical section was `pkg/ssh/authorized_keys.go:794`:

```go
if isEntry && (entry.brokerIssued() || entry.isSameEntryAs(newEntry)) {
    continue
}
```

Every line carrying the `@oidc-pam-` marker was dropped before the new entry was written, so an account could hold exactly one broker key however many sessions it had. `test/e2e/cases.sh:753` `case_second_login_supersedes_key` did pin that behaviour deliberately, and `cases.sh:802` `case_orphan_keys_swept` is the sweeping half, as the issue says. The user-visible consequence is the one described: the first session's already-authenticated connection survives, but a new connection or a `ControlMaster` re-dial is refused while the broker still reports the session live.

One part of the issue is overstated: **the suggested fix — "key managed entries on `session_id`" — is not needed, and no `session_id` plumbing was added.** The broker's key store is already keyed by session (`pkg/auth/broker.go:1878`, `keyManager.SaveKey(session.ID, sshKey)`), and an authorized_keys entry is already identified by its key blob plus comment (`keyEntry.isSameEntryAs`, `pkg/ssh/entry.go:162`), which is what revocation matches on. Per-session revocation therefore already worked; the only thing wrong was that an install threw away entries that were not its own. The whole fix is inside `pkg/ssh`.

The issue's `pkg/auth/broker.go:728` for `RefreshSession` has drifted to line 802 — expected, it was verified at `d8ca4b3`.

## What changed

`AddPublicKey` now asks `planInstall` which existing lines survive, instead of deciding line by line as it copies. A line that is not a broker entry is kept whatever it authorizes; the entry being installed is dropped, because the appended line is the same entry with the current expiry; a broker entry past its deadline is dropped; everything else is one of the account's other sessions and is kept. The install log says what it took and why (`replaced_keys`, `expired_keys`, `evicted_keys`, `other_live_keys`).

Expiry on the install path is not a second mechanism. `entryDeadline` is now the single place that answers "when does this entry stop authorizing anything" — the `expiry-time=` option where there is one, otherwise the comment's issue time plus the configured lifetime — and `entryHasExpired`, which `RemoveExpiredKeys` uses, is now expressed in terms of it. An expired entry is still removed, by the sweep and now also by any install that happens to see it.

`maxConcurrentOIDCKeys = 16` bounds the file. "Never evict" is not obviously right, as the review note says: past `maxAuthorizedKeysBytes` the reader refuses the file outright and the account can then be neither provisioned nor swept without hand-editing. Sixteen is well past the number of sessions a person holds while keeping the broker's own entries to about two kilobytes. The nearest expiry is evicted first, and an entry whose expiry cannot be read at all goes before that — because `RemoveExpiredKeys` retains such an entry on purpose (cleanup fails safe), so if it also outranked keys known to be live, a few mangled lines could hold the limit permanently and evict real sessions instead. Eviction logs at warning level: it is the only write that can take a key a live session is still using.

`dropStrandedBrokerComments` became `pruneBrokerComments`. Its old test — is there any broker entry anywhere in the file — was only sufficient while an account held at most one; with several entries a stranded comment would survive and go on to claim a date for whichever entry followed it. A comment is now kept only if the next entry below it, before any other comment, is broker-issued.

## Tests

New `pkg/ssh/concurrent_sessions_test.go`: two logins leave two live keys and revoking one leaves the other; an install still drops entries sshd has stopped honouring, by option and by comment; the count is bounded at the limit with the newest kept and the oldest gone; the nearest expiry is the one evicted; an undatable broker entry is evicted before a live one. The user's own key survives all of it, and the provenance comment count tracks the entry count.

Three existing tests asserted the removed behaviour and were rewritten rather than deleted:

- `TestASecondLoginSupersedesTheFirstKey` → `TestRepeatedLoginsLeaveAWellFormedFile`. What it was really protecting is file hygiene across repeated logins (#165, #171): no line fused with a comment, no duplicate entry, exactly one trailing newline, the user's own key untouched. That is all still checked; the "one key" part is gone.
- `TestAnInstallPublishesTheCompleteDesiredSetAtOnce` (#228 item 3): its planted file now holds a stale broker entry *and* a live one, so a successful install has both something to remove and something to preserve. The atomicity guarantee it exists for is unchanged.
- `pkg/auth/key_revocation_test.go`'s `TestRevokingASupersededKeyIsNotReportedAsIncomplete` → `TestRevokingAKeyThatIsAlreadyGoneIsNotReportedAsIncomplete`. This is the one change outside `pkg/ssh`, and it is there because the test reached the case under test *by* a second login superseding the first, which no longer happens. It now removes the entry directly, standing for the three things that still get an account there: the expiry sweep, a restart's reconcile, and a revocation that already ran. The #165 invariant it guards — an already-absent key is a success, not `ssh_key_revocation_incomplete` — is unchanged. Two comments in `pkg/auth/broker.go` said the same untrue thing and were corrected.

### Non-vacuity

`pkg/ssh/authorized_keys.go` backed up, perturbed with `perl -0pi -e`, one test run, restored, `diff -q` byte-identical, twice:

1. `live = append(live, ...)` → `drop[i] = true`, i.e. the old "drop every broker entry" behaviour. `go test ./pkg/ssh/ -run TestASecondLoginKeepsTheFirstSessionsKey` fails on all four assertions — one key instead of two, the laptop key unauthorized, one comment for two entries, the revocation matching nothing.
2. The eviction comparator reversed (`Before` → evict the furthest expiry). `TestTheKeyNearestItsExpiryIsTheOneEvicted` and `TestTheNumberOfLiveKeysAnAccountHoldsIsBounded` both fail.

`gofmt -l .` empty, `go build ./...` clean, `go test ./...` all packages ok.

## e2e

`case_second_login_supersedes_key` → `case_second_login_keeps_the_first_key`, registered under the new name. After two device flows for one account it expects two OIDC keys, two *distinct* key blobs, the first login's blob still present, the personal key intact, and `expiry-time="` on every `@oidc-pam-` line. Supporting helpers: `expect_oidc_key_count <user> <want>` (with `expect_oidc_key_for` now defined as a count of 1) and `oidc_key_blobs`, since a per-user single-blob helper no longer describes the file. `bash -n` clean; CI's shellcheck job covers `scripts/` and `test/scripts/` only, so no new lint surface.

Nothing in `README.md` or `DEPLOYMENT.md` asserted one key per account. `DEPLOYMENT.md`'s "Why OpenSSH 7.7 is a hard requirement" — each login's key gets an `expiry-time=` so sshd stops honouring it once stale — is still true, and rather more load-bearing now that several live entries coexist.

## Found, not fixed

- **#227 item 2 is still real.** `RefreshSession` (`pkg/auth/broker.go:802`) extends `Session.ExpiresAt` and never rewrites the key, so a refreshed session's `expiry-time=` still carries the original deadline and sshd starts refusing a key the broker calls healthy. This change makes it *easier* to fix — the provisioning path can now be called for one session without disturbing the others — but does not fix it.
- **The sweep only runs for accounts whose sessions expire.** `sweepExpiredAuthorizedKeys` is reached from session expiry, so an account that stops logging in keeps its (sshd-refused, but present) entries until it logs in again. Harmless for access, since `expiry-time=` is enforced by sshd; it just means the file is tidied lazily.
- **The limit is a constant, not configuration.** A site with genuinely more than sixteen simultaneous sessions per account would want to raise it; that needs a config key and validation, which is a wider change than this fix.
- **`AddPublicKey` cannot be told which session it is provisioning for.** Nothing needs it today — identity is the key blob — but it means the eviction choice can only use each entry's expiry, not the broker's own view of which sessions are still live. Passing the session in would let it evict entries whose session the broker knows is gone before touching a live one.

Closes #227
