### PR TITLE
fix(broker): stop an abandoned device flow from denying the account its login

### DIFF
--- a/configs/CONFIGURATION-GUIDE.md
+++ b/configs/CONFIGURATION-GUIDE.md
@@ -566,6 +566,9 @@ absent.
 | `server.require_peer_auth` | `true` | Verify the peer's credentials over `SO_PEERCRED` and accept uid 0 only. Turning this off lets any local process talk to the broker; there is no reason to. |
 | `server.metrics_addr` | *(unset)* | TCP address for the Prometheus `/metrics` endpoint, e.g. `127.0.0.1:9090`. Unset means no listener. The endpoint is unauthenticated — bind it to loopback. |
 | `authentication.idle_timeout` | *(unset)* | Expire a session this long after its last use, in addition to `token_lifetime`. Unset means only `token_lifetime` applies. |
+| `authentication.max_pending_auths_per_source` | `5` | How many logins one account may have awaiting device approval at once from one source address. Clamped to 1–32; `0` means the default, not "unlimited". See below. |
+| `authentication.pending_auth_lifetime` | `15m` | How long a login that never completes keeps its slot. Clamped to 1m–1h. See below. |
+| `authentication.require_local_account` | `true` | Refuse a login for an account this host does not have before contacting the provider. See below. |
 | `authentication.allow_privileged_accounts` | *(empty)* | The named exceptions to "no OIDC identity may log in as uid < 1000". See above. |
 | `authentication.geoip_database_path` | *(unset)* | MaxMind GeoLite2 database for `geo_restrictions`. Without it every country code is empty, so an `allowed_countries` restriction denies everyone. |
 | `authentication.location_history.*` | 90d, 10 entries, memory | Window, per-user cap and `persist_path` for the "unusual location" risk signal. |
@@ -575,6 +578,37 @@ absent.
 | `audit.overflow_strategy` | `block` | What happens when that channel is full: `block` (backpressure), `sync` (write inline), or `drop` (discard and count). `drop` loses audit records and must be chosen deliberately. |
 | `audit.outputs[].type` | — | `file`, `stdout`, `syslog` or `http`. Any other value is refused at startup. |
 | `audit.enabled` | `true` | Whether to audit at all. With no `audit.outputs` alongside it the broker refuses to start, rather than accepting events and discarding them (#210). |
+
+### Logins Nobody Has Completed Yet
+
+Between showing a verification URL and the user approving it, the broker is
+holding a login that has proved nothing about who asked for it: sshd runs the PAM
+stack for whatever username a remote client offers, before that client has
+authenticated. The three settings above bound what such a login may cost.
+
+`max_pending_auths_per_source` is counted per (account, source address) pair, not
+per account. The account is the part of the request a client chooses freely, so a
+cap on it alone can be filled on somebody else's behalf — which is what #163
+was: unfinished logins counted towards `max_concurrent_sessions`, so a handful of
+connection attempts naming one account locked its owner out. They no longer count
+towards it. Raise this if your users routinely open more than five terminals at
+once and see `TOO_MANY_PENDING_AUTHS`; the value is clamped to 32 because a
+per-source cap as large as the host-wide pool is not a cap.
+
+`pending_auth_lifetime` is the broker's own deadline on an unfinished login,
+replacing the device code's `expires_in` — a number the provider chooses, and may
+set as high as 24 hours. The PAM module gives up after 90 seconds, so anything
+still pending after that is a login nobody is waiting for. Shortening it below a
+minute is not possible; a user who has to fetch their phone needs the window.
+
+`require_local_account` refuses a login naming an account this host does not have
+before the provider is contacted. Such a login could never have succeeded — sshd
+needs a passwd entry, and the identity binding resolves the account again at the
+end of the flow — so all this changes is what it costs to ask: without it, every
+ssh scanner on the internet starts device authorizations against your identity
+provider. The trade is that a remote client can tell a real local account from an
+invented one by whether it is offered a device code. Set it to `false` if that
+matters more to you than the requests.
 
 ## Authentication Policies
 

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -37,7 +36,6 @@ type Broker struct {
 	stopChan              chan struct{}
 	wg                    sync.WaitGroup
 	metrics               *oidcmetrics.Metrics // nil when metrics are disabled
-	pendingFlows          int64                // atomic counter of in-progress device authorization goroutines
 	version               string               // build version, set via SetVersion; reported by Status
 	startedAt             time.Time            // when Start ran; zero until then. Reported by Status
 
@@ -118,6 +116,19 @@ type Session struct {
 	RequireDeviceTrust bool
 
 	Metadata map[string]interface{}
+
+	// cancel is closed when a session that has not completed its device flow is
+	// removed from the store, which is how the goroutine polling for that
+	// authorization learns to stop. It is nil once the flow has completed, and nil on
+	// a session built by anything other than Authenticate — a nil channel simply
+	// never fires in the poll loop's select.
+	//
+	// (#163) Without it, a pending session and its polling goroutine had independent
+	// lifetimes: revoking, sweeping or displacing the session left the goroutine
+	// holding a live device code and polling the provider for it until the code's own
+	// expiry, up to 24 hours later. A cap on how many pending logins the host holds
+	// means nothing if the work each one costs outlives the accounting.
+	cancel chan struct{}
 }
 
 // AuthRequest represents an authentication request
@@ -530,9 +541,18 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		return b.createSuccessResponse(session), nil
 	}
 
-	// Check per-user session limit
+	// (#163) A login for an account this host does not have is refused here, before
+	// policy, before the provider is contacted and before it can take a slot in the
+	// pending-flow pool.
+	if response := b.denyIfNoLocalAccount(req); response != nil {
+		return response, nil
+	}
+
+	// Check per-user session limit. Only established sessions count towards it: see
+	// countActiveUserSessions, and admitPendingSession for the cap that bounds the
+	// logins still waiting to become sessions (#163).
 	maxSessions := b.config.Authentication.MaxConcurrentSessions
-	if maxSessions > 0 && b.countUserSessions(req.UserID) >= maxSessions {
+	if maxSessions > 0 && b.countActiveUserSessions(req.UserID) >= maxSessions {
 		log.Warn().
 			Str("user_id", req.UserID).
 			Int("max_sessions", maxSessions).
@@ -626,9 +646,85 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		})
 	}
 
+	// Create the pending session — always generate the session ID server-side; never
+	// trust the client-supplied value to prevent session fixation/hijacking.
+	//
+	// (#163) The session is built and admitted *before* the provider is called, which
+	// is the other half of the accounting fix. It used to be inserted after the device
+	// authorization round trip and the host-wide cap checked after that, so a request
+	// that was about to be refused had already cost an authenticated POST to the
+	// provider's device endpoint with the broker's own client credentials, and had
+	// briefly occupied a session slot on the way out. Admission now decides first and
+	// the provider is only asked on behalf of a login that has somewhere to live.
+	sessionID, err := generateSessionID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate session ID: %w", err)
+	}
+	createdAt := time.Now()
+	session := &Session{
+		ID:        sessionID,
+		UserID:    req.UserID,
+		Provider:  provider.Name,
+		LoginType: req.LoginType,
+		DeviceID:  req.DeviceID,
+		CreatedAt: createdAt,
+		// A pending session's expiry is the deadline on the *unfinished* login, not the
+		// session lifetime it will get if it completes: pendingAuthLifetime is minutes,
+		// and the real expiry — token_lifetime bounded by the policy's
+		// max_session_duration (#212) — is computed by sessionExpiry when the flow
+		// completes and the session becomes one.
+		ExpiresAt:    createdAt.Add(b.pendingAuthLifetime()),
+		MaxDuration:  policyResult.MaxDuration,
+		LastAccessed: createdAt,
+		SourceIP:     req.SourceIP,
+		UserAgent:    req.UserAgent,
+		// TokenFingerprint stays unset until there is a token to fingerprint (#219):
+		// pollDeviceAuthorization fills it in from the granted token. What it briefly
+		// held instead was the device code — the live credential for this very flow —
+		// in a field documented and copied everywhere else as a safe hash.
+		IsActive:           false,
+		RequireDeviceTrust: policyResult.Metadata[MetadataRequireDeviceTrust] == true,
+		RiskScore:          policyResult.RiskScore,
+		Metadata:           req.Metadata,
+		cancel:             make(chan struct{}),
+	}
+
+	if admission := b.admitPendingSession(session, createdAt); !admission.admitted {
+		log.Warn().
+			Str("user_id", req.UserID).
+			Str("source_ip", req.SourceIP).
+			Str("error_code", admission.errorCode).
+			Int("pending_for_source", admission.perSource).
+			Int("pending_on_host", admission.hostTotal).
+			Msg("Refusing a login: too many authentications are already awaiting device approval")
+		// The record names both counts, because they are two different incidents: one
+		// account and address holding its whole budget of unfinished logins, against a
+		// host whose pending-flow pool is full. Without it there is nothing to alert on
+		// when a flood of logins nobody is completing starts refusing real ones, which
+		// is the condition these caps exist to survive (#163).
+		event := b.denialEvent(req, admission.errorCode, admission.reason)
+		event.SessionID = session.ID
+		event.Provider = provider.Name
+		event.Metadata["pending_for_source"] = admission.perSource
+		event.Metadata["pending_on_host"] = admission.hostTotal
+		event.Metadata["max_pending_auths_per_source"] = b.maxPendingAuthsPerSource()
+		event.Metadata["max_pending_auths_on_host"] = maxPendingAuthsOnHost
+		b.auditLogger.LogAuthEvent(event)
+		return &AuthResponse{
+			Success:      false,
+			ErrorCode:    admission.errorCode,
+			ErrorMessage: admission.reason,
+		}, nil
+	}
+
 	// Initiate device flow
 	deviceFlow, err := provider.StartDeviceFlow(req)
 	if err != nil {
+		// The slot goes back immediately. A provider that is down or rate-limiting the
+		// broker answers every login this way, and a pool full of flows that never
+		// started would refuse the logins that come after it recovers.
+		b.removeSession(session.ID)
+
 		b.auditLogger.LogAuthEvent(security.AuditEvent{
 			EventType:    "device_flow_failed",
 			UserID:       req.UserID,
@@ -653,63 +749,6 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		qrCode = "" // Continue without QR code
 	}
 
-	// Create pending session — always generate the session ID server-side;
-	// never trust the client-supplied value to prevent session fixation/hijacking.
-	sessionID, err := generateSessionID()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate session ID: %w", err)
-	}
-	createdAt := time.Now()
-	session := &Session{
-		ID:        sessionID,
-		UserID:    req.UserID,
-		Provider:  provider.Name,
-		LoginType: req.LoginType,
-		DeviceID:  req.DeviceID,
-		CreatedAt: createdAt,
-		// (#212) sessionExpiry applies policyResult.MaxDuration — the minimum
-		// max_session_duration across every matching policy. It was computed on
-		// every login and then discarded, so `max_session_duration: 30m` on a sudo
-		// policy produced a session that lived for the full token_lifetime.
-		ExpiresAt:    b.sessionExpiry(createdAt, createdAt, policyResult.MaxDuration),
-		MaxDuration:  policyResult.MaxDuration,
-		LastAccessed: createdAt,
-		SourceIP:     req.SourceIP,
-		UserAgent:    req.UserAgent,
-		// TokenFingerprint is deliberately unset here (#219). A pending session has
-		// no token to fingerprint yet — pollDeviceAuthorization fills it in from the
-		// granted token — and what it held instead was the raw device code, the live
-		// credential for the flow this session is waiting on. The field is documented
-		// and treated everywhere else as a hash that is safe to carry and copy, which
-		// is exactly why putting a credential in it is worse than it looks.
-		IsActive:           false,
-		RequireDeviceTrust: policyResult.Metadata[MetadataRequireDeviceTrust] == true,
-		RiskScore:          policyResult.RiskScore,
-		Metadata:           req.Metadata,
-	}
-
-	b.setSession(session)
-
-	// Enforce a cap on concurrent device-flow goroutines to prevent goroutine exhaustion DoS.
-	const maxPendingFlows = 100
-	if atomic.AddInt64(&b.pendingFlows, 1) > maxPendingFlows {
-		atomic.AddInt64(&b.pendingFlows, -1)
-		b.removeSession(session.ID)
-		// The host, not this user: without the record there is nothing to alert on
-		// when a flood of unfinished flows starts refusing everyone's logins, which
-		// is the condition this cap exists to survive (#163).
-		event := b.denialEvent(req, "RATE_LIMITED", "too many pending device authorization flows on this host")
-		event.SessionID = session.ID
-		event.Provider = provider.Name
-		event.Metadata["max_pending_flows"] = maxPendingFlows
-		b.auditLogger.LogAuthEvent(event)
-		return &AuthResponse{
-			Success:      false,
-			ErrorCode:    "RATE_LIMITED",
-			ErrorMessage: "too many pending device authorization flows; try again later",
-		}, nil
-	}
-
 	// Start polling for device authorization in background
 	b.wg.Add(1)
 	// policyResult.RequiredGroups is the union of the global
@@ -719,13 +758,21 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 	// re-evaluating policy there would evaluate it against a different clock.
 	go b.pollDeviceAuthorization(session, provider, deviceFlow, policyResult.RequiredGroups)
 
+	// The user is told when the code stops working, which is the earlier of the two
+	// deadlines — the provider's expires_in and this broker's own pending-flow window.
+	// Reporting the provider's alone promised a window the broker would not honour.
+	expiresAt := deviceFlow.ExpiresAt
+	if session.ExpiresAt.Before(expiresAt) {
+		expiresAt = session.ExpiresAt
+	}
+
 	return &AuthResponse{
 		Success:        true,
 		SessionID:      session.ID,
 		DeviceCode:     deviceFlow.UserCode,
 		DeviceURL:      deviceFlow.DeviceURL,
 		QRCode:         qrCode,
-		ExpiresAt:      deviceFlow.ExpiresAt,
+		ExpiresAt:      expiresAt,
 		RequiresDevice: true,
 		RiskScore:      policyResult.RiskScore,
 		Metadata: map[string]interface{}{
@@ -1191,6 +1238,7 @@ func (b *Broker) getAndRemoveIfExpiredSession(sessionID, userID string) (*Sessio
 		return session, true // valid — do not remove
 	}
 	delete(b.sessions, sessionID) // expired/inactive — remove atomically
+	stopPendingFlow(session)      // an unfinished flow's goroutine goes with it (#163)
 	return nil, false
 }
 
@@ -1252,26 +1300,351 @@ func (b *Broker) sessionExpiry(createdAt, now time.Time, maxDuration time.Durati
 func (b *Broker) removeSession(sessionID string) {
 	b.sessionMutex.Lock()
 	defer b.sessionMutex.Unlock()
-	if s, ok := b.sessions[sessionID]; ok && s.IsActive {
-		if b.metrics != nil {
-			b.metrics.ActiveSessions.Dec()
-		}
+	session, ok := b.sessions[sessionID]
+	if !ok {
+		return
+	}
+	if session.IsActive && b.metrics != nil {
+		b.metrics.ActiveSessions.Dec()
 	}
 	delete(b.sessions, sessionID)
+	stopPendingFlow(session)
 }
 
-// countUserSessions returns the number of active sessions for the given user.
-func (b *Broker) countUserSessions(userID string) int {
+// stopPendingFlow releases the goroutine polling for a pending session's device
+// authorization. Callers pass the value they have just deleted from the store, and
+// only that value, so the channel is closed exactly once: a Session pointer is
+// reachable under one key, and a key is deleted once (#163).
+func stopPendingFlow(session *Session) {
+	if session != nil && session.cancel != nil {
+		close(session.cancel)
+	}
+}
+
+// countActiveUserSessions returns the number of established sessions for the given
+// user — logins that completed their device flow.
+//
+// (#163) It used to count pending ones too, and that is the whole of the reported
+// denial of service. An authenticate request names the account it wants, and sshd
+// runs the PAM stack for whatever username a client offers before anything about
+// that client has been authenticated, so ten abandoned connection attempts against
+// one account filled that account's max_concurrent_sessions with logins nobody had
+// approved. The eleventh — the real one — was refused TOO_MANY_SESSIONS for as long
+// as the device codes lived. The cap is a bound on how much access one identity may
+// hold at once, so what belongs in it is access that was granted.
+func (b *Broker) countActiveUserSessions(userID string) int {
 	b.sessionMutex.RLock()
 	defer b.sessionMutex.RUnlock()
 
 	count := 0
 	for _, session := range b.sessions {
-		if session.UserID == userID {
+		if session.UserID == userID && session.IsActive {
 			count++
 		}
 	}
 	return count
+}
+
+// Bounds on the logins that have started a device flow and not finished one. They
+// are the accounting #163 is about: a pending login is work and memory the host has
+// committed on behalf of a client that has not authenticated at all, and until it
+// completes there is nothing about it that identifies anybody.
+const (
+	// maxPendingAuthsOnHost is the host-wide ceiling. It bounds the sessions, the
+	// polling goroutines and the provider traffic that unfinished logins cost.
+	//
+	// Reaching it does not refuse the login that arrives next: see
+	// admitPendingSession, which displaces a pending flow from whichever (account,
+	// source) pair holds the most. A hard refusal here is the second half of #163 —
+	// a hundred unfinished logins across ten invented usernames made every login on
+	// the host answer RATE_LIMITED.
+	maxPendingAuthsOnHost = 100
+
+	// defaultMaxPendingAuthsPerSource is how many unfinished logins one account may
+	// have in flight from one address. It is deliberately larger than one: a user
+	// opening several terminals at once starts a device flow per login, and each one
+	// holds its slot until the user approves it or the window closes.
+	defaultMaxPendingAuthsPerSource = 5
+
+	// hardMaxPendingAuthsPerSource is the ceiling on the configured value. A per-source
+	// cap at or above the host-wide pool is not a cap: one pair could fill the pool on
+	// its own, and the sharing rule that keeps the pool from becoming a lockout has
+	// nothing left to redistribute.
+	hardMaxPendingAuthsPerSource = 32
+
+	// The window an unfinished login may hold its slot for, and the bounds on the
+	// configured value. Fifteen minutes is already generous: the PAM module gives up
+	// after 90 seconds, so anything still pending after that is a login nobody is
+	// waiting for. The upper bound matters because the provider's own expires_in — the
+	// clock this used to run on — may be up to 24 hours (maxDeviceCodeExpiry), and the
+	// lower one because a window shorter than the walk to fetch a phone refuses
+	// legitimate logins.
+	defaultPendingAuthLifetime = 15 * time.Minute
+	minPendingAuthLifetime     = time.Minute
+	hardMaxPendingAuthLifetime = time.Hour
+)
+
+// maxPendingAuthsPerSource is the configured per-(account, source) cap, bounded at
+// both ends.
+//
+// Zero means the default rather than "no limit", and an oversized value saturates
+// instead of being honoured — the same fail-open clampToInt32 exists for in the IPC
+// limiter, where an unbounded int narrowed to int32 turned a very large configured
+// cap into no cap at all. This cap is what stops a client that has not authenticated
+// from taking somebody else's login capacity, so it has no off switch.
+func (b *Broker) maxPendingAuthsPerSource() int {
+	configured := 0
+	if b.config != nil {
+		configured = b.config.Authentication.MaxPendingAuthsPerSource
+	}
+	switch {
+	case configured <= 0:
+		return defaultMaxPendingAuthsPerSource
+	case configured > hardMaxPendingAuthsPerSource:
+		return hardMaxPendingAuthsPerSource
+	default:
+		return configured
+	}
+}
+
+// pendingAuthLifetime is how long an unfinished login may hold its slot, bounded at
+// both ends for the reasons on the constants above.
+func (b *Broker) pendingAuthLifetime() time.Duration {
+	configured := time.Duration(0)
+	if b.config != nil {
+		configured = b.config.Authentication.PendingAuthLifetime
+	}
+	switch {
+	case configured <= 0:
+		return defaultPendingAuthLifetime
+	case configured < minPendingAuthLifetime:
+		return minPendingAuthLifetime
+	case configured > hardMaxPendingAuthLifetime:
+		return hardMaxPendingAuthLifetime
+	default:
+		return configured
+	}
+}
+
+// pendingSourceKey identifies the budget an unfinished login is charged against: the
+// account it names, together with the address it came from.
+//
+// (#163) The account on its own is what made the old accounting usable as a weapon.
+// It is the one field of an authenticate request a remote client chooses freely —
+// sshd runs the PAM stack for whatever username it is offered, before anything about
+// the connection has been authenticated — so any cap keyed on it alone can be filled
+// on somebody else's behalf. The source address is not chosen: it is where the TCP
+// connection came from, and the PAM module fills it in from PAM_RHOST rather than
+// from anything the client sends. Keyed on the pair, an attacker can exhaust the
+// budget of (victim, attacker's own address) and nothing else, while the victim's own
+// logins draw on a different budget.
+//
+// A login with no source address — the console, or a PAM_RHOST that is a hostname
+// (#169) — shares one budget per account. Those cannot be produced remotely, which is
+// what makes sharing acceptable here.
+func pendingSourceKey(userID, sourceIP string) string {
+	// NUL cannot appear in either half, so the two fields cannot be confused for one
+	// another however they are spelled.
+	return userID + "\x00" + sourceIP
+}
+
+// pendingAdmission is what admitPendingSession decided, and why.
+type pendingAdmission struct {
+	admitted  bool
+	errorCode string
+	reason    string
+	perSource int    // unfinished logins already held by this (account, source) pair
+	hostTotal int    // unfinished logins already held by the host
+	displaced string // session ID dropped to make room, empty if none
+}
+
+// admitPendingSession stores a session for a login whose device flow has not started
+// yet, if the (account, source) pair and the host have room for another one, and
+// reports what it decided.
+//
+// Counting and inserting happen under one write lock because "there is room" is only
+// true at the instant it is observed. The check and the insert used to sit either side
+// of a device-authorization round trip, so every request that arrived during one
+// passed the same check.
+//
+// An entry whose deadline has passed is not counted. It will go when its own polling
+// goroutine reaches the same deadline, or at the next sweep, and until then a cap that
+// counted it would refuse logins on behalf of one that is already over — the sweep
+// runs every five minutes, so that is five minutes of refusals owed to nothing.
+//
+// When the host-wide pool is full the request is not refused outright: the oldest
+// pending flow of whichever pair holds the most is displaced to make room, and only a
+// pair that holds strictly more than the requester can be displaced. That is what
+// stops the pool being the denial of service it exists to prevent. A client holding
+// unfinished logins for a hundred different accounts cannot refuse the hundred-and-
+// first login, because a pair holding none always displaces a pair holding several;
+// and it cannot protect its own by hoarding, because holding the most is exactly what
+// selects it. It is the argument the rate limiter's bucket eviction rests on
+// (maxTrackedAccounts): spending the budget requires being the biggest holder of it,
+// which is what makes you the one who pays.
+func (b *Broker) admitPendingSession(session *Session, now time.Time) pendingAdmission {
+	key := pendingSourceKey(session.UserID, session.SourceIP)
+	perSourceCap := b.maxPendingAuthsPerSource()
+
+	b.sessionMutex.Lock()
+	defer b.sessionMutex.Unlock()
+
+	counts := make(map[string]int)
+	oldest := make(map[string]*Session)
+	hostTotal := 0
+	for _, s := range b.sessions {
+		if s.IsActive {
+			continue
+		}
+		if !s.ExpiresAt.IsZero() && !s.ExpiresAt.After(now) {
+			continue
+		}
+		k := pendingSourceKey(s.UserID, s.SourceIP)
+		counts[k]++
+		hostTotal++
+		if prev, seen := oldest[k]; !seen || s.CreatedAt.Before(prev.CreatedAt) {
+			oldest[k] = s
+		}
+	}
+
+	mine := counts[key]
+	if mine >= perSourceCap {
+		return pendingAdmission{
+			errorCode: "TOO_MANY_PENDING_AUTHS",
+			reason: "too many authentications from this address are already awaiting device " +
+				"approval for this account; complete or abandon one and try again",
+			perSource: mine,
+			hostTotal: hostTotal,
+		}
+	}
+
+	admission := pendingAdmission{admitted: true, perSource: mine, hostTotal: hostTotal}
+
+	if hostTotal >= maxPendingAuthsOnHost {
+		displaced := pendingToDisplace(counts, oldest, mine)
+		if displaced == nil {
+			// Nobody holds more than this requester does, so there is no share to
+			// redistribute and the pool really is full of logins with as good a claim as
+			// this one. Refusing is the only answer left, and it cannot be provoked by a
+			// client holding pending flows under other keys.
+			return pendingAdmission{
+				errorCode: "RATE_LIMITED",
+				reason:    "too many pending device authorization flows on this host; try again shortly",
+				perSource: mine,
+				hostTotal: hostTotal,
+			}
+		}
+		delete(b.sessions, displaced.ID)
+		stopPendingFlow(displaced)
+		admission.displaced = displaced.ID
+		log.Warn().
+			Str("displaced_session_id", displaced.ID).
+			Str("displaced_user_id", displaced.UserID).
+			Str("displaced_source_ip", displaced.SourceIP).
+			Int("pending_on_host", hostTotal).
+			Msg("Pending device authorization pool is full; displaced the oldest flow of its " +
+				"largest holder to admit another login")
+	}
+
+	b.sessions[session.ID] = session
+	return admission
+}
+
+// pendingToDisplace picks the pending session to drop when the host-wide pool is
+// full: the oldest one belonging to whichever (account, source) pair holds the most,
+// and only if that pair holds strictly more than the requester's `mine`. It returns
+// nil when no pair does, which is the caller's signal to refuse instead. Callers hold
+// the session lock.
+func pendingToDisplace(counts map[string]int, oldest map[string]*Session, mine int) *Session {
+	var pick *Session
+	pickCount := 0
+
+	for key, count := range counts {
+		if count <= mine {
+			continue
+		}
+		candidate := oldest[key]
+		if candidate == nil {
+			continue
+		}
+		switch {
+		case pick == nil, count > pickCount, count == pickCount && candidate.CreatedAt.Before(pick.CreatedAt):
+			pick, pickCount = candidate, count
+		}
+	}
+
+	return pick
+}
+
+// denyIfNoLocalAccount refuses a login for an account this host does not have, and
+// returns nil when the login may proceed.
+//
+// (#163) Nothing checked that the requested account exists until the device flow had
+// already completed, by which point the broker had spent an authenticated POST to the
+// provider's device endpoint with its own client credentials and given the login a
+// slot in the pending-flow pool. sshd runs its PAM stack for whatever username it is
+// offered — deliberately, so that a valid and an invalid user cost the same time — so
+// every ssh scanner on the internet was starting device authorizations against the
+// site's identity provider from an unauthenticated connection, and could fill the
+// host's pending pool with names that belong to nobody.
+//
+// Nothing is lost by refusing early: sshd needs a passwd entry for the account once
+// the stack returns, and verifyIdentityBinding resolves the same account again when
+// the flow completes, so such a login could never have succeeded. What changes is only
+// what it costs to ask.
+//
+// A lookup that *fails* is not read as "no such account". That is not something this
+// gate knows, and refusing every login on the host while NSS is briefly unavailable is
+// the same denial of service by another route. The privileged-account guard on the
+// completion path is the one that fails closed on an unreadable passwd file (#159);
+// this one exists to make a doomed login cheap, not to decide anything.
+//
+// The cost is an enumeration oracle that did not exist before: a remote client can
+// tell a real local account from an invented one by whether it is offered a device
+// code. That is the deliberate trade — local usernames on a host that federates its
+// logins are rarely secret, and are usually derivable from the addresses the IdP
+// publishes, whereas an unauthenticated client spending a site's IdP quota is the
+// issue being fixed. Operators who need the old behaviour set
+// authentication.require_local_account: false.
+func (b *Broker) denyIfNoLocalAccount(req *AuthRequest) *AuthResponse {
+	if b.config == nil || !b.config.Authentication.RequireLocalAccount {
+		return nil
+	}
+
+	lookup := b.lookupLocalUID
+	if lookup == nil {
+		lookup = lookupLocalUID
+	}
+
+	_, exists, err := lookup(req.UserID)
+	switch {
+	case err != nil:
+		log.Warn().
+			Err(err).
+			Str("user_id", req.UserID).
+			Msg("Could not determine whether the requested account exists locally; " +
+				"continuing with the login, which the identity binding will decide")
+		return nil
+	case exists:
+		return nil
+	}
+
+	log.Warn().
+		Str("user_id", req.UserID).
+		Str("source_ip", req.SourceIP).
+		Msg("Refusing a login for an account this host does not have, before contacting the provider")
+
+	b.auditLogger.LogAuthEvent(b.denialEvent(req, "NO_LOCAL_ACCOUNT",
+		"no such local account on this host; refused before starting a device authorization"))
+
+	// The message says no more than the policy denial's does. The client learns which
+	// accounts exist from the presence of a device code either way, but the audit trail
+	// is where the reason belongs.
+	return &AuthResponse{
+		Success:      false,
+		ErrorCode:    "NO_LOCAL_ACCOUNT",
+		ErrorMessage: "Access denied",
+	}
 }
 
 func (b *Broker) createSuccessResponse(session *Session) *AuthResponse {
@@ -1354,7 +1727,6 @@ func providerPriority(provider *OIDCProvider) int {
 
 func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvider, deviceFlow *DeviceFlow, requiredGroups []string) {
 	defer b.wg.Done()
-	defer atomic.AddInt64(&b.pendingFlows, -1)
 
 	// interval is not fixed: RFC 8628 §3.5 lets the provider ask for a slower
 	// poll rate mid-flow with slow_down, and requires the client to comply.
@@ -1362,12 +1734,53 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 	ticker := time.NewTicker(time.Duration(interval) * b.pollUnit())
 	defer ticker.Stop()
 
-	timeout := time.NewTimer(time.Until(deviceFlow.ExpiresAt))
+	// (#163) The flow ends at the earlier of the code's own expiry and the deadline on
+	// the slot its session holds. Running on the provider's expires_in alone let a
+	// device code the provider had issued for 24 hours keep a pending session — and a
+	// goroutine polling for it — alive for the whole of that time, on a lifetime the
+	// broker had no say in.
+	deadline := deviceFlow.ExpiresAt
+	if !session.ExpiresAt.IsZero() && session.ExpiresAt.Before(deadline) {
+		deadline = session.ExpiresAt
+	}
+	timeout := time.NewTimer(time.Until(deadline))
 	defer timeout.Stop()
 
 	for {
 		select {
 		case <-b.stopChan:
+			return
+		case <-session.cancel:
+			// The session was removed while the flow was still running: revoked by an
+			// operator, swept for expiry, or displaced to make room for another login.
+			// Nothing can be done with an authorization for a session that no longer
+			// exists, and a goroutine that keeps a device code warm after its slot is
+			// gone is how a cap on pending flows stops being a cap. A nil channel — every
+			// session not built by Authenticate — never selects here.
+			log.Warn().
+				Str("session_id", session.ID).
+				Str("user_id", session.UserID).
+				Msg("Abandoning device authorization for a session that was revoked, expired or displaced")
+			if b.metrics != nil {
+				b.metrics.RecordAuth(provider.Name, "failure", "SESSION_GONE")
+			}
+			// The same record, with the same code, that the completion path writes when
+			// it finds the session gone (#217). Reaching it here rather than there is the
+			// only difference the cancellation makes: an operator's revocation still
+			// leaves a record saying the login it interrupted was refused, and now
+			// nothing was minted in the meantime for that record to have to withdraw.
+			b.auditLogger.LogAuthEvent(security.AuditEvent{
+				EventType: "authentication_denied",
+				UserID:    session.UserID,
+				SessionID: session.ID,
+				SourceIP:  session.SourceIP,
+				Provider:  provider.Name,
+				Success:   false,
+				ErrorCode: "SESSION_GONE",
+				ErrorMessage: "the session was revoked, expired or displaced before device " +
+					"authorization completed; polling was abandoned",
+				Timestamp: time.Now(),
+			})
 			return
 		case <-timeout.C:
 			// Device flow expired
@@ -1603,6 +2016,20 @@ func (b *Broker) pollDeviceAuthorization(session *Session, provider *OIDCProvide
 			updated.IsActive = true
 			updated.DeviceTrusted = userInfo.DeviceTrusted
 
+			// (#163) The session stops being a pending flow here, so its expiry stops
+			// being the pending window's deadline — minutes — and becomes the session
+			// lifetime: one token_lifetime from now, still bounded by the
+			// max_session_duration of the policy that admitted the login (#212).
+			// LastAccessed moves with it, because a session whose idle clock started
+			// before the user had approved anything can be swept the moment it opens.
+			completedAt := time.Now()
+			updated.ExpiresAt = b.sessionExpiry(session.CreatedAt, completedAt, session.MaxDuration)
+			updated.LastAccessed = completedAt
+
+			// There is no pending flow left to cancel, and the channel must not be
+			// reachable from two stored sessions at once — see stopPendingFlow.
+			updated.cancel = nil
+
 			// Generate SSH key if needed
 			if updated.SSHKeyID == "" {
 				sshKey, err := b.generateSSHKey(&updated)
@@ -1767,6 +2194,10 @@ func (b *Broker) expireSessions(now time.Time) {
 		if session.ExpiresAt.Before(now) || idleExpired {
 			expiredSessions = append(expiredSessions, session)
 			delete(b.sessions, id)
+			// A login that never completed has a goroutine still polling for it; the
+			// sweep is the backstop for the ones whose own deadline timer did not fire
+			// first (#163).
+			stopPendingFlow(session)
 		}
 	}
 	b.sessionMutex.Unlock()

--- a/pkg/auth/broker_session_test.go
+++ b/pkg/auth/broker_session_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -366,21 +367,20 @@ func TestAuthenticateTooManySessions(t *testing.T) {
 	// Set max concurrent sessions to 2
 	broker.config.Authentication.MaxConcurrentSessions = 2
 
-	// Create 2 sessions (should succeed)
+	// Two logins the user has already completed. They have to be *established*
+	// sessions: max_concurrent_sessions bounds the access one identity holds, and
+	// since #163 a login still waiting for device approval does not count towards it
+	// — otherwise anyone who can reach the broker fills a chosen account's limit with
+	// logins nobody approved.
 	for i := 0; i < 2; i++ {
-		req := &AuthRequest{
-			UserID:     "test-user",
-			SourceIP:   "127.0.0.1",
-			TargetHost: "test-host",
-			LoginType:  "ssh",
-		}
-		resp, err := broker.Authenticate(req)
-		if err != nil {
-			t.Fatalf("Authenticate call %d failed: %v", i+1, err)
-		}
-		if resp.ErrorCode == "TOO_MANY_SESSIONS" {
-			t.Fatalf("Authenticate call %d should not hit session limit", i+1)
-		}
+		broker.setSession(&Session{
+			ID:        fmt.Sprintf("established-%d", i),
+			UserID:    "test-user",
+			SourceIP:  "127.0.0.1",
+			IsActive:  true,
+			CreatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
 	}
 
 	// 3rd session should be rejected
@@ -600,6 +600,11 @@ func TestAuthenticateSessionIDUniqueness(t *testing.T) {
 	broker, server := newTestBrokerWithDeviceServer(t)
 	defer server.Close()
 	defer func() { close(broker.stopChan); broker.wg.Wait() }()
+
+	// Ten logins in flight for one account from one address is above the per-source
+	// pending cap this suite otherwise defaults to (#163), and this test is about the
+	// IDs, not the cap.
+	broker.config.Authentication.MaxPendingAuthsPerSource = 10
 
 	seen := make(map[string]bool)
 	for i := 0; i < 10; i++ {

--- a/pkg/auth/denial_audit_test.go
+++ b/pkg/auth/denial_audit_test.go
@@ -1,8 +1,8 @@
 package auth
 
 import (
+	"fmt"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -85,9 +85,38 @@ func TestEveryRefusedLoginIsAuditedWithItsErrorCode(t *testing.T) {
 			wantCode:      "RATE_LIMITED",
 			wantReasonHas: "pending device authorization flows",
 			setup: func(_ *testing.T, env *denialTestEnv) {
-				// The cap is checked after the flow is started, so this is the state a
-				// host under a flood of unfinished logins is in.
-				atomic.StoreInt64(&env.broker.pendingFlows, 100)
+				// (#163) A full pool refuses only a requester that already holds as many
+				// unfinished logins as its largest holder does — otherwise it displaces
+				// one and admits this login, which is what stops the pool being a
+				// host-wide lockout. So: ninety-nine other pairs holding one each, and
+				// one already held by this pair.
+				for i := 0; i < 99; i++ {
+					env.broker.setSession(pendingSessionFixture(
+						fmt.Sprintf("other-%d", i), fmt.Sprintf("user-%d", i), "198.51.100.4"))
+				}
+				env.broker.setSession(pendingSessionFixture("mine", "testuser", "192.0.2.10"))
+			},
+			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
+		},
+		{
+			name:          "this account and address are at their pending-flow cap",
+			wantCode:      "TOO_MANY_PENDING_AUTHS",
+			wantReasonHas: "awaiting device approval",
+			setup: func(_ *testing.T, env *denialTestEnv) {
+				for i := 0; i < defaultMaxPendingAuthsPerSource; i++ {
+					env.broker.setSession(pendingSessionFixture(
+						fmt.Sprintf("pending-%d", i), "testuser", "192.0.2.10"))
+				}
+			},
+			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
+		},
+		{
+			name:          "the account does not exist on this host",
+			wantCode:      "NO_LOCAL_ACCOUNT",
+			wantReasonHas: "no such local account",
+			setup: func(_ *testing.T, env *denialTestEnv) {
+				env.broker.config.Authentication.RequireLocalAccount = true
+				env.broker.lookupLocalUID = func(string) (int, bool, error) { return 0, false, nil }
 			},
 			req: &AuthRequest{UserID: "testuser", SourceIP: "192.0.2.10", LoginType: "ssh"},
 		},

--- a/pkg/auth/device_poll_test.go
+++ b/pkg/auth/device_poll_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -154,6 +153,10 @@ func newPollTestEnv(t *testing.T) *pollTestEnv {
 		LastAccessed: time.Now(),
 		SourceIP:     "192.0.2.10",
 		IsActive:     false,
+		// (#163) Every pending session the broker mints carries the channel that
+		// tells its poll loop to stop, so a fixture that stands in for one has to
+		// have it too.
+		cancel: make(chan struct{}),
 	}
 	broker.setSession(session)
 
@@ -223,7 +226,6 @@ func (e *pollTestEnv) run(t *testing.T) time.Duration {
 	t.Helper()
 
 	e.broker.wg.Add(1)
-	atomic.AddInt64(&e.broker.pendingFlows, 1)
 
 	started := time.Now()
 	done := make(chan struct{})

--- a/pkg/auth/pending_sessions_test.go
+++ b/pkg/auth/pending_sessions_test.go
@@ -1,0 +1,597 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/oidc-pam/pkg/config"
+	"github.com/scttfrdmn/oidc-pam/pkg/security"
+)
+
+// These tests are about the logins the broker is holding that nobody has completed:
+// a client asked to log in as some account, the broker started a device
+// authorization on its behalf, and the user has not approved it. Until then the
+// request has cost the host a session, a goroutine and a round trip to the identity
+// provider, and has proved nothing whatsoever about who sent it — sshd runs its PAM
+// stack for whatever username a remote client offers, before that client has
+// authenticated at all.
+//
+// #163 is what happens when such a login is counted as though it had succeeded.
+// Ten connection attempts naming one account filled that account's
+// max_concurrent_sessions with authentications nobody had approved, and the real
+// user was refused TOO_MANY_SESSIONS for as long as the device codes lived; a
+// hundred of them across invented usernames filled a host-wide pool and refused
+// every login on the machine. Both are driven through Authenticate here, because
+// both were properties of how the counting and the storing were ordered rather than
+// of any one helper.
+
+// pendingEnv is a broker wired to a device-authorization endpoint that counts what
+// it is asked for. The count is the point: a request the broker is going to refuse
+// must not have spent an authenticated POST to the site's identity provider first.
+type pendingEnv struct {
+	broker *Broker
+	server *httptest.Server
+	// deviceRequests counts device-authorization requests the provider received.
+	deviceRequests atomic.Int64
+	// expiresIn is what the endpoint reports as the device code's lifetime, so a test
+	// can play a provider that hands out very long-lived codes.
+	expiresIn atomic.Int64
+	auditPath string
+}
+
+func newPendingEnv(t *testing.T) *pendingEnv {
+	t.Helper()
+
+	env := &pendingEnv{}
+	env.expiresIn.Store(600)
+
+	var issued atomic.Int64
+	env.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := issued.Add(1)
+		env.deviceRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DeviceAuthResponse{
+			// A distinct code per flow, so a test that asserts on which session was
+			// displaced is not looking at two flows that are indistinguishable.
+			DeviceCode:      fmt.Sprintf("device-code-%d", n),
+			UserCode:        fmt.Sprintf("CODE-%d", n),
+			VerificationURI: "https://example.com/verify",
+			ExpiresIn:       int(env.expiresIn.Load()),
+			Interval:        5,
+		})
+	}))
+	t.Cleanup(env.server.Close)
+
+	provider := &OIDCProvider{
+		Name: "test-provider",
+		Config: config.OIDCProvider{
+			Name:            "test-provider",
+			Issuer:          env.server.URL,
+			ClientID:        "test-client",
+			Scopes:          []string{"openid", "profile"},
+			DeviceEndpoint:  env.server.URL + "/device",
+			EnabledForLogin: true,
+		},
+		httpClient: env.server.Client(),
+	}
+
+	// A real, file-backed logger: what the broker records about a login it refused or
+	// abandoned is part of what these tests are checking. "sync" writes on the calling
+	// goroutine, so nothing is left buffered.
+	env.auditPath = filepath.Join(t.TempDir(), "audit.jsonl")
+	auditLogger, err := security.NewAuditLogger(config.AuditConfig{
+		Enabled:          true,
+		Outputs:          []config.AuditOutput{{Type: "file", Path: env.auditPath}},
+		OverflowStrategy: "sync",
+	})
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = auditLogger.Stop() })
+
+	cfg := &config.Config{
+		Authentication: config.AuthenticationConfig{
+			TokenLifetime:    time.Hour,
+			RefreshThreshold: 15 * time.Minute,
+		},
+	}
+
+	env.broker = &Broker{
+		config:       cfg,
+		sessions:     make(map[string]*Session),
+		policyEngine: &PolicyEngine{config: cfg},
+		providers:    map[string]*OIDCProvider{"test-provider": provider},
+		auditLogger:  auditLogger,
+		stopChan:     make(chan struct{}),
+		// No poll ever fires: these tests are about what happens to a login *before*
+		// anyone approves it, and the token endpoint is not what is being played here.
+		// The unit multiplies the provider's interval, so an hour puts the first poll
+		// five hours out — the cancellation and deadline branches of the loop are
+		// reached without it.
+		pollIntervalUnit: time.Hour,
+		// A fixed passwd table, so the local-account gate behaves the same wherever the
+		// suite runs.
+		lookupLocalUID: testLookupUID,
+	}
+	// Registered after server.Close, so it runs before it: the polling goroutines are
+	// released while the endpoint they talk to is still up.
+	t.Cleanup(func() {
+		close(env.broker.stopChan)
+		env.broker.wg.Wait()
+	})
+
+	return env
+}
+
+// authenticate asks for a login as userID from sourceIP.
+func (e *pendingEnv) authenticate(t *testing.T, userID, sourceIP string) *AuthResponse {
+	t.Helper()
+
+	resp, err := e.broker.Authenticate(&AuthRequest{
+		UserID:     userID,
+		SourceIP:   sourceIP,
+		TargetHost: "test-host",
+		LoginType:  "ssh",
+	})
+	if err != nil {
+		t.Fatalf("Authenticate(%q from %q): %v", userID, sourceIP, err)
+	}
+	return resp
+}
+
+// countPending returns how many unfinished logins the broker holds for one
+// (account, source) pair.
+func (e *pendingEnv) countPending(userID, sourceIP string) int {
+	e.broker.sessionMutex.RLock()
+	defer e.broker.sessionMutex.RUnlock()
+
+	count := 0
+	for _, session := range e.broker.sessions {
+		if !session.IsActive && session.UserID == userID && session.SourceIP == sourceIP {
+			count++
+		}
+	}
+	return count
+}
+
+// pendingSessionFixture is a session for a login that has started a device flow and
+// not completed one: what Authenticate stores between handing a user code to a
+// client and that client's user approving it. Built directly rather than through
+// Authenticate where a test needs a hundred of them, or needs to move one back in
+// time without racing the goroutine that would be polling for it.
+func pendingSessionFixture(id, userID, sourceIP string) *Session {
+	now := time.Now()
+	return &Session{
+		ID:           id,
+		UserID:       userID,
+		SourceIP:     sourceIP,
+		Provider:     "test-provider",
+		LoginType:    "ssh",
+		IsActive:     false,
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(defaultPendingAuthLifetime),
+		LastAccessed: now,
+		cancel:       make(chan struct{}),
+	}
+}
+
+// agePendingSession moves a stored pending session back in time by d, replacing the
+// map entry rather than mutating it in place — the store's own convention, and the
+// only safe thing to do to a session something else may be reading.
+func agePendingSession(t *testing.T, broker *Broker, sessionID string, d time.Duration) {
+	t.Helper()
+
+	broker.sessionMutex.Lock()
+	defer broker.sessionMutex.Unlock()
+
+	stored, ok := broker.sessions[sessionID]
+	if !ok {
+		t.Fatalf("no session %q to age", sessionID)
+	}
+	aged := *stored
+	aged.CreatedAt = stored.CreatedAt.Add(-d)
+	aged.ExpiresAt = stored.ExpiresAt.Add(-d)
+	aged.LastAccessed = stored.LastAccessed.Add(-d)
+	broker.sessions[sessionID] = &aged
+}
+
+// isClosed reports whether a pending session's cancel channel has been closed,
+// which is how the goroutine polling for it is told to stop.
+func isClosed(ch chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestAbandonedPendingFlowsDoNotDenyTheAccountItsLogin is the regression gate for
+// #163, and fails on the code before it in two places at once.
+//
+// A client that has authenticated nothing repeatedly asks to log in as someone
+// else's account. Every one of those requests is abandoned — no user ever visits the
+// verification URL, which is the whole attack: it costs the sender nothing.
+//
+// Before the fix, each abandoned request took a slot in the victim's
+// max_concurrent_sessions and held it for the device code's lifetime, so the fourth
+// request against a limit of three locked the account out and the victim's own login
+// was refused TOO_MANY_SESSIONS. After it, unfinished logins are counted separately,
+// against the (account, source address) pair that asked for them — the address being
+// the part of the request a remote client does not choose — so the flood exhausts the
+// attacker's own budget and the victim, arriving from a different address, is served.
+func TestAbandonedPendingFlowsDoNotDenyTheAccountItsLogin(t *testing.T) {
+	env := newPendingEnv(t)
+
+	// The limit an operator sets on how many sessions one person may hold at once.
+	env.broker.config.Authentication.MaxConcurrentSessions = 3
+
+	const (
+		victim     = "alice"
+		attackerIP = "198.51.100.4"
+		victimIP   = "203.0.113.9"
+	)
+
+	admitted, refused := 0, 0
+	for i := 0; i < 10; i++ {
+		resp := env.authenticate(t, victim, attackerIP)
+		switch {
+		case resp.Success:
+			admitted++
+		case resp.ErrorCode == "TOO_MANY_PENDING_AUTHS":
+			refused++
+		default:
+			t.Fatalf("attempt %d was refused %q (%s), want either a device code or the "+
+				"pending-flow cap; a flood of unfinished logins must not be answered with a "+
+				"limit that belongs to the account (#163)", i+1, resp.ErrorCode, resp.ErrorMessage)
+		}
+	}
+
+	if admitted != defaultMaxPendingAuthsPerSource {
+		t.Errorf("%d of 10 abandoned logins were admitted, want %d: one account and address may "+
+			"have max_pending_auths_per_source unfinished logins in flight and no more",
+			admitted, defaultMaxPendingAuthsPerSource)
+	}
+	if refused != 10-defaultMaxPendingAuthsPerSource {
+		t.Errorf("%d attempts were refused with TOO_MANY_PENDING_AUTHS, want %d",
+			refused, 10-defaultMaxPendingAuthsPerSource)
+	}
+	if held := env.countPending(victim, attackerIP); held != defaultMaxPendingAuthsPerSource {
+		t.Errorf("the broker holds %d unfinished logins for that pair, want %d", held,
+			defaultMaxPendingAuthsPerSource)
+	}
+	// The refused attempts must not have reached the identity provider: a cap that is
+	// applied after the round trip still lets an unauthenticated client spend the
+	// site's device-authorization quota.
+	if got := env.deviceRequests.Load(); got != int64(defaultMaxPendingAuthsPerSource) {
+		t.Errorf("the provider's device endpoint saw %d requests, want %d — one per admitted "+
+			"login and none for a refused one", got, defaultMaxPendingAuthsPerSource)
+	}
+
+	// The account is not locked out. This is the assertion the issue is about.
+	resp := env.authenticate(t, victim, victimIP)
+	if !resp.Success {
+		t.Fatalf("the account's own login was refused %q (%s) while %d abandoned "+
+			"authentications for it were in flight from elsewhere: unfinished logins nobody "+
+			"approved must not consume the account's session limit (#163)",
+			resp.ErrorCode, resp.ErrorMessage, defaultMaxPendingAuthsPerSource)
+	}
+	if !resp.RequiresDevice || resp.DeviceCode == "" {
+		t.Errorf("the login was admitted without a device code to complete it: %+v", resp)
+	}
+}
+
+// A slot held by a login nobody completed has to come back on its own. A cap whose
+// entries live forever is not a fix, it is the same denial of service with a
+// different message — and before this the entry's lifetime was the device code's
+// expires_in, a number the provider chooses and may set as high as 24 hours.
+func TestPendingLoginSlotIsReleasedWhenItsWindowCloses(t *testing.T) {
+	env := newPendingEnv(t)
+
+	const (
+		user     = "alice"
+		sourceIP = "198.51.100.4"
+	)
+
+	for i := 0; i < defaultMaxPendingAuthsPerSource; i++ {
+		env.broker.setSession(pendingSessionFixture(fmt.Sprintf("pending-%d", i), user, sourceIP))
+	}
+
+	if resp := env.authenticate(t, user, sourceIP); resp.ErrorCode != "TOO_MANY_PENDING_AUTHS" {
+		t.Fatalf("a login at the pending cap answered %q, want TOO_MANY_PENDING_AUTHS", resp.ErrorCode)
+	}
+
+	// Time passes, on the broker's clock rather than the test's: every one of those
+	// unfinished logins is now past the window it was allowed.
+	for i := 0; i < defaultMaxPendingAuthsPerSource; i++ {
+		agePendingSession(t, env.broker, fmt.Sprintf("pending-%d", i), defaultPendingAuthLifetime+time.Minute)
+	}
+
+	if resp := env.authenticate(t, user, sourceIP); !resp.Success {
+		t.Fatalf("a login was refused %q (%s) while every unfinished login counted against it "+
+			"was past its own deadline; the entries have to stop counting when their window "+
+			"closes, not when the sweep next runs (#163)", resp.ErrorCode, resp.ErrorMessage)
+	}
+
+	// And the sweep collects them, closing each one's cancel channel so the goroutine
+	// that was polling for it stops too.
+	swept := env.broker.getSession("pending-0")
+	if swept == nil {
+		t.Fatal("the aged pending session is already gone; nothing left to observe the sweep on")
+	}
+	env.broker.expireSessions(time.Now())
+	if env.broker.getSession("pending-0") != nil {
+		t.Error("the sweep left a pending session that is past its deadline in the store")
+	}
+	if !isClosed(swept.cancel) {
+		t.Error("the swept pending session's poll loop was not told to stop, so it keeps a device " +
+			"code warm for a login the broker has forgotten (#163)")
+	}
+}
+
+// The window an unfinished login may hold its slot for is the broker's, not the
+// provider's. A provider that hands out 24-hour device codes — the upper bound
+// StartDeviceFlow accepts — used to set how long a pending session and its polling
+// goroutine lived, which is how a handful of abandoned requests could occupy the
+// host for a day.
+func TestPendingLifetimeIsBoundedByTheBrokerNotTheProvider(t *testing.T) {
+	env := newPendingEnv(t)
+	env.expiresIn.Store(86400) // the most StartDeviceFlow will accept
+
+	before := time.Now()
+	resp := env.authenticate(t, "alice", "198.51.100.4")
+	if !resp.Success {
+		t.Fatalf("Authenticate refused the login: %q (%s)", resp.ErrorCode, resp.ErrorMessage)
+	}
+
+	session := env.broker.getSession(resp.SessionID)
+	if session == nil {
+		t.Fatal("the admitted login left no pending session")
+	}
+
+	limit := before.Add(defaultPendingAuthLifetime + time.Minute)
+	if session.ExpiresAt.After(limit) {
+		t.Errorf("the pending session expires at %s, about %s from now: a provider's expires_in "+
+			"must not set how long an unfinished login holds its slot (#163)",
+			session.ExpiresAt, session.ExpiresAt.Sub(before).Round(time.Second))
+	}
+	// And the client is told the earlier of the two deadlines, since the code stops
+	// working when the broker stops polling for it.
+	if resp.ExpiresAt.After(limit) {
+		t.Errorf("the client was promised the code would work until %s, past the window the "+
+			"broker will honour", resp.ExpiresAt)
+	}
+}
+
+// The host-wide pool is the other half of #163: a client filling it with unfinished
+// logins under invented usernames used to make every login on the machine answer
+// RATE_LIMITED. A full pool now displaces a pending flow from whichever (account,
+// source) pair holds the most, so holding the largest share is what makes you the
+// one who pays for it, and a login from a pair holding nothing is still served.
+func TestFullPendingPoolDisplacesItsLargestHolder(t *testing.T) {
+	env := newPendingEnv(t)
+	// A hoarder needs room to hoard; the per-source cap is what bounds it in the
+	// default configuration.
+	env.broker.config.Authentication.MaxPendingAuthsPerSource = hardMaxPendingAuthsPerSource
+
+	const (
+		hogUser = "bob"
+		hogIP   = "198.51.100.4"
+		hogHeld = 30
+	)
+
+	hogSessions := make([]*Session, 0, hogHeld)
+	for i := 0; i < hogHeld; i++ {
+		session := pendingSessionFixture(fmt.Sprintf("hog-%d", i), hogUser, hogIP)
+		// Distinct creation times, so "the oldest of them" is a defined thing.
+		session.CreatedAt = session.CreatedAt.Add(time.Duration(i) * time.Second)
+		hogSessions = append(hogSessions, session)
+		env.broker.setSession(session)
+	}
+	for i := 0; i < maxPendingAuthsOnHost-hogHeld; i++ {
+		env.broker.setSession(pendingSessionFixture(
+			fmt.Sprintf("single-%d", i), fmt.Sprintf("user-%d", i), "203.0.113.9"))
+	}
+
+	// A login from a pair holding nothing. The pool is full, and it is served anyway.
+	resp := env.authenticate(t, "alice", "192.0.2.10")
+	if !resp.Success {
+		t.Fatalf("a login from an address holding no unfinished authentications was refused %q "+
+			"(%s) because the host's pending pool was full of somebody else's: a full pool must "+
+			"not be a host-wide lockout (#163)", resp.ErrorCode, resp.ErrorMessage)
+	}
+
+	// It was paid for by the largest holder's oldest flow, and that flow's poll loop
+	// was told to stop — otherwise the pool's bound on goroutines and provider traffic
+	// means nothing.
+	displaced := hogSessions[0]
+	if env.broker.getSession(displaced.ID) != nil {
+		t.Errorf("session %q is still stored; the pool admitted a login without displacing the "+
+			"oldest flow of its largest holder", displaced.ID)
+	}
+	if !isClosed(displaced.cancel) {
+		t.Error("the displaced flow's poll loop was not told to stop, so its goroutine keeps " +
+			"polling the provider for a session that no longer exists (#163)")
+	}
+	if held := env.countPending(hogUser, hogIP); held != hogHeld-1 {
+		t.Errorf("the largest holder still has %d unfinished logins, want %d", held, hogHeld-1)
+	}
+
+	// The largest holder itself is the one that gets refused, and only once nobody
+	// holds more than it does.
+	requests := env.deviceRequests.Load()
+	hogResp := env.authenticate(t, hogUser, hogIP)
+	if hogResp.Success {
+		t.Fatalf("the pair holding the largest share of a full pool was admitted again: %+v", hogResp)
+	}
+	if hogResp.ErrorCode != "RATE_LIMITED" {
+		t.Errorf("error_code = %q, want RATE_LIMITED", hogResp.ErrorCode)
+	}
+	if got := env.deviceRequests.Load(); got != requests {
+		t.Errorf("the refused login still made %d device-authorization request(s); admission has "+
+			"to be decided before the provider is asked", got-requests)
+	}
+}
+
+// max_concurrent_sessions is a bound on the access one identity holds at once, so
+// what belongs in it is access that was granted. Established sessions count; logins
+// still waiting for someone to approve them do not.
+func TestPendingLoginsDoNotCountTowardsTheSessionLimit(t *testing.T) {
+	env := newPendingEnv(t)
+	env.broker.config.Authentication.MaxConcurrentSessions = 2
+
+	const user = "alice"
+	for i := 0; i < 2; i++ {
+		env.broker.setSession(pendingSessionFixture(fmt.Sprintf("pending-%d", i), user, "198.51.100.4"))
+	}
+	if resp := env.authenticate(t, user, "203.0.113.9"); !resp.Success {
+		t.Fatalf("a login was refused %q (%s) with two *unapproved* authentications for the "+
+			"account in flight (#163)", resp.ErrorCode, resp.ErrorMessage)
+	}
+
+	// The same two, completed, do refuse it.
+	for i := 0; i < 2; i++ {
+		established := pendingSessionFixture(fmt.Sprintf("active-%d", i), user, "198.51.100.4")
+		established.IsActive = true
+		established.ExpiresAt = time.Now().Add(time.Hour)
+		established.cancel = nil
+		env.broker.setSession(established)
+	}
+	resp := env.authenticate(t, user, "203.0.113.9")
+	if resp.ErrorCode != "TOO_MANY_SESSIONS" {
+		t.Errorf("a login with the account's session limit already granted answered %q, want "+
+			"TOO_MANY_SESSIONS: the limit still has to be enforced against sessions that exist",
+			resp.ErrorCode)
+	}
+}
+
+// A login for an account this host does not have could never have succeeded — sshd
+// needs a passwd entry once the stack returns, and the identity binding resolves the
+// account again when the flow completes — but it used to be found out only after the
+// broker had spent an authenticated request to the site's identity provider and
+// taken a slot in the pending pool. Every ssh scanner on the internet could do that.
+func TestLoginForAnUnknownLocalAccountNeverReachesTheProvider(t *testing.T) {
+	env := newPendingEnv(t)
+	env.broker.config.Authentication.RequireLocalAccount = true
+
+	resp := env.authenticate(t, "no-such-user", "198.51.100.4")
+	if resp.Success {
+		t.Fatalf("a login for an account this host does not have was admitted: %+v", resp)
+	}
+	if resp.ErrorCode != "NO_LOCAL_ACCOUNT" {
+		t.Errorf("error_code = %q, want NO_LOCAL_ACCOUNT", resp.ErrorCode)
+	}
+	if got := env.deviceRequests.Load(); got != 0 {
+		t.Errorf("the provider's device endpoint saw %d request(s) for an account that does not "+
+			"exist here; an unauthenticated client must not be able to spend the site's "+
+			"device-authorization quota on invented usernames (#163)", got)
+	}
+	if got := env.countPending("no-such-user", "198.51.100.4"); got != 0 {
+		t.Errorf("the refused login left %d pending session(s) behind", got)
+	}
+
+	// An account that does exist is unaffected.
+	if resp := env.authenticate(t, "alice", "198.51.100.4"); !resp.Success {
+		t.Fatalf("the local-account gate refused a login for an account that exists: %q (%s)",
+			resp.ErrorCode, resp.ErrorMessage)
+	}
+}
+
+// Both bounds on an unfinished login are clamped at both ends. A configured value
+// that is honoured however large it is fails open — the same shape as the unbounded
+// int the IPC limiter narrowed to int32, where a very large configured cap became no
+// cap at all — and zero has to mean "the default", not "no limit", because these
+// settings are what stops an unauthenticated client consuming somebody else's
+// capacity.
+func TestPendingBoundsAreClampedAtBothEnds(t *testing.T) {
+	for _, tc := range []struct {
+		configured, want int
+	}{
+		{configured: 0, want: defaultMaxPendingAuthsPerSource},
+		{configured: -1, want: defaultMaxPendingAuthsPerSource},
+		{configured: 1, want: 1},
+		{configured: hardMaxPendingAuthsPerSource, want: hardMaxPendingAuthsPerSource},
+		{configured: hardMaxPendingAuthsPerSource + 1, want: hardMaxPendingAuthsPerSource},
+		{configured: 1 << 30, want: hardMaxPendingAuthsPerSource},
+	} {
+		broker := &Broker{config: &config.Config{
+			Authentication: config.AuthenticationConfig{MaxPendingAuthsPerSource: tc.configured},
+		}}
+		if got := broker.maxPendingAuthsPerSource(); got != tc.want {
+			t.Errorf("max_pending_auths_per_source: %d became %d, want %d", tc.configured, got, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		configured, want time.Duration
+	}{
+		{configured: 0, want: defaultPendingAuthLifetime},
+		{configured: -time.Hour, want: defaultPendingAuthLifetime},
+		{configured: time.Second, want: minPendingAuthLifetime},
+		{configured: 5 * time.Minute, want: 5 * time.Minute},
+		{configured: hardMaxPendingAuthLifetime, want: hardMaxPendingAuthLifetime},
+		{configured: 24 * time.Hour, want: hardMaxPendingAuthLifetime},
+	} {
+		broker := &Broker{config: &config.Config{
+			Authentication: config.AuthenticationConfig{PendingAuthLifetime: tc.configured},
+		}}
+		if got := broker.pendingAuthLifetime(); got != tc.want {
+			t.Errorf("pending_auth_lifetime: %s became %s, want %s", tc.configured, got, tc.want)
+		}
+	}
+}
+
+// Removing a pending session has to stop the goroutine polling for it. Before this
+// the two had independent lifetimes: a revoked, swept or displaced login left a
+// goroutine holding a live device code and polling the provider for it until that
+// code's own expiry, so a bound on how many unfinished logins the host holds bounded
+// nothing that those logins actually cost.
+func TestRevokingAPendingLoginStopsItsPolling(t *testing.T) {
+	env := newPendingEnv(t)
+
+	resp := env.authenticate(t, "alice", "198.51.100.4")
+	if !resp.Success {
+		t.Fatalf("Authenticate refused the login: %q (%s)", resp.ErrorCode, resp.ErrorMessage)
+	}
+
+	env.broker.removeSession(resp.SessionID)
+
+	// The wait is a guard, not a delay: a poll loop that honours the cancellation is
+	// already gone by the time this runs, and one that does not would sit here until
+	// the device code expired ten minutes later.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		env.broker.wg.Wait()
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the goroutine polling for a session that was removed is still running; a " +
+			"pending login and the work it costs have to end together (#163)")
+	}
+
+	// The user was waiting on that login and will be refused, so it is recorded —
+	// with the code the completion path uses for the same condition (#217, #218).
+	var abandoned *security.AuditEvent
+	for _, event := range auditEventsAt(t, env.auditPath) {
+		if event.EventType == "authentication_denied" && event.ErrorCode == "SESSION_GONE" {
+			e := event
+			abandoned = &e
+		}
+	}
+	if abandoned == nil {
+		t.Fatal("abandoning a revoked login's device authorization left no record; an operator " +
+			"who revokes a session mid-flow has nothing saying what it interrupted (#218)")
+	}
+	if abandoned.SessionID != resp.SessionID {
+		t.Errorf("the record names session %q, want the one that was revoked (%q)",
+			abandoned.SessionID, resp.SessionID)
+	}
+}

--- a/pkg/auth/session_fail_closed_test.go
+++ b/pkg/auth/session_fail_closed_test.go
@@ -35,6 +35,18 @@ func TestDeviceFlowWillNotActivateASessionThatIsGone(t *testing.T) {
 	// The operator revokes it while the provider round-trip is in flight.
 	env.broker.removeSession(env.session.ID)
 
+	// A revocation now also cancels the flow's polling (#163), and a flow that
+	// notices the cancellation stops before it has anything to withdraw. This test is
+	// about the other ordering, which is still reachable and is the one that can leave
+	// a credential behind: the revocation landed while this goroutine was inside the
+	// token request, so it had already passed the select that watches for
+	// cancellation and runs to completion regardless. Re-arming the channel after the
+	// revocation is how that ordering is made deterministic — the flow has not
+	// started, so nothing else can be reading it — and it leaves the pointer-identity
+	// check at the end of the flow as the only thing standing between a revoked
+	// session and an active one with a key installed.
+	env.session.cancel = make(chan struct{})
+
 	env.run(t)
 
 	if session := env.activeSession(); session != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -171,6 +171,31 @@ type AuthenticationConfig struct {
 	GeoIPDatabasePath     string                          `mapstructure:"geoip_database_path"`
 	LocationHistory       LocationHistoryConfig           `mapstructure:"location_history"`
 
+	// MaxPendingAuthsPerSource caps the authentications one account may have in
+	// progress from one source address at the same time — logins that have started a
+	// device flow and have not been approved yet.
+	//
+	// (#163) Pending logins used to be counted against MaxConcurrentSessions, which
+	// is keyed on the account alone. The account is the one field of an authenticate
+	// request that an unauthenticated remote client chooses, so that cap could be
+	// filled on somebody else's behalf and their next login refused. This one is
+	// keyed on the account *and* the address the login came from, which the client
+	// does not choose. Zero means the broker's default; see
+	// Broker.maxPendingAuthsPerSource for the bounds applied to it.
+	MaxPendingAuthsPerSource int `mapstructure:"max_pending_auths_per_source"`
+
+	// PendingAuthLifetime is how long an authentication that is never completed may
+	// hold one of those slots, measured on the broker's clock rather than on the
+	// device code's. Zero means the default. A provider may issue a device code good
+	// for 24 hours, and an abandoned login held its slot — and until #163 a slice of
+	// its account's session cap — for that entire time.
+	PendingAuthLifetime time.Duration `mapstructure:"pending_auth_lifetime"`
+
+	// RequireLocalAccount refuses a login for an account the broker cannot resolve
+	// locally, before the request reaches the identity provider at all. Defaults to
+	// true (set in setDefaults). See Broker.denyIfNoLocalAccount.
+	RequireLocalAccount bool `mapstructure:"require_local_account"`
+
 	// AllowPrivilegedAccounts names the privileged local accounts an OIDC identity
 	// may log in as. By default no identity may bind to uid 0 or to any account with
 	// uid < PrivilegedUIDThreshold, whatever the token says, because that binding is
@@ -548,6 +573,12 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("authentication.token_lifetime", "8h")
 	v.SetDefault("authentication.refresh_threshold", "1h")
 	v.SetDefault("authentication.max_concurrent_sessions", 10)
+	// (#163) An unfinished login is bounded per (account, source address) and by its
+	// own clock, and a login for an account this host does not have is refused before
+	// it reaches the provider.
+	v.SetDefault("authentication.max_pending_auths_per_source", 5)
+	v.SetDefault("authentication.pending_auth_lifetime", "15m")
+	v.SetDefault("authentication.require_local_account", true)
 
 	// Security defaults
 	v.SetDefault("security.audit_enabled", true)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -92,6 +92,23 @@ authentication:
 	if cfg.Server.LogLevel != "info" {
 		t.Errorf("Expected default log level 'info', got '%s'", cfg.Server.LogLevel)
 	}
+
+	// (#163) The bounds on logins nobody has completed yet apply to a file written
+	// before they existed, which is every file already deployed. A default of zero
+	// would leave those hosts with the accounting that let an unauthenticated client
+	// exhaust an account's session limit.
+	if cfg.Authentication.MaxPendingAuthsPerSource != 5 {
+		t.Errorf("max_pending_auths_per_source = %d, want the default 5",
+			cfg.Authentication.MaxPendingAuthsPerSource)
+	}
+	if cfg.Authentication.PendingAuthLifetime != 15*time.Minute {
+		t.Errorf("pending_auth_lifetime = %s, want the default 15m",
+			cfg.Authentication.PendingAuthLifetime)
+	}
+	if !cfg.Authentication.RequireLocalAccount {
+		t.Error("require_local_account defaulted to false, so a login for an account this host " +
+			"does not have still reaches the identity provider")
+	}
 }
 
 func TestConfigValidation(t *testing.T) {


### PR DESCRIPTION
## What was wrong

The broker counted a login nobody had approved as though it had succeeded. An authenticate request names the account it wants, sshd runs its PAM stack for whatever username a client offers before that client has authenticated anything, and every such request became a session in the broker's map that counted towards the named account's `max_concurrent_sessions`. Ten connection attempts naming one account — none of them completed, which is what makes the attack free — filled that account's limit with authentications nobody had approved, and the real user's next login was refused `TOO_MANY_SESSIONS`. The entries went away when the device code the provider had issued expired, a lifetime the provider chooses and may set as high as 24 hours.

The host-wide cap that was supposed to bound this was the second half of the same problem. A hundred unfinished flows, spread across invented usernames so no single account limit was reached, made every login on the machine answer `RATE_LIMITED` until the codes expired. It was also checked *after* the session had been stored and after the round trip to the identity provider, so a request that was about to be refused had already spent an authenticated POST to the provider's device endpoint and briefly occupied a session slot on the way out.

## Reachability, stated precisely

The broker's IPC socket is root-owned, `0660`, and `verifyPeerCredentials` accepts uid 0 only, so the peer is always root. That does **not** make this a root-only defect, and the issue's "unauthenticated remote client" framing is essentially correct: the peer is sshd's PAM stack, which runs as root *before* the remote client has authenticated and forwards that client's chosen username — deliberately, so that a valid and an invalid user cost the same time. The requests therefore come from a client that has proved nothing, over ssh. The one field it does not control is `source_ip`, which the module derives from `PAM_RHOST`; that is what makes the address usable as a second key.

Severity is denial of service, not privilege escalation: nothing here grants access. It can be aimed at one chosen account or at the whole host.

## Claims verified

Line numbers in the issue are stale; the substance holds. Against `main` at the time of this branch:

| Claim | Where | Verdict |
|---|---|---|
| Pending sessions count towards `max_concurrent_sessions` | `pkg/auth/broker.go:554` (`countUserSessions`, no `IsActive` test) | Confirmed |
| The session is stored before the host-wide cap is checked | the `b.setSession(session)` / `atomic.AddInt64(&b.pendingFlows, 1)` pair this diff removes | Confirmed |
| A pending session's removal is driven by the provider's device-code expiry | `ExpiresAt` came from `sessionExpiry`, the poll loop's timer from `deviceFlow.ExpiresAt`, bounded only by `maxDeviceCodeExpiry` = 86400 | Confirmed |
| Nothing checks that the requested account exists before the IdP is contacted | `verifyIdentityBinding` runs at the end of the flow | Confirmed |
| A full pool refuses everyone | the old cap answered `RATE_LIMITED` to whichever request arrived next | Confirmed |

## What changed

Unfinished logins are accounted for separately from sessions. `max_concurrent_sessions` counts only logins that completed — what a limit on how much access one identity holds should count. A login still awaiting device approval is charged instead against the `(account, source address)` pair that asked for it: the account is the one field a remote client chooses freely, so a cap keyed on it alone can always be filled on somebody else's behalf, while the address is where the connection came from. An attacker can exhaust the budget of `(victim, its own address)` and nothing else.

The host-wide pool is still bounded at 100, but reaching it no longer refuses the login that arrives next: it displaces the oldest pending flow of whichever pair holds the most, and only a pair holding strictly more than the requester can be displaced. Holding the largest share is exactly what selects you to pay for it, so hoarding cannot lock the host out, and a login from a pair holding nothing is always served. That is the argument the IPC limiter's LRU bucket eviction already rests on. Only when nobody holds more than the requester — a pool genuinely full of logins with as good a claim — is `RATE_LIMITED` returned.

An unfinished login now expires on the broker's clock (`pending_auth_lifetime`, 15m default) rather than on the provider's `expires_in`, and that deadline also bounds the goroutine polling for it. Removing a pending session — by revocation, by the sweep, or by displacement — closes a per-session cancellation channel that stops its poll loop. Without it a cap on how many unfinished logins the host holds bounded none of the work each one costs: the goroutine kept a live device code warm for up to the code's full lifetime after its session was gone. Abandoning a flow that way is audited with the same `SESSION_GONE` code the completion path already uses for the same condition (#217), so an operator who revokes a session mid-flow still gets a record of the login it interrupted — and now nothing was minted in the meantime for that record to withdraw. Admission also decides *before* `StartDeviceFlow`, so a refused login costs the identity provider nothing, and the slot is returned immediately if the provider errors.

Finally, a login naming an account this host does not have is refused before the provider is contacted (`require_local_account`, default true). Such a login could never have succeeded — sshd needs a passwd entry once the stack returns, and the identity binding resolves the account again at the end of the flow — so all that changes is what it costs to ask, which until now was an authenticated request to the site's IdP and a slot in the pending pool, available to every ssh scanner on the internet. The trade is an enumeration oracle (a client can tell a real account from an invented one by whether it is offered a device code), which is why the setting exists to turn it off. The gate does **not** treat an NSS *error* as "no such account" — refusing every login while `getpwnam` is briefly unavailable would be the same denial of service by another route; the privileged-account guard on the completion path is the one that fails closed there (#159).

Two smaller things fall out. A pending session no longer stores the device code in `TokenFingerprint` (nothing read it, and the completion path overwrites it with the real fingerprint), and the `expires_at` handed to the client is now the earlier of the provider's expiry and the broker's window, rather than promising a window the broker will not honour.

### Settings

Three keys, in `pkg/config` with the other authentication settings, defaulted via `setDefaults` so they apply to files written before they existed, clamped at both ends — an oversized value saturates rather than being honoured, the fail-open shape `clampToInt32` exists for in the IPC limiter — and documented in `configs/CONFIGURATION-GUIDE.md`:

| Key | Default | Bounds |
|---|---|---|
| `authentication.max_pending_auths_per_source` | `5` | 1–32, `0` means the default |
| `authentication.pending_auth_lifetime` | `15m` | 1m–1h, `0` means the default |
| `authentication.require_local_account` | `true` | — |

## Tests

`pkg/auth/pending_sessions_test.go` drives everything through `Authenticate`, since these were properties of how counting and storing were ordered rather than of any one helper. Its device endpoint counts requests, so "a refused login must not have reached the provider" is an assertion rather than a claim. No test sleeps: pending entries are aged by rewriting the stored session's timestamps, and the one wait is a 10s *guard* on a goroutine that has already exited when the code is correct.

The regression gate is `TestAbandonedPendingFlowsDoNotDenyTheAccountItsLogin`: ten abandoned requests for `alice` from one address against `max_concurrent_sessions: 3`, then `alice`'s own login from a different address, which must be served.

### Non-vacuity proof

For each guard: back up `pkg/auth/broker.go`, perturb with `perl -0pi -e`, run *only* the covering test, restore, `diff -q`. All six perturbations produced a failure, and every restore was byte-identical.

| Guard perturbed | Covering test | Failure observed |
|---|---|---|
| `&& session.IsActive` dropped from `countActiveUserSessions` | `TestAbandonedPendingFlowsDoNotDenyTheAccountItsLogin` | `attempt 4 was refused "TOO_MANY_SESSIONS"` |
| per-source cap (`if false && mine >= perSourceCap`) | same | `10 of 10 abandoned logins were admitted, want 5` |
| deadline skip in admission counting | `TestPendingLoginSlotIsReleasedWhenItsWindowCloses` | refused `TOO_MANY_PENDING_AUTHS` after every entry was past its deadline |
| pending expiry hardcoded to 24h | `TestPendingLifetimeIsBoundedByTheBrokerNotTheProvider` | `expires ... about 24h0m0s from now` |
| displacement disabled (`if true \|\| count <= mine`) | `TestFullPendingPoolDisplacesItsLargestHolder` | a login from a pair holding nothing was refused `RATE_LIMITED` |
| `close(session.cancel)` disabled | `TestRevokingAPendingLoginStopsItsPolling` | guard fired: the poll goroutine was still running |

`TestDeviceFlowWillNotActivateASessionThatIsGone` (the #217 gate) needed reworking rather than removing: a revocation now cancels the flow early, so the test's setup no longer reached `replaceSession` at all. It now simulates the ordering that *is* still reachable and is the one that can leave a credential behind — the revocation landed while the goroutine was inside the token request, past the select that watches for cancellation — so the pointer-identity CAS is still exercised, along with the key and token withdrawal.

`gofmt -l .` empty, `go build ./...`, `golangci-lint run` on both packages clean, `go test ./...` green, `go test -race ./pkg/auth ./pkg/config` green, and `-race -count=3` over the touched tests green. (The macOS cgo failures for the `//go:build linux` files are absent here because nothing in this change touches them.)

## Found, not fixed

- A login with no source address — the console, or a `PAM_RHOST` that is a hostname rather than an address (#169) — shares one pending budget per account. Those cannot be produced remotely, which is what makes the sharing acceptable, but it is a sharing.
- Two clients behind one NAT address share a budget for the same account, so an attacker who is on the victim's network can still consume that pair's five slots. Closing that needs something the client cannot choose and does not share, which at this point in the flow does not exist.
- A pending session's idle timeout still runs from its creation (`CheckSession` deliberately does not touch `LastAccessed` while pending), so an `idle_timeout` shorter than `pending_auth_lifetime` sweeps unfinished logins early. Harmless — it ends logins nobody is completing — but it means two settings can bound the same window.
- `RateLimiter`'s doc comment in `internal/ipc/ratelimit.go` still describes this pending-flow accounting as future work. Another package, and another agent's files this week, so it is left alone.

Closes #163
