### PR TITLE
build(pam): build the module as hardened C, from the one script that verifies it (#198, #222)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,14 @@ jobs:
       - name: Check the cgo quarantine
         run: ./scripts/check-cgo-quarantine.sh
 
+      # #222: four places compiled pam_oidc.so and three of them did not inspect
+      # the result, which a build with no PAM entry points in it does not report
+      # (#140). scripts/build-pam-module.sh cannot finish without inspecting it, so
+      # what has to stay true is that nothing else compiles the module — a second
+      # producer is where the check gets forgotten again.
+      - name: Check one script is the only producer of the PAM module
+        run: ./scripts/check-pam-module-producers.sh
+
       # Every `uses:` in this directory must name a 40-hex commit SHA. A version
       # tag is mutable: whoever controls the action's repository can retarget it,
       # and the two references that were left unpinned sat between "build the PAM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,22 +163,15 @@ jobs:
             -o bin/oidc-admin-linux-${{ matrix.arch }} \
             ./cmd/oidc-admin
 
-      - name: Build PAM module (CGO)
-        env:
-          GOOS: linux
-          GOARCH: ${{ matrix.arch }}
-          CGO_ENABLED: 1
-        run: |
-          go build -buildmode=c-shared -trimpath -ldflags="${{ steps.vars.outputs.ldflags }}" \
-            -o bin/pam_oidc.so-linux-${{ matrix.arch }} \
-            ./cmd/pam-module
-          rm -f bin/pam_oidc.so-linux-${{ matrix.arch }}.h
-
-      # A c-shared build with no PAM entry points in it exits 0 (#140), so the
-      # artifact has to be inspected before it can be released. This step is what
-      # stops another release shipping a module PAM cannot use.
-      - name: Verify the PAM module is loadable
-        run: ./scripts/verify-pam-module.sh bin/pam_oidc.so-linux-${{ matrix.arch }}
+      # The module is C, built by the one script every producer uses, which
+      # applies the hardening flags and then inspects what it produced: a build
+      # with no PAM entry points in it exits 0 (#140), so nothing but reading the
+      # artifact can tell a release from a module PAM cannot use. The architecture
+      # argument makes the file name a claim the script checks — this job runs on a
+      # runner of the matrix architecture, and a change that made it cross-build
+      # would otherwise publish a module that fails at dlopen (#222).
+      - name: Build and verify the PAM module
+        run: ./scripts/build-pam-module.sh bin/pam_oidc.so-linux-${{ matrix.arch }} ${{ matrix.arch }}
 
       - name: Build PAM helper (CGO)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **`pam_oidc.so` no longer carries the Go runtime into `sshd`, and is compiled
+  with hardening flags (#198).** The module is loaded into every authenticating
+  `sshd` pre-auth child, as root, and holds a 16 KB broker response on the stack.
+  It was compiled with `-Wall -Wextra` and nothing else: no stack protector, no
+  `_FORTIFY_SOURCE`, and partial RELRO with a writable PLT.
+
+  It was also built as a Go `c-shared` library, which starts the Go runtime in
+  every process that `dlopen`s it. The runtime replaces the process's handlers for
+  `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGPIPE` and `SIGURG` with its own, adds
+  `SA_ONSTACK` to the handlers it leaves alone, runs its own threads, and marks the
+  library `DF_1_NODELETE` so `dlclose` cannot unload it. It did all of that in
+  `sshd` in service of no Go code: all six `pam_sm_*` entry points are C, they call
+  no Go, and the package exports no Go function to C, so the Go files in
+  `cmd/pam-module` are cgo wrappers that exist to let `go test` drive the C.
+
+  The module is now compiled from that one C file by the C compiler, with
+  `-fstack-protector-strong`, a `_FORTIFY_SOURCE` floor of 2 set in the source so a
+  distribution asking for a higher level keeps it, and `-Wl,-z,relro -Wl,-z,now
+  -Wl,-z,noexecstack`. The result is 70 KB rather than 2.4 MB, has full RELRO and a
+  guarded stack, starts no threads, installs no signal handlers, and can be
+  unloaded. Every SSH login in the end-to-end harness authenticates against it.
+
+  The same flags are in `bridge_linux.go`'s `#cgo` directives, so the C the tests
+  exercise is compiled the way the shipped module is. `-Werror` was deliberately
+  not added: the code is warning-clean today, but making a future compiler's new
+  diagnostic a build failure for anyone building from source is a different bargain
+  from the flags above, and CI compiles the module on every push anyway.
 - **Release artifacts are now signed and carry build provenance (#180).** Until
   now the only integrity material published was a `.sha256` file uploaded to the
   same release page as the tarball it describes, which detects a corrupted
@@ -39,6 +66,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the download; nothing checked the payload that actually reaches PAM.
 
 ### Fixed
+- **One script now builds `pam_oidc.so`, and it cannot finish without inspecting
+  what it built (#222).** A module with no PAM entry points in it builds and exits
+  0 — that is #140, and it shipped in every release before it was found — so
+  `scripts/verify-pam-module.sh` exists to read the artifact. Four places compiled
+  the module and one of them ran the verifier. The three that did not were
+  `scripts/build-simple.sh`, `scripts/build-releases.sh` — both since deleted as
+  unreferenced (#241) — and `make release`; the Makefile's `build-pam` and the e2e
+  image did verify, contrary to the issue.
+
+  Every remaining producer now calls `scripts/build-pam-module.sh`, which compiles
+  the module and runs the verifier over the result with no way to ask it not to.
+  `scripts/check-pam-module-producers.sh` (a `Validate` step, and
+  `make check-pam-producers`) fails the build if a second producer appears, because
+  a check every producer has to remember is one edit away from being forgotten
+  again.
+- A module can no longer be packaged as an architecture it was not built for.
+  `scripts/build-simple.sh` used to package one host-native `pam_oidc.so` as *both*
+  the `linux-amd64` and the `linux-arm64` artifact: it built the module as
+  `pam_oidc-native.so` and copied that file into every Linux package, so on an
+  arm64 host the amd64 tarball contained an arm64 module — a file that installs
+  cleanly and then fails at `dlopen` time, inside `sshd`'s auth path. The PAM helper
+  was packaged the same way. That script and `scripts/build-releases.sh` have since
+  been deleted (#241), which removes those two paths outright; what keeps the
+  property is that `build-pam-module.sh` now checks a module's machine type against
+  the architecture its name claims whenever a caller states one, and the release
+  workflow — the one path that publishes artifacts — states it for each.
 - The README's release-download snippet still read `VERSION=v0.4.0`, two releases
   stale, and every `curl`, `tar` and verification command below it interpolates
   that value — so the new signature-verification instructions would have been run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,13 +107,28 @@ not have. Its cgo is behind a `//go:build linux` tag, so `go build ./...` and
 `go test ./...` work on a Mac — the C and the tests that drive it are simply
 absent there. Everything else, `pkg/pam` included, is pure Go.
 
-**The C must stay in `cmd/pam-module`.** cgo compiles only the C sources in the
-directory of the package being built, so C living anywhere else is not compiled
-into the module — and because a header supplies valid declarations, the build
-still exits 0 and produces a `.so` with no entry points in it. That shipped in
-every release before this one (#140). `scripts/verify-pam-module.sh` checks the
-built artifact for exactly that, and runs from `make build-pam`,
-`make verify-linux` and the release workflow.
+**The shipped module is C only, and nothing in it calls Go.** All six entry
+points are in `cgo_bridge_linux.c`; the package's Go files are cgo wrappers that
+let `go test` drive that C (cgo is not permitted in `_test.go` files, so they live
+in normal ones). `scripts/build-pam-module.sh` therefore compiles the one C file
+with the C compiler rather than building the package as a Go `c-shared` library,
+which is what keeps the Go runtime — its threads, its handlers for `SIGSEGV`,
+`SIGBUS`, `SIGFPE`, `SIGPIPE` and `SIGURG`, and `DF_1_NODELETE` — out of every
+`sshd` pre-auth child that loads the module (#198). **A `//export` in this package,
+or any other C→Go call, brings all of that back**, so it is a change to weigh
+rather than make in passing.
+
+**`scripts/build-pam-module.sh` is the only thing that builds the module.** The
+Makefile, both release scripts, the e2e image and the release workflow all call it,
+and it applies the hardening flags and inspects what it produced. That inspection
+cannot be separated from the build: a module with no entry points in it exits 0,
+because a header supplies valid declarations, and that shipped in every release
+before #140 was found. `make check-pam-producers`
+(`scripts/check-pam-module-producers.sh`) fails the build if a second producer
+appears — four producers with the check pasted into one of them is what #222 was.
+
+**The C must stay in `cmd/pam-module`** so `go test` still compiles it: cgo
+compiles only the C sources in the directory of the package being built.
 
 Two checks keep that quarantine from eroding: a `macOS (no PAM headers)` CI job
 that runs `go build/vet/test ./...` on a host with no PAM headers, and
@@ -121,6 +136,13 @@ that runs `go build/vet/test ./...` on a host with no PAM headers, and
 graph that `cmd/pam-module` is the only package with cgo files on Linux and that
 none has any on macOS. `make check-cgo` needs no headers and runs on any OS, so
 run it after touching a `#cgo` line or a build constraint.
+
+The `#cgo CFLAGS`/`LDFLAGS` in `bridge_linux.go` carry the same hardening flags as
+`scripts/build-pam-module.sh`, so the C the tests exercise is compiled the way the
+shipped module is compiled. Change one and change the other. `_FORTIFY_SOURCE` is
+set in `cgo_bridge_linux.c` instead of either, because it has to precede the first
+system header, and as a floor rather than an assignment so a distribution asking
+for a higher level keeps it.
 
 To exercise the C locally, run the sweep CI runs inside a Linux container:
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -403,6 +403,24 @@ Only `sshd` is exercised end-to-end by CI (`test/e2e`). The `login`, `su` and
 `sudo` files in `configs/pam/` are examples: deploy them one at a time, from a
 host you can still get back into.
 
+#### What loading the module does to the process
+
+`pam_oidc.so` is about 70 KB of C linked against `libpam` and `libjson-c`. It
+starts no threads, installs no signal handlers, and can be unloaded — so what it
+adds to an `sshd` pre-auth child is the memory it occupies and the time its `auth`
+phase blocks for, and nothing else.
+
+That is worth stating because it was not always true, and because it constrains
+what the module may become. Releases through v0.5.0 built the module as a Go
+`c-shared` library: a 2.4 MB object which starts the Go runtime in every process
+that `dlopen`s it, and the runtime replaces the process's handlers for `SIGSEGV`,
+`SIGBUS`, `SIGFPE`, `SIGPIPE` and `SIGURG` with its own, adds `SA_ONSTACK` to the
+handlers it leaves in place, runs its own threads, and sets `DF_1_NODELETE` so
+`dlclose` cannot unload it. It did all of that in `sshd`, as root, before
+authentication, in service of no Go code — none ran in the module (#198). The
+entry points were always C, so the fix was to build the module with the C
+compiler. Keeping it that way means keeping Go out of the module's call path.
+
 #### SSH Configuration (`/etc/pam.d/ssh`)
 ```bash
 # Production SSH PAM configuration.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-pam skip-pam test install clean lint fmt vet check-cgo tidy verify-linux help
+.PHONY: build build-pam skip-pam test install clean lint fmt vet check-cgo check-pam-producers tidy verify-linux help
 
 # Build variables
 BINARY_DIR := bin
@@ -71,21 +71,11 @@ build-broker:
 ## Build PAM module (Linux only; verifies the result is loadable)
 build-pam:
 	@echo "Building PAM module..."
-	@# The module's C bridge needs Linux-PAM (<security/pam_ext.h>) and json-c,
-	@# which macOS does not have, so the cgo in cmd/pam-module is behind a
-	@# //go:build linux tag. On another OS this would build a .so with no PAM
-	@# entry points in it, which is exactly the failure #140 was about — refuse
-	@# instead. Use `make verify-linux` to build and test in the container.
-	@if [ "$$(go env GOOS)" != "linux" ]; then \
-		echo "build-pam: the PAM module can only be built for Linux (GOOS=$$(go env GOOS))." >&2; \
-		echo "           Run 'make verify-linux', or build in a Linux container." >&2; \
-		exit 1; \
-	fi
-	@mkdir -p $(BINARY_DIR)
-	CGO_ENABLED=1 go build -buildmode=c-shared $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(PAM_MODULE) ./cmd/pam-module
-	@# A build that emits a module with no pam_sm_* symbols exits 0, so the only
-	@# way to know it worked is to look at the artifact.
-	@./scripts/verify-pam-module.sh $(BINARY_DIR)/$(PAM_MODULE)
+	@# One script builds the module, everywhere: it applies the hardening flags,
+	@# refuses to run off Linux (where the C bridge's Linux-PAM and json-c headers
+	@# do not exist) and inspects the artifact it produced, because a module with
+	@# no pam_sm_* symbols in it builds and exits 0 (#140, #222).
+	@./scripts/build-pam-module.sh $(BINARY_DIR)/$(PAM_MODULE)
 
 ## Build PAM helper binary
 build-helper:
@@ -131,12 +121,12 @@ verify-linux:
 		-v oidc-pam-gocache:/root/.cache \
 		-w /src oidc-pam-verify \
 		sh -c './scripts/check-cgo-quarantine.sh \
+			&& ./scripts/check-pam-module-producers.sh \
 			&& go vet ./... \
 			&& go test -race ./... \
 			&& golangci-lint run --timeout=5m ./... \
 			&& echo "Building and verifying the PAM module..." \
-			&& CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -o /tmp/pam_oidc.so ./cmd/pam-module \
-			&& ./scripts/verify-pam-module.sh /tmp/pam_oidc.so'
+			&& ./scripts/build-pam-module.sh /tmp/pam_oidc.so'
 
 ## Install binaries to system locations
 install: build
@@ -199,6 +189,10 @@ vet:
 check-cgo:
 	@./scripts/check-cgo-quarantine.sh
 
+## Check nothing but build-pam-module.sh compiles the module (works on any OS)
+check-pam-producers:
+	@./scripts/check-pam-module-producers.sh
+
 ## Tidy dependencies
 tidy:
 	@echo "Tidying dependencies..."
@@ -226,15 +220,24 @@ docker-run:
 	docker run -it --rm oidc-pam:latest
 
 ## Create release build
+##
+## The broker, helper and admin CLI cross-compile from anywhere. The PAM module
+## does not: it is C, so it needs a compiler that targets the output architecture
+## and that architecture's PAM and json-c headers. Building it for the other
+## architecture here needs CC set to a cross-toolchain; build-pam-module.sh
+## refuses rather than writing a host-architecture module under a name that claims
+## otherwise. The released modules are built on a runner of each architecture —
+## see the build matrix in .github/workflows/release.yml, which is the release
+## path this target predates.
 release: clean
 	@echo "Creating release build..."
 	@mkdir -p $(BINARY_DIR)
 	GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(BROKER_BINARY)-linux-amd64 ./cmd/broker
-	GOOS=linux GOARCH=amd64 go build -buildmode=c-shared $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(PAM_MODULE)-linux-amd64 ./cmd/pam-module
+	./scripts/build-pam-module.sh $(BINARY_DIR)/$(PAM_MODULE)-linux-amd64 amd64
 	GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(HELPER_BINARY)-linux-amd64 ./cmd/pam-helper
 	GOOS=linux GOARCH=amd64 go build $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(ADMIN_BINARY)-linux-amd64 ./cmd/oidc-admin
 	GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(BROKER_BINARY)-linux-arm64 ./cmd/broker
-	GOOS=linux GOARCH=arm64 go build -buildmode=c-shared $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(PAM_MODULE)-linux-arm64 ./cmd/pam-module
+	./scripts/build-pam-module.sh $(BINARY_DIR)/$(PAM_MODULE)-linux-arm64 arm64
 	GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(HELPER_BINARY)-linux-arm64 ./cmd/pam-helper
 	GOOS=linux GOARCH=arm64 go build $(GO_BUILD_FLAGS) -o $(BINARY_DIR)/$(ADMIN_BINARY)-linux-arm64 ./cmd/oidc-admin
 
@@ -269,6 +272,7 @@ help:
 	@echo "  fmt             Format code"
 	@echo "  vet             Run go vet"
 	@echo "  check-cgo       Check cgo is confined to cmd/pam-module"
+	@echo "  check-pam-producers  Check one script is the only producer of the PAM module"
 	@echo "  tidy            Tidy dependencies"
 	@echo "  coverage        Generate coverage report"
 	@echo "  security        Run security scan"

--- a/cmd/pam-module/bridge_linux.go
+++ b/cmd/pam-module/bridge_linux.go
@@ -4,7 +4,9 @@ package main
 
 /*
 #cgo CFLAGS: -I${SRCDIR} -I/usr/include/security -Wall -Wextra
+#cgo CFLAGS: -fstack-protector-strong
 #cgo LDFLAGS: -lpam -ljson-c
+#cgo LDFLAGS: -Wl,-z,relro,-z,now -Wl,-z,noexecstack
 #include "cgo_bridge.h"
 */
 import "C"
@@ -24,9 +26,17 @@ import "github.com/scttfrdmn/oidc-pam/pkg/pam"
 //
 // Keeping the "C" import behind a build tag is also what lets `go build ./...`
 // and `go test ./...` run on a developer's Mac (#141). On a non-Linux host this
-// package compiles to a trivial main with no C in it, which is why `make
-// build-pam` refuses to run outside Linux instead of quietly emitting an empty
-// module.
+// package compiles to a trivial main with no C in it, which is why
+// scripts/build-pam-module.sh refuses to run outside Linux instead of quietly
+// emitting an empty module.
+//
+// The hardening flags are here so that the C these tests exercise is compiled the
+// way the shipped module is compiled. The shipped module is not built by cgo —
+// scripts/build-pam-module.sh hands cgo_bridge_linux.c to the C compiler, which
+// is what keeps the Go runtime out of sshd (#198) — so this list and the one in
+// that script are two views of the same decision and are meant to agree. The
+// fortify level is set in cgo_bridge_linux.c rather than in either of them,
+// because it has to precede the first system header.
 
 // pamCodesFromHeaders is every PAM result code pkg/pam declares, read from the
 // headers this module is compiled against.

--- a/cmd/pam-module/cgo_bridge_linux.c
+++ b/cmd/pam-module/cgo_bridge_linux.c
@@ -1,3 +1,13 @@
+// _FORTIFY_SOURCE has to be defined before the first system header is included,
+// which is why it is here and not a -D in the build. It is a floor, not an
+// assignment: a distribution whose compiler already asks for a higher level (3,
+// on current Ubuntu) keeps it, and stating it on the command line instead would
+// quietly downgrade that and warn about the redefinition. It needs -O to do
+// anything, which scripts/build-pam-module.sh and cgo both supply.
+#ifndef _FORTIFY_SOURCE
+#define _FORTIFY_SOURCE 2
+#endif
+
 #include "cgo_bridge.h"
 #include <stdarg.h>
 #include <stdio.h>

--- a/cmd/pam-module/main.go
+++ b/cmd/pam-module/main.go
@@ -1,21 +1,37 @@
-// Command pam-module produces pam_oidc.so, the PAM module that talks to the
-// oidc-auth broker.
+// Command pam-module holds the source of pam_oidc.so, the PAM module that talks
+// to the oidc-auth broker.
 //
-// The PAM entry points — pam_sm_authenticate and the other five — are
-// implemented in C, in cgo_bridge_linux.c. They live in *this* package and not
-// in pkg/pam because cgo compiles only the C sources sitting in the directory of
-// the package being built. An earlier layout kept them in pkg/pam, which this
-// package does not import, so `go build -buildmode=c-shared ./cmd/pam-module`
-// succeeded and produced a shared object containing no PAM entry points at all
-// (#140). Header-only linkage made it silent: the compiler saw valid
-// declarations from cgo_bridge.h, nothing referenced libpam, and the linker
-// dropped -lpam as unused.
+// The module itself is C. The PAM entry points — pam_sm_authenticate and the
+// other five — are implemented in cgo_bridge_linux.c, they call no Go, and this
+// package exports no Go function to C, so scripts/build-pam-module.sh compiles
+// that one file with the C compiler and links it against libpam and json-c. That
+// is the whole shipped artifact: 70 KB of C, with no Go runtime in it.
 //
-// Two things keep that from happening again: the C is here, and `make build-pam`
-// refuses to finish unless nm finds all six pam_sm_* symbols in the result.
+// Building it instead as a Go c-shared library, which is what this project used to
+// do, produced the same six entry points inside a 2.4 MB object that starts the Go
+// runtime in every process that dlopens it. In sshd's pre-auth children that
+// means the runtime's threads, its handlers for SIGSEGV, SIGBUS, SIGFPE, SIGPIPE
+// and SIGURG installed over sshd's own, and DF_1_NODELETE so the library can
+// never be unloaded — none of it in service of any Go code, since none runs
+// (#198). If something in this module ever does need to call Go, the c-shared
+// build and everything in that list comes back with it.
+//
+// The Go files here are cgo test wrappers: they drive the C from `go test` (cgo
+// is not permitted in _test.go files, so the wrappers live in normal ones). They
+// are not part of the module.
+//
+// The C is in *this* package rather than pkg/pam because cgo compiles only the C
+// sources sitting in the directory of the package being built, and pkg/pam is a
+// package this one does not import — so the c-shared build of an earlier layout
+// succeeded and produced a shared object with no PAM entry points in it at all
+// (#140). Header-only linkage made it silent: the compiler saw valid declarations
+// from cgo_bridge.h, nothing referenced libpam, and the linker dropped -lpam as
+// unused. scripts/check-cgo-quarantine.sh keeps the C here so the tests still
+// compile it, and scripts/build-pam-module.sh refuses to finish unless nm finds
+// all six pam_sm_* symbols in what it built.
 package main
 
-// This binary is never executed. Building it as c-shared is what emits the
-// module, and PAM calls into the C entry points directly; main() exists only
-// because package main requires it.
+// This binary is never executed and is not what ships; the module is built from
+// the C. main() exists only because package main requires it, and package main is
+// what lets the cgo test wrappers live alongside the C they exercise.
 func main() {}

--- a/scripts/build-pam-module.sh
+++ b/scripts/build-pam-module.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# build-pam-module.sh <output-path> [expected-arch]
+#
+# The one path that produces pam_oidc.so. Everything that ships, tests or
+# packages the module calls this: the Makefile, the e2e image and release.yml.
+# scripts/check-pam-module-producers.sh fails the build if anything else starts
+# compiling the module itself.
+#
+# There is one build path because building the module and checking the result
+# cannot be separate steps. A shared object with no PAM entry points in it builds
+# and exits 0 (#140), so a compiler's exit status says nothing about whether the
+# artifact is usable — only inspecting it does. With the build open-coded in each
+# producer, that inspection is a line each producer has to remember, and three of
+# them did not (#222). Here it is not a line anyone can forget: this script does
+# not finish without running scripts/verify-pam-module.sh over what it just
+# built, and there is no flag to ask it not to.
+#
+# The module is plain C. All six pam_sm_* entry points are in
+# cmd/pam-module/cgo_bridge_linux.c and nothing in them calls into Go — the
+# package's Go files are cgo test wrappers that drive the C from `go test`, and
+# the package exports no Go function to C at all. So the shipped artifact is
+# built with the C compiler rather than as a Go c-shared library, which keeps the
+# Go runtime — its threads, its signal handlers and its DF_1_NODELETE — out of
+# every sshd pre-auth child that loads the module (#198). Keep it that way: if
+# something in this module ever needs to call Go, the runtime comes back with it.
+#
+# Usage:
+#   scripts/build-pam-module.sh bin/pam_oidc.so
+#   scripts/build-pam-module.sh bin/pam_oidc.so-linux-arm64 arm64
+#
+# The optional second argument is the architecture the caller intends to ship
+# this file as. Give it whenever the output name claims an architecture: the
+# compiler builds for whatever it targets, so a name that disagrees with the
+# result is a module that installs cleanly and then fails at dlopen time, inside
+# sshd's auth path.
+#
+# Environment:
+#   CC  the compiler to use (default: cc). A cross-build needs a cross-toolchain
+#       here and the matching PAM and json-c headers for the target.
+
+set -euo pipefail
+
+SO="${1:-}"
+EXPECT_ARCH="${2:-}"
+
+if [[ -z "${SO}" ]] || [[ $# -gt 2 ]]; then
+    echo "usage: $0 <output-path> [expected-arch]" >&2
+    exit 2
+fi
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="${REPO_ROOT}/cmd/pam-module"
+
+# The C bridge needs Linux-PAM (<security/pam_ext.h>) and json-c, neither of
+# which exists on macOS. Refusing here is what keeps a developer's Mac from
+# producing something that looks like a module: `make build` skips this target off
+# Linux, and `make verify-linux` and the e2e harness build it in a container.
+if [[ "$(uname -s)" != "Linux" ]]; then
+    cat >&2 <<EOF
+build-pam-module: the PAM module can only be built on Linux (this is $(uname -s)).
+  Its C bridge needs Linux-PAM (<security/pam_ext.h>) and json-c.
+  Run 'make verify-linux', or build in a Linux container.
+EOF
+    exit 1
+fi
+
+CC="${CC:-cc}"
+if ! command -v "${CC}" >/dev/null 2>&1; then
+    echo "build-pam-module: no C compiler (CC=${CC}); install gcc or clang." >&2
+    exit 1
+fi
+
+# Hardening. cmd/pam-module/bridge_linux.go carries the same flags in its #cgo
+# directives so that `go test ./cmd/pam-module` compiles this C the way the
+# shipped artifact is compiled; the two lists are meant to agree.
+#
+# The artifact is a shared object loaded into sshd as root, and it holds a 16 KB
+# response buffer on the stack, so:
+#   -fstack-protector-strong  guards that buffer and every other stack array.
+#   -O2                       is what makes _FORTIFY_SOURCE do anything; the
+#                             fortify level itself is a floor set in the C source,
+#                             so a distribution that already asks for a higher one
+#                             is not quietly downgraded here.
+#   -Wl,-z,relro -Wl,-z,now   full RELRO. Without -z now the build gets partial
+#                             RELRO only and the PLT stays writable.
+#   -Wl,-z,noexecstack        a non-executable stack. The toolchains this is built
+#                             with already default to it; stating it means the
+#                             property does not depend on that default.
+# -fPIC is required for -shared and is not an optional hardening flag here.
+#
+# Not -Werror: the code is warning-clean under -Wall -Wextra today, but a future
+# compiler's new diagnostic would then be a build failure for anyone building
+# from source, which is a different bargain from the flags above. CI compiles the
+# module on every push, so a new warning is still seen.
+CFLAGS_HARDENING=(
+    -O2
+    -Wall -Wextra
+    -fstack-protector-strong
+    -fPIC
+)
+LDFLAGS_HARDENING=(
+    "-Wl,-z,relro"
+    "-Wl,-z,now"
+    "-Wl,-z,noexecstack"
+)
+
+mkdir -p -- "$(dirname -- "${SO}")"
+
+echo "build-pam-module: compiling ${SO} with ${CC}"
+"${CC}" -shared \
+    "${CFLAGS_HARDENING[@]}" \
+    -I "${SRC_DIR}" -I /usr/include/security \
+    -o "${SO}" \
+    "${SRC_DIR}/cgo_bridge_linux.c" \
+    "${LDFLAGS_HARDENING[@]}" \
+    -lpam -ljson-c
+
+# Assert the file is for the architecture its name claims. The since-deleted
+# scripts/build-simple.sh packaged one host-native module as both the amd64 and
+# the arm64 artifact (#222, #241); naming the output for the architecture built is
+# the fix, and this is what keeps the name honest.
+if [[ -n "${EXPECT_ARCH}" ]]; then
+    case "${EXPECT_ARCH}" in
+        amd64) want_machine="Advanced Micro Devices X86-64" ;;
+        arm64) want_machine="AArch64" ;;
+        386)   want_machine="Intel 80386" ;;
+        *)
+            echo "build-pam-module: unknown expected architecture '${EXPECT_ARCH}'" >&2
+            exit 2
+            ;;
+    esac
+    if ! command -v readelf >/dev/null 2>&1; then
+        # Skipping is not an option: an unchecked name is exactly the artifact
+        # this argument exists to prevent.
+        echo "build-pam-module: readelf not found; cannot confirm ${SO} is ${EXPECT_ARCH}." >&2
+        echo "  install binutils, or drop the expected-arch argument." >&2
+        exit 1
+    fi
+    got_machine="$(readelf -h "${SO}" | sed -n 's/^[[:space:]]*Machine:[[:space:]]*//p')"
+    if [[ "${got_machine}" != "${want_machine}" ]]; then
+        echo "build-pam-module: ${SO} is for ${got_machine}, not ${EXPECT_ARCH} (${want_machine})." >&2
+        echo "  ${CC} built for its own target. Cross-building needs a cross-toolchain in CC" >&2
+        echo "  and the target's PAM and json-c headers; release.yml builds each" >&2
+        echo "  architecture on a runner of that architecture instead." >&2
+        exit 1
+    fi
+fi
+
+# The point of the whole script.
+"${REPO_ROOT}/scripts/verify-pam-module.sh" "${SO}"

--- a/scripts/check-pam-module-producers.sh
+++ b/scripts/check-pam-module-producers.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# check-pam-module-producers.sh — assert scripts/build-pam-module.sh is the only
+# thing that compiles pam_oidc.so.
+#
+# A module with no PAM entry points in it builds and exits 0 (#140), so the
+# artifact has to be inspected before it can be trusted. That inspection lives
+# inside scripts/build-pam-module.sh, which cannot finish without it — but only
+# for callers that go through it. When each producer compiled the module itself,
+# the check was a separate line three of them did not have (#222).
+#
+# So the invariant worth pinning is not "every producer calls the verifier", which
+# is one grep away from being true again by accident. It is "there is one
+# producer". This fails the build when a second one appears, which is the point at
+# which it is cheap to fix.
+#
+# Usage: scripts/check-pam-module-producers.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+readonly BUILDER="scripts/build-pam-module.sh"
+readonly VERIFIER="scripts/verify-pam-module.sh"
+
+# Every file that can run a build: the Makefile, the shell scripts, the images and
+# the workflows. Documentation and Go source are not scanned — prose quotes these
+# commands, and no .go file can emit the module.
+build_inputs() {
+	printf '%s\n' Makefile
+	find scripts test .github/workflows \
+		-type f \( -name '*.sh' -o -name 'Dockerfile*' -o -name '*.yml' -o -name '*.yaml' \) \
+		-print | sort
+}
+
+# Compiling the module means one of two things: building the Go package as a
+# c-shared library, or handing cgo_bridge_linux.c to a C compiler. A line has to
+# name one of those *and* invoke a compiler to count, because these files discuss
+# both — #140 is explained by quoting the command that caused it, and this script
+# has to contain the pattern it searches for. Comment lines are dropped for the
+# same reason.
+readonly SUBJECT='buildmode=c-shared|cgo_bridge_linux\.c'
+readonly COMPILER='go build|\$\{?CC\}?|(^|[[:space:]"'"'"'])(cc|gcc|clang)[[:space:]]'
+
+offenders() {
+	local file
+	while IFS= read -r file; do
+		[ -f "${file}" ] || continue
+		[ "${file}" = "${BUILDER}" ] && continue
+		grep -nE "${SUBJECT}" "${file}" 2>/dev/null |
+			grep -vE '^[0-9]+:[[:space:]]*(@?#|//)' |
+			grep -E "${COMPILER}" |
+			sed "s|^|${file}:|" || true
+	done < <(build_inputs)
+}
+
+status=0
+
+found="$(offenders)"
+if [ -n "${found}" ]; then
+	echo "check-pam-module-producers: something other than ${BUILDER} builds the PAM module:" >&2
+	echo "${found}" | sed 's/^/    /' >&2
+	echo >&2
+	echo "  Call ${BUILDER} instead. It compiles the module with the hardening flags" >&2
+	echo "  and then runs ${VERIFIER} over the result, which is the only way to know a" >&2
+	echo "  c-shared or -shared build produced something PAM can use (#140, #222)." >&2
+	status=1
+fi
+
+# The builder is only worth having as the single producer because it verifies. Its
+# own comments say so at length, so this has to find the call and not the prose.
+if ! grep -nE "${VERIFIER}" "${BUILDER}" | grep -qvE '^[0-9]+:[[:space:]]*#'; then
+	echo "check-pam-module-producers: ${BUILDER} no longer runs ${VERIFIER}." >&2
+	echo "  Every producer goes through it, so removing that call leaves nothing" >&2
+	echo "  checking that the shipped module has any PAM entry points in it (#140)." >&2
+	status=1
+fi
+
+if [ "${status}" -eq 0 ]; then
+	echo "check-pam-module-producers: OK — ${BUILDER} is the only producer, and it verifies its output."
+fi
+
+exit "${status}"

--- a/scripts/verify-pam-module.sh
+++ b/scripts/verify-pam-module.sh
@@ -15,9 +15,11 @@
 # a module that PAM could load and find nothing in, so every C-side fix was
 # absent from the artifact regardless of what the source said.
 #
-# A compiler cannot catch that; only inspecting the result can. Anything that
-# produces a shipped .so must run this — `make build-pam` and the release
-# workflow both do.
+# A compiler cannot catch that; only inspecting the result can. Rather than ask
+# every producer to remember this step — which three of them did not (#222) —
+# scripts/build-pam-module.sh is the only thing that builds the module and it runs
+# this itself, on every build. scripts/check-pam-module-producers.sh fails the
+# build if a second producer appears.
 
 set -euo pipefail
 

--- a/test/e2e/Dockerfile.client
+++ b/test/e2e/Dockerfile.client
@@ -19,12 +19,13 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -o /out/pam_oidc.so ./cmd/pam-module
-
-# A module can build cleanly and export none of the pam_sm_* entry points (#140),
-# in which case every login in this harness would fail for a reason that has
-# nothing to do with the code under test. Fail the build instead.
-RUN ./scripts/verify-pam-module.sh /out/pam_oidc.so
+# The same script the Makefile and release.yml build with, so the module these
+# logins exercise is the module that ships — same compiler, same hardening flags.
+# It also verifies its own output: a module can build cleanly and export none of
+# the pam_sm_* entry points (#140), in which case every login in this harness
+# would fail for a reason that has nothing to do with the code under test, and
+# read as flakiness (#222). Fail the image build instead.
+RUN ./scripts/build-pam-module.sh /out/pam_oidc.so
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
`pam_oidc.so` is dlopened as root into every sshd pre-auth child. It was compiled
without hardening flags, and it was built as a Go `c-shared` library, which put
the Go runtime into that process. Both are fixed here, and the reason they land in
one PR is that the fix for #222 — one build path instead of several — is what makes
either change apply everywhere the module is produced.

## The producer inventory, established here

`git grep -n buildmode=c-shared` on `main`, over `Makefile`, `scripts/`,
`.github/workflows/`, `test/` and `docs/`, finds **eight build sites in six
files**, not four:

| Build site (`main`) | Ran `verify-pam-module.sh`? |
| --- | --- |
| `Makefile:85` — `build-pam` | yes (`Makefile:87`) |
| `Makefile:138` — `verify-linux` container sweep | yes (same `sh -c` chain) |
| `Makefile:233` — `release`, amd64 | **no** |
| `Makefile:237` — `release`, arm64 | **no** |
| `.github/workflows/release.yml:172` | yes (next step) |
| `test/e2e/Dockerfile.client:22` | yes (`:25`) |
| `scripts/build-simple.sh:84` | **no** |
| `scripts/build-releases.sh:110` | **no** |

(`docs/design/oidc_pam_project.md:296` and `scripts/verify-pam-module.sh:11` also
contain the string; both are prose, and the design doc's is a stale
`./pkg/pam` snippet — see "Found, not fixed".)

**So #222 is wrong on two of the three paths it names.** It lists `build-simple.sh`,
"the `Makefile` target that builds the module", and "the e2e harness build path" as
the three skippers, and calls the e2e one "the one that matters most". In fact
`make build-pam` and the e2e image were both verifying already; the paths that
weren't are the `Makefile`'s `release` target (both architectures) and
`scripts/build-releases.sh`, neither of which the issue mentions. Its
count is low and its set is wrong, but its point 3 — "the general fix is to have
exactly one place that builds the module" — is right, and is what this PR does.

Its architecture claim is right about the consequence and wrong about the cause.
`build-simple.sh` did not misname its build: it wrote `pam_oidc-native.so`, which
claims no architecture. The bug is in the *packaging* loop below it, which copied
that single file into **every** Linux tarball, so on an arm64 host the
`linux-amd64` package shipped an arm64 module — installs cleanly, fails at
`dlopen` inside sshd's auth path. The PAM helper was packaged the same way.

## What #198's second half assumed, and what is actually true

The issue says the `c-shared` exit "is not available to you without a rewrite",
because "this repository has real Go logic in the module (`args_linux.go`,
`auth_linux.go`, `pkg/pam`)". Verified otherwise:

- `grep -rn '//export' cmd/ pkg/` → nothing. There is no C→Go entry point.
- All six `pam_sm_*` functions are defined in `cmd/pam-module/cgo_bridge_linux.c`.
  `nm -D --defined-only` on the shipped `.so` finds them there.
- `cgo_bridge_linux.c` and `cgo_bridge.h` reference no Go symbol, no `_cgo_*`
  thunk, and no `GoString`/`GoBytes`.
- The package's Go files are cgo *test* wrappers — cgo is not allowed in
  `_test.go`, so they live in normal files and `go test` drives the C through
  them. They are not part of the module.

No rewrite was needed, so the module is now built by handing that one C file to
the C compiler.

## Claims verified, and how

Everything below was measured inside Linux containers, reusing the existing paths
(`test/docker/Dockerfile.verify` and `test/e2e/`) rather than a new image. **This
host is macOS and cannot build the module at all** — the C bridge needs
`<security/pam_ext.h>` and `<json-c/json.h>`.

Against the module built by `scripts/build-pam-module.sh`:

- `readelf -lW` → `GNU_RELRO` present; `readelf -dW` → `BIND_NOW` + `FLAGS_1: NOW`
  (full RELRO). The old `c-shared` build had `GNU_RELRO` without `BIND_NOW`, i.e.
  partial RELRO with a writable PLT.
- `GNU_STACK` is `RW`, not `RWE`.
- `nm -D --undefined-only` → `__stack_chk_fail` present (was absent), and
  `__memcpy_chk`/`__snprintf_chk`/`__vsnprintf_chk` (fortify active, so `-O2` is
  reaching it).
- No `TEXTREL`.
- All six `pam_sm_*` exported; `libpam.so.0` and `libjson-c.so` in `NEEDED`.
- No `runtime.*`/`go:` symbols, **no `pthread_create`, no `sigaction`**, no
  `DF_1_NODELETE`. Size 72 KB against 2.4 MB.
- Warning-clean under `-Wall -Wextra`.

For #198's signal claim on the *old* build, I read the Go runtime source rather
than infer: `initsig` runs at library init, `sigInstallGoHandler` in library mode
installs handlers for `_SigPanic` signals plus SIGPIPE and `sigPreempt`, and
`sigtab_linux_generic.go` marks SIGSEGV/SIGBUS/SIGFPE as `_SigPanic` with
`sigPreempt = SIGURG` — the five the issue names, exactly. `readelf -dW` on a
`c-shared` artifact confirmed `FLAGS_1: NODELETE`. The runtime also adds
`SA_ONSTACK` to sshd's pre-existing handlers via `setsigstack` and forwards
through `sigfwdgo`, so the effect is not a clean replacement.

Behavioural verification, which is the one that mattered for switching build
modes: **`./test/e2e/run-tests.sh` → 17/17 cases passed** against the C-built,
hardened module. That harness runs a real `sshd` with a real PAM stack, the real
broker and a fake IdP, and it covers the failure cases (`broker_down`, key
supersession, orphan sweeps, per-account rate limiting), so the module is loaded
by libpam and exercised end to end, not merely inspected.

Also verified in a container: `check-cgo-quarantine.sh`,
`check-pam-module-producers.sh`, `go vet ./cmd/pam-module`,
`go test ./cmd/pam-module/...`, and the arch assertion in both directions (a
matching `expected-arch` is accepted, a mismatched one exits non-zero). I broke
each of the three failure branches of `check-pam-module-producers.sh` on purpose
and confirmed each fires — including one real bug that testing found: its "the
builder still verifies" assertion originally passed on a builder with the verify
call deleted, because `grep -q` matched the builder's own explanatory comments.

Locally on macOS: `go build ./...`, `go vet ./...`, `gofmt`,
`check-cgo-quarantine.sh`, `check-pam-module-producers.sh`,
`shellcheck --severity=warning scripts/*.sh test/scripts/*.sh` (the severity CI
uses), `bash -n` on every touched script, and `yaml.safe_load` on both edited
workflows. No `uses:` line is touched, so SHA pinning is unaffected.

## Only verifiable in CI

- The release build on an **arm64** runner. The arch assertion and the aarch64
  branch of the machine-name mapping have not run on real arm64 hardware here;
  the `Build and verify the PAM module` step in `release.yml`'s matrix is what
  exercises it. It fails loudly rather than silently if the mapping is wrong.
- The **`PAM (cgo)`** job compiling the C through cgo with the new `#cgo`
  hardening flags on Ubuntu 24.04, where `_FORTIFY_SOURCE` already defaults to 3;
  the floor-not-assignment form is what should keep that at 3 without a
  redefinition warning. I tested this on the Debian-based verify image, not on
  24.04.
- `make release` and `scripts/build-releases.sh` end to end. Neither can complete
  on any single host (see below), so what I verified is the module line, not the
  whole target.

## Consequences worth knowing

- **The `#cgo` flags and the script's flags are now two lists that must agree.**
  A C build has no way to share them. Mitigation is adjacency plus comments in
  both, a note in CONTRIBUTING, and the fact that the e2e suite exercises the
  script's artifact — so a drift that breaks the module is caught, though a drift
  that only weakens the tests' copy is not.
- `bin/pam_oidc.so` no longer carries `-X main.version=...`. It never did anything:
  the package declares no such variables, so the linker discarded it.
- `make release` still cannot produce a module for the non-host architecture — it
  now says so instead of failing inside the compiler. Releases come from
  `release.yml`'s per-architecture runners.

## Found, not fixed

- `scripts/build-simple.sh` and `scripts/build-releases.sh` generate installer
  scripts inside their tarballs that still copy `pam_oidc.so` to `/lib/security`,
  the hardcoded path #208 removed from the real installers. That directory exists
  on neither Debian/Ubuntu nor RHEL-family systems, so a tarball's own installer
  reintroduces exactly the failure #208 fixed.
- Neither `make release` nor `scripts/build-releases.sh` can complete on any one
  host: the pure-Go cross-builds are fine, but the cgo `pam-helper` and the module
  are not. They read as full release paths and are not.
- `make docker-build` references a root `Dockerfile` that does not exist in the
  repository.
- `docs/design/oidc_pam_project.md:296` shows
  `go build -buildmode=c-shared -o … ./pkg/pam`, which is both the pre-#140 layout
  and now the wrong build mode. That file is under the unmaintained design
  directory, so I left it alone.

Closes #198
Closes #222
