### PR TITLE
fix(audit,auth): refuse to audit into nowhere, bind token ciphertexts to their record, check ownership where tokens are handed out

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,7 +92,7 @@ When deploying OIDC PAM, follow these security recommendations:
 
 OIDC PAM includes several security features:
 
-- **Encrypted Token Storage**: AES-256-GCM authenticated encryption (base64 32-byte key; no passphrase stretching)
+- **Encrypted Token Storage**: AES-256-GCM authenticated encryption (base64 32-byte key; no passphrase stretching), each token bound to the account, session and field it was stored for, so a ciphertext moved to another record does not decrypt
 - **Identity Binding**: The authenticated OIDC identity is bound to the requested local username, and `require_groups` is enforced
 - **Comprehensive Audit Logging**: All authentication events logged, and a broker told to audit with no `audit.outputs` refuses to start rather than accepting events and discarding them
 - **Risk-Based Policy Engine**: Geographic and temporal access controls
@@ -153,6 +153,19 @@ security audit (all findings remediated as of v0.4.x):
 - It has not undergone an independent third-party security audit
 - Breaking changes may occur before 1.0
 - Validate thoroughly for your own environment before high-security production use
+
+### The Audit Trail Is Not Tamper-Evident
+The broker runs as root and its audit log lives under `/var/log/oidc-auth`, so
+whoever has compromised the broker can rewrite its own record of the compromise.
+Records are appended independently and nothing chains them, which means a deleted
+entry is indistinguishable from an entry that was never written (#232).
+
+A per-record hash chain on its own would not change that: an attacker who can
+rewrite the file and holds no secret can recompute the chain after editing it. The
+mitigation that works is getting records off the host as they are written, so
+configure a `syslog` or `http` audit output alongside the file one where the
+integrity of the trail matters. Anchoring the chain in something an on-host
+attacker cannot forge is tracked in #232.
 
 ### PAM Integration
 - PAM modules run with elevated privileges

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,7 +94,7 @@ OIDC PAM includes several security features:
 
 - **Encrypted Token Storage**: AES-256-GCM authenticated encryption (base64 32-byte key; no passphrase stretching)
 - **Identity Binding**: The authenticated OIDC identity is bound to the requested local username, and `require_groups` is enforced
-- **Comprehensive Audit Logging**: All authentication events logged
+- **Comprehensive Audit Logging**: All authentication events logged, and a broker told to audit with no `audit.outputs` refuses to start rather than accepting events and discarding them
 - **Risk-Based Policy Engine**: Geographic and temporal access controls
 - **Automatic Key Rotation**: SSH key lifecycle management
 - **Session Management**: Automatic token expiration and cleanup

--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -427,7 +427,19 @@ audit:
     - "token_validation"
     - "session_management"
     - "policy_violations"
+  outputs:
+    - type: "file"
+      path: "/var/log/oidc-auth/audit.log"
 ```
+
+`audit.outputs` is the one key here that has no default, and auditing is on
+unless you turn it off, so a configuration that enables auditing without naming
+an output is **refused at startup** (#210). Before that refusal existed such a
+broker started, accepted every event and wrote it nowhere, and reported nothing
+wrong: `oidc_audit_events_dropped_total` and the failed-write count both stay at
+zero when there is no output to drop an event from or fail to write to. A host
+with no audit trail looked exactly like a host where nothing had happened. If you
+genuinely want no audit trail, write `audit.enabled: false` and mean it.
 
 ### 6. How Far the Provider Is Trusted
 
@@ -562,6 +574,7 @@ absent.
 | `audit.buffer_size` | `1000` | Capacity of the in-memory audit event channel. |
 | `audit.overflow_strategy` | `block` | What happens when that channel is full: `block` (backpressure), `sync` (write inline), or `drop` (discard and count). `drop` loses audit records and must be chosen deliberately. |
 | `audit.outputs[].type` | — | `file`, `stdout`, `syslog` or `http`. Any other value is refused at startup. |
+| `audit.enabled` | `true` | Whether to audit at all. With no `audit.outputs` alongside it the broker refuses to start, rather than accepting events and discarding them (#210). |
 
 ## Authentication Policies
 

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -900,8 +900,11 @@ func (b *Broker) RefreshSession(sessionID, userID string) (*AuthResponse, error)
 	}
 
 	// The refresh token lives encrypted in the token store; decrypt it only for
-	// the duration of this call rather than keeping a copy on the session.
-	storedToken, err := b.tokenManager.GetToken(session.TokenID)
+	// the duration of this call rather than keeping a copy on the session. The
+	// account is named so the store refuses a token ID that does not belong to
+	// this session's user (#233) rather than handing over whatever the ID points
+	// at.
+	storedToken, err := b.tokenManager.GetToken(session.TokenID, session.UserID)
 	if err != nil {
 		log.Warn().
 			Err(err).

--- a/pkg/auth/broker_core_test.go
+++ b/pkg/auth/broker_core_test.go
@@ -182,13 +182,13 @@ func TestTokenManagerCore(t *testing.T) {
 		t.Fatal("StoreToken returned an empty token ID")
 	}
 
-	// Test ValidateToken
-	stored, err := tokenManager.ValidateToken("test-fingerprint", "test-user")
+	// Test GetToken, which is the call that checks ownership
+	stored, err := tokenManager.GetToken(tokenID, "test-user")
 	if err != nil {
-		t.Fatalf("ValidateToken: %v", err)
+		t.Fatalf("GetToken: %v", err)
 	}
-	if stored.UserID != "test-user" {
-		t.Errorf("stored token user = %q, want test-user", stored.UserID)
+	if stored.AccessToken != testToken.AccessToken {
+		t.Errorf("stored access token = %q, want %q", stored.AccessToken, testToken.AccessToken)
 	}
 
 	// Test GetTokenStats

--- a/pkg/auth/broker_session_test.go
+++ b/pkg/auth/broker_session_test.go
@@ -500,7 +500,7 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 	}
 
 	// The new refresh token is reachable through the store...
-	refreshed, err := tokenManager.GetToken(updated.TokenID)
+	refreshed, err := tokenManager.GetToken(updated.TokenID, "test-user")
 	if err != nil {
 		t.Fatalf("GetToken(%q): %v", updated.TokenID, err)
 	}
@@ -510,7 +510,7 @@ func TestBrokerRefreshSessionSuccess(t *testing.T) {
 
 	// ...and the rotated one is gone, rather than lingering as dead credential
 	// material until the token store's own sweep.
-	if _, err := tokenManager.GetToken(oldTokenID); err == nil {
+	if _, err := tokenManager.GetToken(oldTokenID, "test-user"); err == nil {
 		t.Error("the pre-refresh token is still in the store after rotation")
 	}
 }

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -281,7 +281,7 @@ func TestDeviceFlowCompletesAfterAuthorizationPending(t *testing.T) {
 	if session.TokenID == "" {
 		t.Fatal("session has no TokenID, so its tokens were never stored")
 	}
-	stored, err := env.broker.tokenManager.GetToken(session.TokenID)
+	stored, err := env.broker.tokenManager.GetToken(session.TokenID, session.UserID)
 	if err != nil {
 		t.Fatalf("GetToken(%q): %v", session.TokenID, err)
 	}

--- a/pkg/auth/session_tokens_test.go
+++ b/pkg/auth/session_tokens_test.go
@@ -98,7 +98,7 @@ func TestRevokeSessionDestroysItsStoredTokens(t *testing.T) {
 	broker, tm := newTokenTestBroker(t)
 	tokenID := storeSessionWithToken(t, broker, tm, "sess-revoke", "test-user", time.Now().Add(time.Hour))
 
-	if _, err := tm.GetToken(tokenID); err != nil {
+	if _, err := tm.GetToken(tokenID, "test-user"); err != nil {
 		t.Fatalf("token should exist before revocation: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestRevokeSessionDestroysItsStoredTokens(t *testing.T) {
 		t.Fatalf("RevokeSession: %v", err)
 	}
 
-	if _, err := tm.GetToken(tokenID); err == nil {
+	if _, err := tm.GetToken(tokenID, "test-user"); err == nil {
 		t.Error("session was revoked but its tokens are still in the store")
 	}
 	if total := tm.GetTokenStats()["total_tokens"].(int); total != 0 {
@@ -123,7 +123,7 @@ func TestRevokeSessionForWrongUserLeavesTokens(t *testing.T) {
 		t.Fatal("expected cross-user revocation to be refused")
 	}
 
-	if _, err := tm.GetToken(tokenID); err != nil {
+	if _, err := tm.GetToken(tokenID, "owner"); err != nil {
 		t.Errorf("a refused revocation destroyed the owner's tokens: %v", err)
 	}
 	if broker.getSession("sess-owned") == nil {
@@ -142,14 +142,14 @@ func TestExpiredSessionsHaveTheirTokensRevoked(t *testing.T) {
 	if broker.getSession("sess-expired") != nil {
 		t.Error("expired session was not removed")
 	}
-	if _, err := tm.GetToken(expiredID); err == nil {
+	if _, err := tm.GetToken(expiredID, "user-a"); err == nil {
 		t.Error("the expired session's tokens are still in the store")
 	}
 
 	if broker.getSession("sess-live") == nil {
 		t.Fatal("the live session was removed")
 	}
-	if _, err := tm.GetToken(liveID); err != nil {
+	if _, err := tm.GetToken(liveID, "user-b"); err != nil {
 		t.Errorf("the live session's tokens were revoked: %v", err)
 	}
 }
@@ -170,7 +170,7 @@ func TestIdleSessionsHaveTheirTokensRevoked(t *testing.T) {
 	if broker.getSession("sess-idle") != nil {
 		t.Error("idle session was not removed")
 	}
-	if _, err := tm.GetToken(tokenID); err == nil {
+	if _, err := tm.GetToken(tokenID, "user-a"); err == nil {
 		t.Error("the idle session's tokens are still in the store")
 	}
 }

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -63,6 +63,8 @@ const (
 // that wrote it — which is why the record format needs no version field of its
 // own. If the store is ever persisted, that stops being true and this constant is
 // where the compatibility break becomes visible.
+// #nosec G101 -- a format tag, not a credential: this string is public input to
+// the AEAD and is safe to log, while the key it is used with comes from config.
 const tokenAADVersion = "oidc-pam/stored-token/v1"
 
 // tokenAAD returns the additional authenticated data binding one encrypted field

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -25,9 +25,8 @@ type TokenManager struct {
 
 // TokenStore represents a token storage backend
 type TokenStore struct {
-	tokens           map[string]*StoredToken
-	fingerprintIndex map[string]string // fingerprint → tokenID for O(1) ValidateToken
-	mutex            sync.RWMutex
+	tokens map[string]*StoredToken
+	mutex  sync.RWMutex
 }
 
 // StoredToken represents a token stored in the token store
@@ -98,8 +97,7 @@ func NewTokenManager(cfg *config.Config) (*TokenManager, error) {
 
 	// Initialize token store
 	tokenStore := &TokenStore{
-		tokens:           make(map[string]*StoredToken),
-		fingerprintIndex: make(map[string]string),
+		tokens: make(map[string]*StoredToken),
 	}
 
 	return &TokenManager{
@@ -126,6 +124,17 @@ func (tm *TokenManager) Stop() error {
 
 	close(tm.stopChan)
 	tm.wg.Wait()
+
+	// (#233) Zero the token encryption key. Destroy existed for this and had no
+	// caller outside a test, so the key stayed in the heap for as long as the
+	// process did — which on a Restart=always unit failing its preconditions is a
+	// process that dies and respawns every few seconds, each one leaving another
+	// copy behind. Safe here because Stop is terminal: the broker stops its own
+	// goroutines and the IPC server stops accepting before this is reached, so no
+	// encrypt or decrypt can still be in flight.
+	if tm.encryption != nil {
+		tm.encryption.Destroy()
+	}
 
 	return nil
 }
@@ -194,12 +203,9 @@ func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) (stri
 		storedToken.Metadata["claims"] = token.Claims
 	}
 
-	// Store in token store and update fingerprint index
+	// Store in token store
 	tm.tokenStore.mutex.Lock()
 	tm.tokenStore.tokens[tokenID] = storedToken
-	if storedToken.Fingerprint != "" {
-		tm.tokenStore.fingerprintIndex[storedToken.Fingerprint] = tokenID
-	}
 	tm.tokenStore.mutex.Unlock()
 
 	log.Debug().
@@ -213,14 +219,29 @@ func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) (stri
 	return tokenID, nil
 }
 
-// GetToken retrieves a token from the token store
-func (tm *TokenManager) GetToken(tokenID string) (*Token, error) {
+// GetToken decrypts and returns the token stored under tokenID, which must belong
+// to userID.
+//
+// (#233) The caller naming the account it believes owns the token is the whole
+// point of the second argument: before it, a token ID was a bearer token for the
+// access and refresh tokens inside it, and the only check of ownership in this
+// file was ValidateToken, which nothing in production ever called. Whatever
+// crossed a session with another account's token — a bug here, or an attacker who
+// can write to the store — used to end with the broker holding one user's
+// credentials and attributing them to another.
+func (tm *TokenManager) GetToken(tokenID, userID string) (*Token, error) {
 	tm.tokenStore.mutex.RLock()
 	storedToken, exists := tm.tokenStore.tokens[tokenID]
 	tm.tokenStore.mutex.RUnlock()
 
 	if !exists {
 		return nil, fmt.Errorf("token not found")
+	}
+
+	// Constant-time comparison so a caller probing token IDs cannot learn from
+	// the timing which account a stored token belongs to (L-15).
+	if subtle.ConstantTimeCompare([]byte(storedToken.UserID), []byte(userID)) != 1 {
+		return nil, fmt.Errorf("token does not belong to requesting user")
 	}
 
 	// Check if token has expired
@@ -290,48 +311,12 @@ func (tm *TokenManager) GetToken(tokenID string) (*Token, error) {
 	return token, nil
 }
 
-// ValidateToken validates a token fingerprint and verifies it belongs to the given user.
-// Both fingerprint and userID must match to prevent token hijacking across users.
-// Uses the O(1) fingerprint index for lookup.
-func (tm *TokenManager) ValidateToken(tokenFingerprint, userID string) (*StoredToken, error) {
-	tm.tokenStore.mutex.RLock()
-	defer tm.tokenStore.mutex.RUnlock()
-
-	tokenID, ok := tm.tokenStore.fingerprintIndex[tokenFingerprint]
-	if !ok {
-		return nil, fmt.Errorf("token not found")
-	}
-
-	storedToken, ok := tm.tokenStore.tokens[tokenID]
-	if !ok {
-		// Index is out of sync (should not happen); treat as not found.
-		return nil, fmt.Errorf("token not found")
-	}
-
-	// Constant-time comparison so validation timing does not leak which user a
-	// stored token belongs to (L-15).
-	if subtle.ConstantTimeCompare([]byte(storedToken.UserID), []byte(userID)) != 1 {
-		return nil, fmt.Errorf("token does not belong to requesting user")
-	}
-
-	if storedToken.ExpiresAt.Before(time.Now()) {
-		return nil, fmt.Errorf("token expired")
-	}
-
-	// LastUsed is intentionally not updated here: writing through a pointer
-	// under RLock races with concurrent ValidateToken callers. LastUsed is not
-	// used for any security decision, so it is only updated under write lock
-	// paths (StoreToken, performCleanup).
-	return storedToken, nil
-}
-
 // RevokeToken revokes a token
 func (tm *TokenManager) RevokeToken(tokenID string) error {
 	tm.tokenStore.mutex.Lock()
 	defer tm.tokenStore.mutex.Unlock()
 
 	if storedToken, exists := tm.tokenStore.tokens[tokenID]; exists {
-		delete(tm.tokenStore.fingerprintIndex, storedToken.Fingerprint)
 		delete(tm.tokenStore.tokens, tokenID)
 
 		log.Debug().
@@ -354,7 +339,6 @@ func (tm *TokenManager) RevokeUserTokens(userID string) error {
 	var revokedTokens []string
 	for tokenID, storedToken := range tm.tokenStore.tokens {
 		if storedToken.UserID == userID {
-			delete(tm.tokenStore.fingerprintIndex, storedToken.Fingerprint)
 			delete(tm.tokenStore.tokens, tokenID)
 			revokedTokens = append(revokedTokens, tokenID)
 		}
@@ -376,7 +360,6 @@ func (tm *TokenManager) RevokeSessionTokens(sessionID string) error {
 	var revokedTokens []string
 	for tokenID, storedToken := range tm.tokenStore.tokens {
 		if storedToken.SessionID == sessionID {
-			delete(tm.tokenStore.fingerprintIndex, storedToken.Fingerprint)
 			delete(tm.tokenStore.tokens, tokenID)
 			revokedTokens = append(revokedTokens, tokenID)
 		}
@@ -437,10 +420,7 @@ func (tm *TokenManager) generateTokenID() (string, error) {
 func (tm *TokenManager) removeToken(tokenID string) {
 	tm.tokenStore.mutex.Lock()
 	defer tm.tokenStore.mutex.Unlock()
-	if st, ok := tm.tokenStore.tokens[tokenID]; ok {
-		delete(tm.tokenStore.fingerprintIndex, st.Fingerprint)
-		delete(tm.tokenStore.tokens, tokenID)
-	}
+	delete(tm.tokenStore.tokens, tokenID)
 }
 
 func (tm *TokenManager) cleanupExpiredTokens(ctx context.Context) {
@@ -474,11 +454,8 @@ func (tm *TokenManager) performCleanup() {
 		}
 	}
 
-	// Remove expired tokens and their index entries
+	// Remove expired tokens
 	for _, tokenID := range expiredTokens {
-		if st, ok := tm.tokenStore.tokens[tokenID]; ok {
-			delete(tm.tokenStore.fingerprintIndex, st.Fingerprint)
-		}
 		delete(tm.tokenStore.tokens, tokenID)
 	}
 

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +44,48 @@ type StoredToken struct {
 	Metadata     map[string]interface{}
 	CreatedAt    time.Time
 	LastUsed     time.Time
+}
+
+// The three encrypted fields of a stored token. They are named in the additional
+// authenticated data so that a ciphertext cannot be moved between fields of the
+// same record either: an access token pasted into the refresh_token slot would
+// otherwise decrypt, and the broker would present it to the provider as a refresh
+// token.
+const (
+	tokenFieldAccess  = "access_token"
+	tokenFieldRefresh = "refresh_token"
+	tokenFieldID      = "id_token"
+)
+
+// tokenAADVersion prefixes every AAD so a future change to what is bound can be
+// told from this one rather than silently producing ciphertexts that will not
+// open. There is nothing to migrate today — the token store is an in-memory map
+// that lives and dies with the process, so no ciphertext ever outlives the code
+// that wrote it — which is why the record format needs no version field of its
+// own. If the store is ever persisted, that stops being true and this constant is
+// where the compatibility break becomes visible.
+const tokenAADVersion = "oidc-pam/stored-token/v1"
+
+// tokenAAD returns the additional authenticated data binding one encrypted field
+// of a stored token to the identity it was stored for (#232).
+//
+// AES-GCM already proves a ciphertext was not modified, but it says nothing about
+// where the ciphertext belongs: without AAD, a refresh token lifted out of user
+// A's record and written into user B's decrypts cleanly, the tag validates, and
+// the broker then refreshes A's credentials while every downstream decision —
+// policy, audit attribution, key provisioning — is made for B. With the record's
+// user, session and field name bound in, such a ciphertext fails to open.
+//
+// The parts are length-prefixed rather than joined by a separator, so no
+// combination of user and session IDs can produce the same AAD as a different
+// pair.
+func tokenAAD(field, userID, sessionID string) []byte {
+	var b strings.Builder
+	b.WriteString(tokenAADVersion)
+	for _, part := range []string{field, userID, sessionID} {
+		fmt.Fprintf(&b, "|%d:%s", len(part), part)
+	}
+	return []byte(b.String())
 }
 
 // NewTokenManager creates a new token manager
@@ -106,20 +149,22 @@ func (tm *TokenManager) StoreToken(token *Token, userID, sessionID string) (stri
 
 	if tm.encryption != nil {
 		var err error
-		accessToken, err = tm.encryption.Encrypt(token.AccessToken)
+		// Each field is bound to the account and session it is being stored for,
+		// so the ciphertext is only usable in this record (#232).
+		accessToken, err = tm.encryption.EncryptWithAAD(token.AccessToken, tokenAAD(tokenFieldAccess, userID, sessionID))
 		if err != nil {
 			return "", fmt.Errorf("failed to encrypt access token: %w", err)
 		}
 
 		if token.RefreshToken != "" {
-			refreshToken, err = tm.encryption.Encrypt(token.RefreshToken)
+			refreshToken, err = tm.encryption.EncryptWithAAD(token.RefreshToken, tokenAAD(tokenFieldRefresh, userID, sessionID))
 			if err != nil {
 				return "", fmt.Errorf("failed to encrypt refresh token: %w", err)
 			}
 		}
 
 		if token.IDToken != "" {
-			idToken, err = tm.encryption.Encrypt(token.IDToken)
+			idToken, err = tm.encryption.EncryptWithAAD(token.IDToken, tokenAAD(tokenFieldID, userID, sessionID))
 			if err != nil {
 				return "", fmt.Errorf("failed to encrypt ID token: %w", err)
 			}
@@ -192,20 +237,24 @@ func (tm *TokenManager) GetToken(tokenID string) (*Token, error) {
 
 	if storedToken.Encrypted && tm.encryption != nil {
 		var err error
-		accessToken, err = tm.encryption.Decrypt(storedToken.AccessToken)
+		// The AAD comes from the record being read, so a ciphertext that was
+		// written for a different account, session or field does not open here
+		// (#232).
+		user, session := storedToken.UserID, storedToken.SessionID
+		accessToken, err = tm.encryption.DecryptWithAAD(storedToken.AccessToken, tokenAAD(tokenFieldAccess, user, session))
 		if err != nil {
 			return nil, fmt.Errorf("failed to decrypt access token: %w", err)
 		}
 
 		if storedToken.RefreshToken != "" {
-			refreshToken, err = tm.encryption.Decrypt(storedToken.RefreshToken)
+			refreshToken, err = tm.encryption.DecryptWithAAD(storedToken.RefreshToken, tokenAAD(tokenFieldRefresh, user, session))
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt refresh token: %w", err)
 			}
 		}
 
 		if storedToken.IDToken != "" {
-			idToken, err = tm.encryption.Decrypt(storedToken.IDToken)
+			idToken, err = tm.encryption.DecryptWithAAD(storedToken.IDToken, tokenAAD(tokenFieldID, user, session))
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt ID token: %w", err)
 			}

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -97,7 +97,7 @@ func TestTokenManagerBasicOperations(t *testing.T) {
 
 	// A round trip returns the original plaintext, so the ID is all a caller
 	// needs to keep.
-	retrievedToken, err := tm.GetToken(tokenID)
+	retrievedToken, err := tm.GetToken(tokenID, "test-user")
 	if err != nil {
 		t.Fatalf("GetToken(%q): %v", tokenID, err)
 	}
@@ -106,15 +106,6 @@ func TestTokenManagerBasicOperations(t *testing.T) {
 	}
 	if retrievedToken.RefreshToken != testToken.RefreshToken {
 		t.Errorf("refresh token = %q, want %q", retrievedToken.RefreshToken, testToken.RefreshToken)
-	}
-
-	// Test ValidateToken
-	stored, err := tm.ValidateToken("test-fingerprint", "test-user")
-	if err != nil {
-		t.Fatalf("ValidateToken: %v", err)
-	}
-	if stored.ID != tokenID {
-		t.Errorf("ValidateToken returned token %q, want %q", stored.ID, tokenID)
 	}
 
 	// Test GetTokenStats
@@ -176,14 +167,14 @@ func TestStoredCiphertextDoesNotOpenInAnotherRecord(t *testing.T) {
 		t.Fatal("the refresh token was stored in plaintext; this test would prove nothing")
 	}
 
-	token, err := tm.GetToken(bobID)
+	token, err := tm.GetToken(bobID, "bob")
 	if err == nil {
 		t.Errorf("bob's record opened alice's refresh token: got %q", token.RefreshToken)
 	}
 
 	// Alice's own record is untouched and must still work: the binding may not
 	// cost the legitimate read.
-	if token, err := tm.GetToken(aliceID); err != nil {
+	if token, err := tm.GetToken(aliceID, "alice"); err != nil {
 		t.Errorf("GetToken(alice): %v", err)
 	} else if token.RefreshToken != aliceRefresh {
 		t.Errorf("alice's refresh token = %q, want %q", token.RefreshToken, aliceRefresh)
@@ -196,7 +187,7 @@ func TestStoredCiphertextDoesNotOpenInAnotherRecord(t *testing.T) {
 	tm.tokenStore.tokens[aliceID].RefreshToken = alicesAccessCiphertext
 	tm.tokenStore.mutex.Unlock()
 
-	if token, err := tm.GetToken(aliceID); err == nil {
+	if token, err := tm.GetToken(aliceID, "alice"); err == nil {
 		t.Errorf("an access token opened in the refresh_token field: got %q", token.RefreshToken)
 	}
 }
@@ -343,8 +334,7 @@ func TestTokenManagerConcurrency(t *testing.T) {
 			}
 
 			// Test concurrent operations
-			_, _ = tm.GetToken(tokenID)
-			_, _ = tm.ValidateToken(tokenID, fmt.Sprintf("user-%d", i))
+			_, _ = tm.GetToken(tokenID, fmt.Sprintf("user-%d", i))
 			_ = tm.RevokeToken(tokenID)
 		}(i)
 	}
@@ -353,9 +343,11 @@ func TestTokenManagerConcurrency(t *testing.T) {
 	t.Log("Concurrent operations completed successfully")
 }
 
-func TestValidateTokenConcurrent(t *testing.T) {
-	// Regression test: ValidateToken mutates LastUsed. Under a read lock this
-	// would race; the fix uses a write lock. Run with -race to verify.
+func TestGetTokenConcurrent(t *testing.T) {
+	// Regression test: reading a token mutates LastUsed. Under a read lock this
+	// would race; the fix uses a write lock. Run with -race to verify. This
+	// covered ValidateToken until #233 deleted it; GetToken is the reader that
+	// carries the same mutation.
 
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
@@ -369,7 +361,7 @@ func TestValidateTokenConcurrent(t *testing.T) {
 		t.Fatalf("Failed to create token manager: %v", err)
 	}
 
-	// Store a token so ValidateToken has something to find
+	// Store a token so the readers have something to find
 	testToken := &Token{
 		AccessToken:  "access",
 		RefreshToken: "refresh",
@@ -379,7 +371,8 @@ func TestValidateTokenConcurrent(t *testing.T) {
 		Fingerprint:  "concurrent-fp",
 		Claims:       make(map[string]interface{}),
 	}
-	if _, err := tm.StoreToken(testToken, "user1", "session1"); err != nil {
+	tokenID, err := tm.StoreToken(testToken, "user1", "session1")
+	if err != nil {
 		t.Fatalf("Failed to store token: %v", err)
 	}
 
@@ -391,13 +384,13 @@ func TestValidateTokenConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				storedToken, err := tm.ValidateToken("concurrent-fp", "user1")
+				token, err := tm.GetToken(tokenID, "user1")
 				if err != nil {
-					t.Errorf("ValidateToken failed: %v", err)
+					t.Errorf("GetToken failed: %v", err)
 					return
 				}
-				if storedToken == nil {
-					t.Error("ValidateToken returned nil token")
+				if token == nil {
+					t.Error("GetToken returned nil token")
 					return
 				}
 			}
@@ -422,8 +415,8 @@ func newTMForTest(t *testing.T) *TokenManager {
 	return tm
 }
 
-// storeTestToken stores a token with the given fingerprint and returns it.
-func storeTestToken(t *testing.T, tm *TokenManager, fp string) *Token {
+// storeTestToken stores a token with the given fingerprint and returns its ID.
+func storeTestToken(t *testing.T, tm *TokenManager, fp string) string {
 	t.Helper()
 	tok := &Token{
 		AccessToken: "access-" + fp,
@@ -432,54 +425,55 @@ func storeTestToken(t *testing.T, tm *TokenManager, fp string) *Token {
 		Fingerprint: fp,
 		Claims:      make(map[string]interface{}),
 	}
-	if _, err := tm.StoreToken(tok, "user1", "sess1"); err != nil {
+	tokenID, err := tm.StoreToken(tok, "user1", "sess1")
+	if err != nil {
 		t.Fatalf("StoreToken(%q): %v", fp, err)
 	}
-	return tok
+	return tokenID
 }
 
-// TestFingerprintIndexPopulatedOnStore verifies that StoreToken adds an entry
-// to the fingerprint index.
-func TestFingerprintIndexPopulatedOnStore(t *testing.T) {
-	tm := newTMForTest(t)
-	storeTestToken(t, tm, "fp-store-test")
-
+// storedIDs returns the IDs currently in the store.
+func storedIDs(tm *TokenManager) []string {
 	tm.tokenStore.mutex.RLock()
-	_, ok := tm.tokenStore.fingerprintIndex["fp-store-test"]
-	tm.tokenStore.mutex.RUnlock()
+	defer tm.tokenStore.mutex.RUnlock()
+	ids := make([]string, 0, len(tm.tokenStore.tokens))
+	for id := range tm.tokenStore.tokens {
+		ids = append(ids, id)
+	}
+	return ids
+}
 
-	if !ok {
-		t.Error("Expected fingerprint index to contain the stored fingerprint")
+// The five tests below tracked the fingerprint index that #233 deleted along
+// with ValidateToken. What they were really asserting — that every path which
+// drops a token drops it from the store — still matters, so they now assert it
+// against the one map that remains.
+
+func TestStoreTokenPutsTheRecordInTheStore(t *testing.T) {
+	tm := newTMForTest(t)
+	tokenID := storeTestToken(t, tm, "fp-store-test")
+
+	if got := storedIDs(tm); len(got) != 1 || got[0] != tokenID {
+		t.Errorf("store holds %v, want just %q", got, tokenID)
 	}
 }
 
-// TestFingerprintIndexRemovedOnRevoke verifies that RevokeToken removes the
-// fingerprint index entry.
-func TestFingerprintIndexRemovedOnRevoke(t *testing.T) {
+func TestRevokeTokenRemovesTheRecord(t *testing.T) {
 	tm := newTMForTest(t)
-	storeTestToken(t, tm, "fp-revoke-test")
-
-	// Find the tokenID from the index, then revoke it.
-	tm.tokenStore.mutex.RLock()
-	tokenID := tm.tokenStore.fingerprintIndex["fp-revoke-test"]
-	tm.tokenStore.mutex.RUnlock()
+	tokenID := storeTestToken(t, tm, "fp-revoke-test")
 
 	if err := tm.RevokeToken(tokenID); err != nil {
 		t.Fatalf("RevokeToken: %v", err)
 	}
 
-	tm.tokenStore.mutex.RLock()
-	_, ok := tm.tokenStore.fingerprintIndex["fp-revoke-test"]
-	tm.tokenStore.mutex.RUnlock()
-
-	if ok {
-		t.Error("Expected fingerprint index entry to be removed after revoke")
+	if got := storedIDs(tm); len(got) != 0 {
+		t.Errorf("store still holds %v after revoking the only token", got)
+	}
+	if _, err := tm.GetToken(tokenID, "user1"); err == nil {
+		t.Error("a revoked token ID still resolves")
 	}
 }
 
-// TestFingerprintIndexRemovedOnCleanup verifies that performCleanup removes
-// expired tokens' fingerprint index entries.
-func TestFingerprintIndexRemovedOnCleanup(t *testing.T) {
+func TestCleanupRemovesExpiredRecords(t *testing.T) {
 	tm := newTMForTest(t)
 
 	// Store a token that is already expired.
@@ -496,18 +490,12 @@ func TestFingerprintIndexRemovedOnCleanup(t *testing.T) {
 
 	tm.performCleanup()
 
-	tm.tokenStore.mutex.RLock()
-	_, inTokens := tm.tokenStore.tokens[tm.tokenStore.fingerprintIndex["fp-cleanup-test"]]
-	_, inIndex := tm.tokenStore.fingerprintIndex["fp-cleanup-test"]
-	tm.tokenStore.mutex.RUnlock()
-
-	if inTokens || inIndex {
-		t.Error("Expected expired token and its index entry to be removed after cleanup")
+	if got := storedIDs(tm); len(got) != 0 {
+		t.Errorf("store still holds %v after cleanup of an expired token", got)
 	}
 }
 
-// TestFingerprintIndexRemovedByUserRevoke verifies RevokeUserTokens cleans the index.
-func TestFingerprintIndexRemovedByUserRevoke(t *testing.T) {
+func TestRevokeUserTokensRemovesTheRecords(t *testing.T) {
 	tm := newTMForTest(t)
 	storeTestToken(t, tm, "fp-user-revoke")
 
@@ -515,18 +503,12 @@ func TestFingerprintIndexRemovedByUserRevoke(t *testing.T) {
 		t.Fatalf("RevokeUserTokens: %v", err)
 	}
 
-	tm.tokenStore.mutex.RLock()
-	_, ok := tm.tokenStore.fingerprintIndex["fp-user-revoke"]
-	tm.tokenStore.mutex.RUnlock()
-
-	if ok {
-		t.Error("Expected index entry removed after RevokeUserTokens")
+	if got := storedIDs(tm); len(got) != 0 {
+		t.Errorf("store still holds %v after RevokeUserTokens", got)
 	}
 }
 
-// TestFingerprintIndexRemovedBySessionRevoke verifies RevokeSessionTokens
-// cleans the index.
-func TestFingerprintIndexRemovedBySessionRevoke(t *testing.T) {
+func TestRevokeSessionTokensRemovesTheRecords(t *testing.T) {
 	tm := newTMForTest(t)
 	storeTestToken(t, tm, "fp-session-revoke")
 
@@ -534,115 +516,116 @@ func TestFingerprintIndexRemovedBySessionRevoke(t *testing.T) {
 		t.Fatalf("RevokeSessionTokens: %v", err)
 	}
 
-	tm.tokenStore.mutex.RLock()
-	_, ok := tm.tokenStore.fingerprintIndex["fp-session-revoke"]
-	tm.tokenStore.mutex.RUnlock()
-
-	if ok {
-		t.Error("Expected index entry removed after RevokeSessionTokens")
+	if got := storedIDs(tm); len(got) != 0 {
+		t.Errorf("store still holds %v after RevokeSessionTokens", got)
 	}
 }
 
-// TestValidateTokenO1 stores a large number of tokens and validates one that
-// sits in the middle, confirming the O(1) path works correctly regardless of
-// store size.
-func TestValidateTokenO1(t *testing.T) {
+// TestGetTokenRefusesAnotherAccountsTokenID covers #233: a token ID is a lookup
+// key, not a bearer credential, so naming the wrong account must not return the
+// token.
+//
+// The check used to live in ValidateToken, which no production path called — so
+// in the running broker nothing verified ownership at all, and a session that
+// ended up holding another account's token ID (a bug in session handling, or an
+// attacker who can write to the store) got that account's access and refresh
+// tokens back.
+func TestGetTokenRefusesAnotherAccountsTokenID(t *testing.T) {
 	tm := newTMForTest(t)
 
-	const n = 200
-	var targetFP string
-	for i := 0; i < n; i++ {
-		fp := fmt.Sprintf("fp-%04d", i)
-		storeTestToken(t, tm, fp)
-		if i == n/2 {
-			targetFP = fp
-		}
+	aliceID, err := tm.StoreToken(&Token{
+		AccessToken:  "alices-access-token",
+		RefreshToken: "alices-refresh-token",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Fingerprint:  "alice-fp",
+	}, "alice", "session-alice")
+	if err != nil {
+		t.Fatalf("StoreToken(alice): %v", err)
 	}
 
-	st, err := tm.ValidateToken(targetFP, "user1")
-	if err != nil {
-		t.Fatalf("ValidateToken: %v", err)
+	if token, err := tm.GetToken(aliceID, "bob"); err == nil {
+		t.Errorf("bob read alice's token: access=%q refresh=%q", token.AccessToken, token.RefreshToken)
 	}
-	if st.Fingerprint != targetFP {
-		t.Errorf("Expected fingerprint %q, got %q", targetFP, st.Fingerprint)
+
+	// A prefix of the owner's name is not the owner either — the comparison is
+	// over the whole value, not a length-blind one.
+	if _, err := tm.GetToken(aliceID, "alic"); err == nil {
+		t.Error("a truncated user ID was accepted as the owner")
+	}
+
+	if token, err := tm.GetToken(aliceID, "alice"); err != nil {
+		t.Errorf("GetToken(alice): %v", err)
+	} else if token.AccessToken != "alices-access-token" {
+		t.Errorf("access token = %q, want %q", token.AccessToken, "alices-access-token")
 	}
 }
 
-// TestValidateTokenIndexConsistency verifies that the fingerprint index and
-// the token map stay in sync across a sequence of stores and revocations.
-func TestValidateTokenIndexConsistency(t *testing.T) {
+// TestStopZeroesTheEncryptionKey covers #233: Encryption.Destroy existed for
+// this and had no caller outside its own test, so the AES key stayed in the
+// broker's heap for the life of the process.
+func TestStopZeroesTheEncryptionKey(t *testing.T) {
 	tm := newTMForTest(t)
 
-	for i := 0; i < 10; i++ {
-		storeTestToken(t, tm, fmt.Sprintf("fp-consistency-%d", i))
+	// The key is read through the Encryption value the manager holds, which is
+	// the same buffer Destroy scrubs.
+	before, err := tm.encryption.Encrypt("canary")
+	if err != nil {
+		t.Fatalf("Encrypt before Stop: %v", err)
+	}
+	if _, err := tm.encryption.Decrypt(before); err != nil {
+		t.Fatalf("Decrypt before Stop: %v", err)
 	}
 
-	// Revoke half of them via RevokeUserTokens.
-	if err := tm.RevokeUserTokens("user1"); err != nil {
-		t.Fatalf("RevokeUserTokens: %v", err)
+	if err := tm.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
 	}
 
-	tm.tokenStore.mutex.RLock()
-	tokenCount := len(tm.tokenStore.tokens)
-	indexCount := len(tm.tokenStore.fingerprintIndex)
-	tm.tokenStore.mutex.RUnlock()
-
-	if tokenCount != indexCount {
-		t.Errorf("Token map (%d) and fingerprint index (%d) are out of sync", tokenCount, indexCount)
+	// An all-zero key is still a usable AES key, so the observable consequence of
+	// zeroing is that a ciphertext written under the real key no longer opens.
+	if got, err := tm.encryption.Decrypt(before); err == nil {
+		t.Errorf("the encryption key survived Stop: decrypted %q", got)
 	}
 }
 
-// BenchmarkValidateToken measures ValidateToken throughput with a populated
-// store.  Run with: go test -bench=BenchmarkValidateToken -benchmem ./pkg/auth/
-func BenchmarkValidateToken(b *testing.B) {
-	tm, err := NewTokenManager(&config.Config{
-		Security: config.SecurityConfig{
-			SecureTokenStorage: true,
-			TokenEncryptionKey: "benchmark-key-that-is-long-enough-for-security",
-		},
-	})
-	if err != nil {
-		b.Fatalf("NewTokenManager: %v", err)
-	}
-
-	// Pre-populate the store with 1000 tokens.
-	const storeSize = 1000
-	fps := make([]string, storeSize)
-	for i := 0; i < storeSize; i++ {
-		fp := fmt.Sprintf("bench-fp-%04d", i)
-		fps[i] = fp
-		tok := &Token{
-			AccessToken: "access-" + fp,
-			TokenType:   "Bearer",
-			ExpiresAt:   time.Now().Add(time.Hour),
-			Fingerprint: fp,
-			Claims:      make(map[string]interface{}),
-		}
-		if _, err := tm.StoreToken(tok, "user", "sess"); err != nil {
-			b.Fatalf("StoreToken: %v", err)
-		}
-	}
+// BenchmarkGetToken measures GetToken throughput with a populated store.
+// Run with: go test -bench=BenchmarkGetToken -benchmem ./pkg/auth/
+func BenchmarkGetToken(b *testing.B) {
+	tm, ids := benchStore(b, "bench")
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
-			fp := fps[i%storeSize]
-			if _, err := tm.ValidateToken(fp, "user"); err != nil {
-				b.Errorf("ValidateToken(%q): %v", fp, err)
+			id := ids[i%len(ids)]
+			if _, err := tm.GetToken(id, "user"); err != nil {
+				b.Errorf("GetToken(%q): %v", id, err)
 			}
 			i++
 		}
 	})
 }
 
-// BenchmarkValidateTokenSerial is a serial variant of BenchmarkValidateToken
-// that shows single-goroutine latency.
-func BenchmarkValidateTokenSerial(b *testing.B) {
+// BenchmarkGetTokenSerial is a serial variant of BenchmarkGetToken that shows
+// single-goroutine latency.
+func BenchmarkGetTokenSerial(b *testing.B) {
+	tm, ids := benchStore(b, "bench-serial")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := ids[i%len(ids)]
+		if _, err := tm.GetToken(id, "user"); err != nil {
+			b.Errorf("GetToken(%q): %v", id, err)
+		}
+	}
+}
+
+// benchStore returns a manager holding 1000 live tokens and their IDs.
+func benchStore(b *testing.B, prefix string) (*TokenManager, []string) {
+	b.Helper()
 	tm, err := NewTokenManager(&config.Config{
 		Security: config.SecurityConfig{
 			SecureTokenStorage: true,
-			TokenEncryptionKey: "benchmark-key-that-is-long-enough-for-security",
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
 		},
 	})
 	if err != nil {
@@ -650,10 +633,9 @@ func BenchmarkValidateTokenSerial(b *testing.B) {
 	}
 
 	const storeSize = 1000
-	fps := make([]string, storeSize)
+	ids := make([]string, storeSize)
 	for i := 0; i < storeSize; i++ {
-		fp := fmt.Sprintf("bench-serial-fp-%04d", i)
-		fps[i] = fp
+		fp := fmt.Sprintf("%s-fp-%04d", prefix, i)
 		tok := &Token{
 			AccessToken: "access-" + fp,
 			TokenType:   "Bearer",
@@ -661,18 +643,13 @@ func BenchmarkValidateTokenSerial(b *testing.B) {
 			Fingerprint: fp,
 			Claims:      make(map[string]interface{}),
 		}
-		if _, err := tm.StoreToken(tok, "user", "sess"); err != nil {
+		id, err := tm.StoreToken(tok, "user", "sess")
+		if err != nil {
 			b.Fatalf("StoreToken: %v", err)
 		}
+		ids[i] = id
 	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		fp := fps[i%storeSize]
-		if _, err := tm.ValidateToken(fp, "user"); err != nil {
-			b.Errorf("ValidateToken(%q): %v", fp, err)
-		}
-	}
+	return tm, ids
 }
 
 func TestTokenManagerAlwaysEncrypts(t *testing.T) {

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -124,6 +124,83 @@ func TestTokenManagerBasicOperations(t *testing.T) {
 	}
 }
 
+// TestStoredCiphertextDoesNotOpenInAnotherRecord covers #232: an encrypted token
+// is bound to the account, session and field it was stored for, so a ciphertext
+// moved into another record no longer decrypts.
+//
+// The scenario is an attacker with write access to the store but not the key. It
+// used to succeed in silence: GCM validated the tag, GetToken returned the
+// plaintext, and the broker refreshed one user's credentials while attributing
+// everything it then did — policy, audit, key provisioning — to the other. A
+// failure to decrypt is the outcome that leaves a trace.
+func TestStoredCiphertextDoesNotOpenInAnotherRecord(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			TokenEncryptionKey: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+		},
+	}
+	tm, err := NewTokenManager(cfg)
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+
+	const aliceRefresh = "alices-refresh-token"
+	aliceID, err := tm.StoreToken(&Token{
+		AccessToken:  "alices-access-token",
+		RefreshToken: aliceRefresh,
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Fingerprint:  "alice-fp",
+	}, "alice", "session-alice")
+	if err != nil {
+		t.Fatalf("StoreToken(alice): %v", err)
+	}
+
+	bobID, err := tm.StoreToken(&Token{
+		AccessToken:  "bobs-access-token",
+		RefreshToken: "bobs-refresh-token",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Fingerprint:  "bob-fp",
+	}, "bob", "session-bob")
+	if err != nil {
+		t.Fatalf("StoreToken(bob): %v", err)
+	}
+
+	tm.tokenStore.mutex.Lock()
+	alicesCiphertext := tm.tokenStore.tokens[aliceID].RefreshToken
+	alicesAccessCiphertext := tm.tokenStore.tokens[aliceID].AccessToken
+	// The attack: alice's refresh token, verbatim, in bob's record.
+	tm.tokenStore.tokens[bobID].RefreshToken = alicesCiphertext
+	tm.tokenStore.mutex.Unlock()
+
+	if alicesCiphertext == aliceRefresh {
+		t.Fatal("the refresh token was stored in plaintext; this test would prove nothing")
+	}
+
+	token, err := tm.GetToken(bobID)
+	if err == nil {
+		t.Errorf("bob's record opened alice's refresh token: got %q", token.RefreshToken)
+	}
+
+	// Alice's own record is untouched and must still work: the binding may not
+	// cost the legitimate read.
+	if token, err := tm.GetToken(aliceID); err != nil {
+		t.Errorf("GetToken(alice): %v", err)
+	} else if token.RefreshToken != aliceRefresh {
+		t.Errorf("alice's refresh token = %q, want %q", token.RefreshToken, aliceRefresh)
+	}
+
+	// A ciphertext is also bound to the field it was written to, so an access
+	// token cannot be promoted into the refresh_token slot of its own record and
+	// then presented to the provider as one.
+	tm.tokenStore.mutex.Lock()
+	tm.tokenStore.tokens[aliceID].RefreshToken = alicesAccessCiphertext
+	tm.tokenStore.mutex.Unlock()
+
+	if token, err := tm.GetToken(aliceID); err == nil {
+		t.Errorf("an access token opened in the refresh_token field: got %q", token.RefreshToken)
+	}
+}
+
 func TestTokenManagerRevocation(t *testing.T) {
 	// Test token revocation functionality
 

--- a/pkg/config/shipped_configs_test.go
+++ b/pkg/config/shipped_configs_test.go
@@ -64,7 +64,8 @@ func TestShippedConfigsLoad(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			path := file
-			if !isWholeConfig(t, file) {
+			whole := isWholeConfig(t, file)
+			if !whole {
 				path = wrapProviderFragment(t, file)
 			}
 			// LoadConfig refuses a configuration anyone but root can read (#209),
@@ -84,8 +85,17 @@ func TestShippedConfigsLoad(t *testing.T) {
 			// error reaches log.Fatal in cmd/broker. Checked rather than
 			// constructed so the test neither writes to /var/log nor needs a
 			// syslog daemon.
-			if err := security.ValidateAuditConfig(cfg.Audit); err != nil {
-				t.Fatalf("%s would kill the broker at startup: %v", name, err)
+			//
+			// Only for a whole configuration: since #210 an enabled audit
+			// subsystem must name an output, and a provider fragment is a single
+			// oidc.providers entry that has no audit section to name one in. The
+			// wrapper above supplies nothing but the provider, so checking it here
+			// would report the wrapper's own emptiness rather than anything about
+			// the shipped file.
+			if whole {
+				if err := security.ValidateAuditConfig(cfg.Audit); err != nil {
+					t.Fatalf("%s would kill the broker at startup: %v", name, err)
+				}
 			}
 		})
 	}
@@ -129,9 +139,21 @@ func TestDocumentedConfigSnippetsLoad(t *testing.T) {
 			t.Run(snippet.name(), func(t *testing.T) {
 				// Validate() is not called: a snippet shows part of a
 				// configuration and is not required to be complete.
-				_, err := config.LoadConfig(path)
+				cfg, err := config.LoadConfig(path)
 				if err != nil && !isUnresolvableSecret(err) {
 					t.Fatalf("the YAML at %s:%d does not load: %v", doc, snippet.line, err)
+				}
+				// An audit: block is the one section a snippet cannot show
+				// partially. Since #210 an enabled audit subsystem must name an
+				// output, and audit.enabled defaults to true, so a documented
+				// audit: block without outputs is a block an operator pastes and
+				// then cannot start the broker. CONFIGURATION-GUIDE.md's "Enable
+				// comprehensive audit logging" example was exactly that.
+				if cfg != nil && setsSection(t, path, "audit") {
+					if err := security.ValidateAuditConfig(cfg.Audit); err != nil {
+						t.Fatalf("the audit configuration at %s:%d would kill the broker at startup: %v",
+							doc, snippet.line, err)
+					}
 				}
 			})
 		}
@@ -237,6 +259,21 @@ func yamlFilesUnder(t *testing.T, root string) []string {
 		t.Fatalf("failed to walk %s: %v", root, err)
 	}
 	return files
+}
+
+// setsSection reports whether a configuration file writes the named top-level
+// section at all, which is how a snippet showing an audit: block is told from one
+// that says nothing about auditing and only inherits the defaults.
+func setsSection(t *testing.T, path, section string) bool {
+	t.Helper()
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		return false
+	}
+	return v.IsSet(section)
 }
 
 // isWholeConfig reports whether a file parses as YAML and is rooted at the top

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -424,6 +424,22 @@ func ValidateAuditConfig(cfg config.AuditConfig) error {
 	}
 
 	var problems []string
+
+	// (#210) audit.enabled defaults to true and audit.outputs has no default, so a
+	// configuration that omits the audit block entirely — or writes
+	// `audit: {enabled: true}` — used to produce a logger with no destinations.
+	// writeEvent then iterated an empty slice: every event was accepted, nothing
+	// was written, and neither DroppedEvents nor FailedWrites moved, so the two
+	// counters an operator alerts on stayed at zero while the audit trail did not
+	// exist. Refusing to start is the only honest answer. Defaulting to stdout
+	// would be worse: it puts the audit trail somewhere the operator did not
+	// choose (the journal, under the shipped unit) and keeps the "auditing is on"
+	// claim true by moving the records rather than by writing them where asked.
+	if len(cfg.Outputs) == 0 {
+		problems = append(problems, "audit.enabled is true but audit.outputs is empty: "+
+			"name at least one output ("+SupportedAuditOutputTypes()+"), or set audit.enabled: false")
+	}
+
 	for i, out := range cfg.Outputs {
 		if _, ok := auditOutputConstructors[out.Type]; !ok {
 			problems = append(problems, fmt.Sprintf("audit.outputs[%d]: unsupported type %q (supported: %s)",

--- a/pkg/security/audit_test.go
+++ b/pkg/security/audit_test.go
@@ -86,6 +86,44 @@ func TestNewAuditLogger(t *testing.T) {
 	}
 }
 
+// TestAuditingOnWithNowhereToWriteIsRefused covers #210. audit.enabled defaults
+// to true and audit.outputs has no default, so the configuration this asserts on
+// is the one an operator produces by omitting the audit block: a logger that
+// accepted every event and wrote it nowhere. Nothing reported it, because the
+// only two signals of a broken audit pipeline — DroppedEvents and FailedWrites —
+// count events the code decided not to write and writes that returned an error,
+// and a nil output list produces neither. Both stayed at zero, `oidc-admin
+// status` reported a healthy broker, and "there are no audit records" was
+// indistinguishable from "nothing happened".
+//
+// The assertion is on both halves: the configuration is refused, and it is
+// refused before any output is opened, since ValidateAuditConfig is what
+// cmd/broker's fatal error comes from and what the shipped-configuration gate in
+// pkg/config calls without touching /var/log.
+func TestAuditingOnWithNowhereToWriteIsRefused(t *testing.T) {
+	cfg := config.AuditConfig{Enabled: true}
+
+	if err := ValidateAuditConfig(cfg); err == nil {
+		t.Error("ValidateAuditConfig accepted auditing enabled with no outputs")
+	} else if !strings.Contains(err.Error(), "audit.outputs") {
+		t.Errorf("error does not name the setting to fix: %v", err)
+	}
+
+	logger, err := NewAuditLogger(cfg)
+	if err == nil {
+		t.Fatal("NewAuditLogger built a logger with no destinations")
+	}
+	if logger != nil {
+		t.Error("NewAuditLogger returned a logger alongside an error")
+	}
+
+	// Disabled auditing is a deliberate choice and stays legal: the refusal is
+	// about a configuration that claims to audit and does not.
+	if err := ValidateAuditConfig(config.AuditConfig{Enabled: false}); err != nil {
+		t.Errorf("disabled auditing was refused: %v", err)
+	}
+}
+
 func TestAuditEvent(t *testing.T) {
 	event := &AuditEvent{
 		EventType:  "authentication",
@@ -498,6 +536,10 @@ func TestAuditLoggerDropCounter(t *testing.T) {
 		Enabled:          true,
 		BufferSize:       2,
 		OverflowStrategy: "drop",
+		// An enabled logger must name an output or NewAuditLogger refuses the
+		// configuration (#210); the capture output below replaces it, so which
+		// type is named here does not matter.
+		Outputs: []config.AuditOutput{{Type: "stdout"}},
 	}
 	logger, err := NewAuditLogger(cfg)
 	if err != nil {
@@ -529,6 +571,7 @@ func TestAuditLoggerDefaultDoesNotDrop(t *testing.T) {
 		Enabled:          true,
 		BufferSize:       4,
 		OverflowStrategy: "", // empty → block (default)
+		Outputs:          []config.AuditOutput{{Type: "stdout"}},
 	}
 	logger, err := NewAuditLogger(cfg)
 	if err != nil {
@@ -560,6 +603,7 @@ func TestAuditLoggerSyncStrategy(t *testing.T) {
 		Enabled:          true,
 		BufferSize:       1,
 		OverflowStrategy: "sync",
+		Outputs:          []config.AuditOutput{{Type: "stdout"}},
 	}
 	logger, err := NewAuditLogger(cfg)
 	if err != nil {
@@ -590,6 +634,7 @@ func TestAuditLoggerBlockStrategy(t *testing.T) {
 		Enabled:          true,
 		BufferSize:       4,
 		OverflowStrategy: "block",
+		Outputs:          []config.AuditOutput{{Type: "stdout"}},
 	}
 	logger, err := NewAuditLogger(cfg)
 	if err != nil {

--- a/pkg/security/encryption.go
+++ b/pkg/security/encryption.go
@@ -67,8 +67,22 @@ func ValidateKeyString(keyString string) error {
 	return err
 }
 
-// Encrypt encrypts the given plaintext
+// Encrypt encrypts the given plaintext with no additional authenticated data.
+//
+// Prefer EncryptWithAAD wherever the ciphertext will be stored in a record that
+// identifies something: GCM proves a ciphertext was not modified, but on its own
+// it says nothing about where the ciphertext belongs, so one lifted out of a
+// record and pasted into another still decrypts (#232).
 func (e *Encryption) Encrypt(plaintext string) (string, error) {
+	return e.EncryptWithAAD(plaintext, nil)
+}
+
+// EncryptWithAAD encrypts plaintext and binds the ciphertext to aad, which is
+// authenticated but not stored: decryption succeeds only when the caller supplies
+// the same bytes. Pass whatever identifies the record the ciphertext is being
+// written into, so that moving it to another record makes it undecryptable rather
+// than making it somebody else's secret.
+func (e *Encryption) EncryptWithAAD(plaintext string, aad []byte) (string, error) {
 	if plaintext == "" {
 		return "", nil
 	}
@@ -92,14 +106,23 @@ func (e *Encryption) Encrypt(plaintext string) (string, error) {
 	}
 
 	// Encrypt the plaintext
-	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), aad)
 
 	// Encode to base64
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
-// Decrypt decrypts the given ciphertext
+// Decrypt decrypts a ciphertext that was encrypted with no additional
+// authenticated data.
 func (e *Encryption) Decrypt(ciphertext string) (string, error) {
+	return e.DecryptWithAAD(ciphertext, nil)
+}
+
+// DecryptWithAAD decrypts a ciphertext produced by EncryptWithAAD, and fails
+// unless aad is byte-identical to the value it was encrypted under. The error
+// deliberately does not distinguish a wrong AAD from a corrupted ciphertext:
+// both mean the record and the secret in it do not belong together.
+func (e *Encryption) DecryptWithAAD(ciphertext string, aad []byte) (string, error) {
 	if ciphertext == "" {
 		return "", nil
 	}
@@ -132,7 +155,7 @@ func (e *Encryption) Decrypt(ciphertext string) (string, error) {
 	nonce, ciphertextBytes := data[:nonceSize], data[nonceSize:]
 
 	// Decrypt the ciphertext
-	plaintext, err := gcm.Open(nil, nonce, ciphertextBytes, nil)
+	plaintext, err := gcm.Open(nil, nonce, ciphertextBytes, aad)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt: %w", err)
 	}

--- a/pkg/security/encryption_test.go
+++ b/pkg/security/encryption_test.go
@@ -329,6 +329,53 @@ func TestEncryptionWithDifferentKeys(t *testing.T) {
 	}
 }
 
+// TestAADBindsCiphertextToItsContext covers #232: a ciphertext must only open
+// under the additional authenticated data it was sealed with. GCM's tag proves
+// the ciphertext was not modified and says nothing about where it belongs, so
+// without this the same bytes decrypt in any record that has the key.
+func TestAADBindsCiphertextToItsContext(t *testing.T) {
+	enc, err := NewEncryption(testKey1)
+	if err != nil {
+		t.Fatalf("NewEncryption: %v", err)
+	}
+
+	const secret = "refresh-token-belonging-to-alice"
+	alice := []byte("user=alice|session=s1")
+	bob := []byte("user=bob|session=s2")
+
+	ciphertext, err := enc.EncryptWithAAD(secret, alice)
+	if err != nil {
+		t.Fatalf("EncryptWithAAD: %v", err)
+	}
+
+	plaintext, err := enc.DecryptWithAAD(ciphertext, alice)
+	if err != nil {
+		t.Fatalf("DecryptWithAAD with the sealing AAD: %v", err)
+	}
+	if plaintext != secret {
+		t.Errorf("round trip returned %q, want %q", plaintext, secret)
+	}
+
+	// The whole point: the same key, the same ciphertext, a different record.
+	if _, err := enc.DecryptWithAAD(ciphertext, bob); err == nil {
+		t.Error("a ciphertext sealed for one identity opened under another")
+	}
+	// And no AAD at all must not be a way around it, which is what a caller
+	// still using Decrypt would be doing.
+	if _, err := enc.Decrypt(ciphertext); err == nil {
+		t.Error("a ciphertext sealed with AAD opened with none")
+	}
+	// Nor the reverse: nothing sealed without AAD may be opened as though it had
+	// been bound to something.
+	unbound, err := enc.Encrypt(secret)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := enc.DecryptWithAAD(unbound, alice); err == nil {
+		t.Error("a ciphertext sealed with no AAD opened under one")
+	}
+}
+
 func TestEncryptionConsistency(t *testing.T) {
 	enc, err := NewEncryption(testKey1)
 	if err != nil {


### PR DESCRIPTION
Three issues on the audit trail and token encryption: #210 (auditing on by default with
nowhere to write), the crypto half of #232 (no AAD on stored tokens), and the two live
items of #233 (a security control with no callers, and key material never zeroed).

## What I verified before changing anything

**#210 — confirmed, with one detail in the issue wrong.** `pkg/config/config.go:562`
sets `audit.enabled` to `true` and nothing in `setDefaults` sets `audit.outputs`.
`pkg/security/audit.go:143` builds the output list by iterating `cfg.Outputs`, so an
empty config yields a nil slice; `audit.go:349` then iterates that nil slice in
`writeEvent`, which is why neither `DroppedEvents` nor `FailedWrites` moves — the event
is accepted and no write is attempted, so there is nothing to count. The two counters an
operator alerts on, and the `oidc_audit_events_dropped_total` gauge fed from them, read
zero forever while no audit trail exists.

The one claim that is false: the issue says copying `configs/providers/okta.yaml` reaches
this state. It does not — `okta.yaml:127-140` names a file output. I checked every whole
config under `configs/`, `test/e2e/broker.yaml`, and what `scripts/install.sh` installs;
all of them name an output, so nothing shipped depends on the hole. Omitting the `audit:`
block entirely, or writing `audit: {enabled: true}`, is the way in, and that is what the
new test asserts on.

**#232 — confirmed.** `Encrypt`/`Decrypt` passed `nil` as GCM's additional data, and
`StoreToken` sealed all three token fields that way, so any ciphertext decrypted in any
record. The audit trail is likewise unchained; see the deferral below.

**#233 item 1 — confirmed.** `TokenManager.ValidateToken` had callers in
`broker_core_test.go` and `token_manager_test.go` and none in `pkg`, `internal` or `cmd`.
The refresh path called `GetToken`, which did a map lookup by ID and returned decrypted
tokens with no ownership check at all. The constant-time comparison added for L-15 was
guarding a function no running broker executed.

**#233 item 2 — confirmed, and the issue names the wrong method**, as its author already
noted in a correction comment: there is no `Stop()` on `Encryption`, only
`Destroy()` (`pkg/security/encryption.go:184`), and there is no background rotation
goroutine to outlive anything. Its only caller was `key_format_test.go`. Item 3 was
withdrawn by the author; item 4 is Makefile drift outside this area. Neither is touched
here, so this does not close #233.

## What changed

**#210 fails the broker closed.** `ValidateAuditConfig` now reports an empty
`audit.outputs` as a problem, and since `NewAuditLogger` already calls it, a broker told
to audit with nowhere to write refuses to start. I took the refusal over defaulting
`audit.outputs` to `stdout` deliberately: `README.md` promises "complete access trails
for compliance, with backpressure rather than silent drops" and `SECURITY.md` promises
"comprehensive audit logging", and defaulting would keep those sentences true by moving
the records somewhere the operator never chose — the journal, under the shipped unit —
rather than by writing them where asked. Refusing is the only answer that cannot be
mistaken for working.

Writing that guard surfaced a real documentation defect: the audit example in
`configs/CONFIGURATION-GUIDE.md` §5 had no `outputs:`, so anyone following the guide
would have hit the new refusal. The guide is fixed and the doc-snippet gate test now
validates any snippet that sets an `audit:` section, so the next one cannot regress.

**#232 binds each ciphertext to its record.** Each of the three token fields is sealed
under an AAD naming the account, the session and the field, length-prefixed so no pair of
identities can collide. `GetToken` rebuilds the AAD from the record it is reading, which
is what makes a moved ciphertext fail — an attacker who relocates bytes gets the
destination record's identity into the AAD by definition, and it is the wrong one.
`Encrypt`/`Decrypt` keep their signatures and delegate with a nil AAD; the token store
uses the new `EncryptWithAAD`/`DecryptWithAAD`. No migration and no record-format version
field, because the store is an in-memory map that dies with the process, so no ciphertext
outlives the code that wrote it.

**#233 puts the ownership check on the live path.** `GetToken(tokenID, userID)` refuses,
in constant time, a record that does not belong to the named account, and
`RefreshSession` passes `session.UserID`. `ValidateToken` is deleted rather than wired up:
wiring it would have left two ways to read a token of which only one checked. The
fingerprint index went with it — it existed only to make that lookup O(1), and keeping a
second map in sync with the first now buys nothing. Its five tests were rewritten against
the invariant that survives (every path that drops a token drops it from the store);
`TestValidateTokenIndexConsistency`, which asserted the two maps agreed, is gone with the
second map. `TokenManager.Stop` now calls `Destroy`, which is safe ground: the broker
waits on its own goroutines and the IPC server stops accepting before `Stop` is reached.

## Deferred, deliberately: the audit trail is still not tamper-evident

This is the other half of #232 and it is left open on purpose, so the issue stays open
with only its AAD half done. A per-record hash chain is the standard answer, but against
the threat the issue itself describes — an attacker who has compromised a root-run broker
and can write to its own log under `/var/log/oidc-auth` — an unkeyed chain in that same
file buys nothing: having deleted a record they recompute the chain over the rest. What
makes tampering detectable is an anchor the attacker cannot reach: signing the head with a
key the broker does not hold readable, or shipping records off the host as they are
written. Choosing between those decides the on-disk format for a project that already
ships releases, and belongs in one deliberate change together with the `verify-audit`
command that reads it — not appended here. `SECURITY.md` now states plainly that the trail
is not tamper-evident and points at the `syslog` and `http` outputs, which are the
off-host anchor available today.

## Tests, and proof they are not vacuous

New: `TestAuditingOnWithNowhereToWriteIsRefused` (#210),
`TestAADBindsCiphertextToItsContext` and `TestStoredCiphertextDoesNotOpenInAnotherRecord`
(#232), `TestGetTokenRefusesAnotherAccountsTokenID` and `TestStopZeroesTheEncryptionKey`
(#233).

For each guard I backed the file up, perturbed only the new check with `perl -0pi -e`, ran
only the covering test, then restored and confirmed with `diff -q` that the file was
byte-identical:

| Guard perturbed | Covering test | Result with the guard disabled |
| --- | --- | --- |
| `len(cfg.Outputs) == 0` in `ValidateAuditConfig` | `TestAuditingOnWithNowhereToWriteIsRefused` | FAIL — an enabled logger with no outputs was accepted |
| AAD dropped in `EncryptWithAAD` | `TestAADBindsCiphertextToItsContext` | FAIL — a ciphertext opened under another AAD |
| AAD dropped in `GetToken` | `TestStoredCiphertextDoesNotOpenInAnotherRecord` | FAIL — alice's refresh token decrypted inside bob's record |
| ownership comparison in `GetToken` | `TestGetTokenRefusesAnotherAccountsTokenID` | FAIL — bob read alice's access and refresh tokens, and a truncated user ID was accepted |
| `Destroy()` call in `Stop` | `TestStopZeroesTheEncryptionKey` | FAIL — the key survived Stop |

`go build ./...` clean, `gofmt -l .` empty, `go test ./...` green, `go test -race` green on
`pkg/auth`, `pkg/security` and `pkg/config`, `golangci-lint run` reports 0 issues on the
three packages touched. (macOS host, so the `//go:build linux` cgo files are not built
here.)

## Found, not fixed

- `BenchmarkValidateToken`/`BenchmarkValidateTokenSerial` were configured with a
  passphrase-shaped encryption key, which `NewEncryption` has rejected since v0.4.0
  removed the PBKDF2 derivation, so both failed on the first line of every run. Since
  I was rewriting them against `GetToken` anyway they now use a real key — noted because
  it means nobody has run these benchmarks since v0.4.0.
- `Session.TokenFingerprint` is written in three places and read nowhere in production,
  and for a pending session it holds `deviceFlow.DeviceCode` — a credential-ish value —
  which contradicts the comment at `session_tokens_test.go:24` calling the field "a hash,
  not a credential".
- `scripts/setup-dev.sh:159` generates a dev `broker.yaml` containing `logging:`,
  `providers:` and `development:` top-level keys that the broker has refused since #170,
  and no audit outputs, so it now fails the new startup check too. The generated file has
  presumably not been used in a while.
- `GetToken` treats the access token's expiry as the whole record's expiry, so once the
  access token has expired the refresh path fails with `NO_REFRESH_TOKEN` rather than
  refreshing — a refresh token outliving its access token is the normal case, so this
  makes refresh work only inside the access token's lifetime.
- `CONTRIBUTING.md:219` uses `TestTokenManager_ValidateToken` as its table-driven-test
  example, naming a method this PR deletes. It is illustrative style, not an API claim,
  so I left it alone.

Closes #210
Addresses #232 (AAD half; the hash chain stays open on it)
Addresses #233 (items 1 and 2; item 3 withdrawn by its author, item 4 is Makefile drift)
