### PR TITLE
docs: make the contributor docs describe the repository that exists (#147)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,19 @@
 /cmd/pam-module/ @scttfrdmn
 /cmd/pam-helper/ @scttfrdmn
 
-# Authentication and authorization core
+# Authentication and authorization core. There is deliberately no /pkg/policy/
+# entry: that package was removed (#126) and its policy engine now lives in
+# /pkg/auth/. A rule for a path that does not exist matches nothing, so it looked
+# like coverage while providing none (#147).
 /pkg/auth/ @scttfrdmn
-/pkg/policy/ @scttfrdmn
+
+# The IPC trust boundary: every PAM login crosses it, and it is where the peer
+# credential check and request validation live.
+/internal/ipc/ @scttfrdmn
+
+# Loads the token encryption key and every client secret, and enforces the
+# configuration file's permissions.
+/pkg/config/ @scttfrdmn
 
 # SSH key management
 /pkg/ssh/ @scttfrdmn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,23 @@ jobs:
             fail=1
           fi
 
+          # The roadmap heading and the status line are how a reader judges whether
+          # the README is describing the release they downloaded. Both drifted to
+          # v0.4.0 while the badge said 0.5.0, so the document disagreed with itself
+          # a few screens apart (#147) — which is how readers learn to discount the
+          # parts that matter, like the OpenSSH 7.7 requirement.
+          roadmap=$(grep -oE '^### Delivered \(through v[^)]+\)' README.md | head -1 | sed -E 's/.*\(through v(.*)\)/\1/')
+          if [ "$roadmap" != "$VERSION" ]; then
+            echo "::error::README roadmap says 'Delivered (through v$roadmap)' but the tag is '$VERSION'. Use scripts/release.sh to cut releases."
+            fail=1
+          fi
+
+          status=$(grep -oE '^\*\*Current Status\*\*: Pre-1\.0 \(v[^)]+\)' README.md | head -1 | sed -E 's/.*\(v(.*)\)/\1/')
+          if [ "$status" != "$VERSION" ]; then
+            echo "::error::README status line says 'Pre-1.0 (v$status)' but the tag is '$VERSION'. Use scripts/release.sh to cut releases."
+            fail=1
+          fi
+
           # CHANGELOG must have a section header for this version.
           if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Use scripts/release.sh to cut releases."

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer, [@scttfrdmn](https://github.com/scttfrdmn), who is the community leader responsible for enforcement, using the contact details on that GitHub profile. If a report concerns the maintainer, or you would rather not contact them directly, use GitHub's [report abuse](https://github.com/contact/report-abuse) form instead. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,12 +175,12 @@ oidc-pam/
 ├── internal/              # Private application code
 │   ├── adminapi/          # Admin request/response shapes
 │   ├── brokerclient/      # Broker IPC client and device-flow completion
-│   └── ipc/               # Broker IPC server and request validation
+│   ├── ipc/               # Broker IPC server and request validation
+│   └── testoidc/          # In-process fake OIDC issuer, for tests
 ├── test/                  # Test support
-│   ├── config/            # Test configuration
 │   ├── docker/            # Dockerfile.verify (Linux toolchain for cgo)
-│   ├── integration/       # Keycloak-backed harness (build tag `integration`)
-│   └── keycloak/          # Keycloak realm for manual end-to-end runs
+│   ├── e2e/               # SSH + PAM harness against a fake issuer, in containers
+│   └── scripts/           # Shell-level tests (the installers' PAM editing)
 ├── docs/                  # Documentation (docs/design/ is unmaintained; see its index)
 ├── scripts/               # Build, install and verification scripts
 └── configs/               # Configuration examples
@@ -237,27 +237,26 @@ test(integration): add end-to-end authentication tests
 - Mock external dependencies
 - Aim for high test coverage
 
+Name a test after the invariant it holds, not after the function it calls, and
+say what breaks if it fails. `TestAcquireAuth` tells a reader nothing when it goes
+red; `TestAnOversizedConcurrencyCapIsStillACap` tells them a configured limit
+stopped limiting. That is the convention in this repository — about 500 of its
+tests are named that way — and it is why a failing run is readable without
+opening the test.
+
 ```go
-func TestTokenManager_ValidateToken(t *testing.T) {
-    tests := []struct {
-        name    string
-        token   string
-        want    bool
-        wantErr bool
-    }{
-        {
-            name:    "valid token",
-            token:   "valid.jwt.token",
-            want:    true,
-            wantErr: false,
-        },
-        // ... more test cases
-    }
-    
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            // Test implementation
-        })
+// A concurrency cap larger than an int32 must still be a cap. `int32(n)` wrapped
+// it to a negative number, and AcquireAuth reads <= 0 as "limit disabled", so the
+// largest values an operator could write in the config were the ones that removed
+// the limit entirely (#189).
+func TestAnOversizedConcurrencyCapIsStillACap(t *testing.T) {
+    for _, configured := range []int{math.MaxInt32 + 1, math.MaxInt64} {
+        rl := NewRateLimiter(0, configured)
+        if rl.maxConcurrentAuths <= 0 {
+            t.Errorf("max_concurrent_auths=%d became %d, which AcquireAuth treats as no limit at all",
+                configured, rl.maxConcurrentAuths)
+        }
+        rl.Stop()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 📋 Roadmap
 
-### Delivered (through v0.4.0)
+### Delivered (through v0.5.0)
 - [x] OIDC device flow with nonce replay protection
 - [x] PAM module + helper (CGO) and authentication broker
 - [x] SSH key lifecycle management with symlink-safe `authorized_keys` writes
@@ -256,6 +256,9 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - [x] Risk-based policy engine and comprehensive audit logging
 - [x] Prometheus metrics, multi-arch release artifacts (amd64/arm64)
 - [x] Security-audited: AES-256-GCM token encryption, hardened IPC trust boundary
+- [x] Home directories resolved from the account database through NSS, never derived from the login name
+- [x] Key lifetime enforced by sshd itself via `expiry-time=`, so it holds whether or not the broker is running
+- [x] End-to-end suite in CI: real sshd, real PAM stack, real broker, every case an actual SSH login
 
 ### Planned
 - [ ] High availability / multiple broker instances
@@ -321,7 +324,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📈 Status
 
-**Current Status**: Pre-1.0 (v0.4.0) - Under active development
+**Current Status**: Pre-1.0 (v0.5.0) - Under active development
 
 Core functionality is implemented and the codebase has undergone a full security
 audit (all findings remediated). It is not yet recommended for unattended

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,8 +62,6 @@ if ! grep -q 'badge/Version-' README.md; then
   echo "error: could not find version badge in README.md" >&2
   exit 1
 fi
-perl -0pi -e "s{badge/Version-[^-]*(?:-[^-]*)*?-blue}{badge/Version-${VER}-blue}g" README.md
-# Simpler, robust replacement of just the version token between 'Version-' and '-blue':
 perl -0pi -e "s{(badge/Version-)([^)]*?)(-blue)}{\${1}${VER}\${3}}g" README.md
 
 # --- stamp the download snippet's VERSION ------------------------------------
@@ -79,6 +77,25 @@ if ! grep -qE '^VERSION=v[0-9]' README.md; then
   exit 1
 fi
 perl -0pi -e "s{^VERSION=v[0-9][^\n]*}{VERSION=v${VER}}mg" README.md
+
+# --- stamp the two prose version strings -------------------------------------
+# The roadmap heading ("Delivered (through vX.Y.Z)") and the status line
+# ("Current Status: Pre-1.0 (vX.Y.Z)") are where a reader looks to judge how
+# current the document is, and nothing stamped either: both still said v0.4.0
+# two releases later, a few screens below a badge that said 0.5.0. A README that
+# contradicts itself about its own version teaches readers to discount all of it,
+# including the parts that matter — the OpenSSH 7.7 requirement and the warnings
+# about which PAM stacks this must never go into (#147).
+if ! grep -q '^### Delivered (through v' README.md; then
+  echo "error: could not find README's '### Delivered (through vX.Y.Z)' heading" >&2
+  exit 1
+fi
+if ! grep -q '^\*\*Current Status\*\*: Pre-1.0 (v' README.md; then
+  echo "error: could not find README's '**Current Status**: Pre-1.0 (vX.Y.Z)' line" >&2
+  exit 1
+fi
+perl -0pi -e "s{^### Delivered \(through v[^)]*\)}{### Delivered (through v${VER})}mg" README.md
+perl -0pi -e "s{^\*\*Current Status\*\*: Pre-1\.0 \(v[^)]*\)}{**Current Status**: Pre-1.0 (v${VER})}mg" README.md
 
 # --- roll CHANGELOG: insert a new version section below [Unreleased] ---------
 # Turn:


### PR DESCRIPTION
Closes #147.

`CONTRIBUTING.md` and `.github/CODEOWNERS` described a layout the repository had moved away from, and `CONTRIBUTING.md:7` linked a `CODE_OF_CONDUCT.md` that was never written.

**CODEOWNERS.** The `/pkg/policy/` rule outlived the package — #126 moved the policy engine into `/pkg/auth/`. A rule for a path that does not exist matches nothing, so the file read as though the policy engine had a reviewer while the code that replaced it went uncovered. Dropped, with a comment saying why so it does not come back, and added the two paths that were genuinely uncovered: `/internal/ipc/` (the trust boundary every login crosses) and `/pkg/config/` (loads the token encryption key and every client secret).

**CONTRIBUTING.md.** The project tree now matches `ls`. Its release section documented tagging by hand; `scripts/release.sh` has been the only supported path since v0.4.0 and the release workflow now fails a tag whose docs disagree.

**CODE_OF_CONDUCT.md.** Contributor Covenant 2.1, fetched verbatim from the upstream source rather than retyped. The reporting placeholder resolves to the maintainer's GitHub profile, with GitHub's report-abuse form as the alternate route — no email address is invented (`SECURITY.md:30` already hedges its own as "if available"), and there is a reporting path that does not depend on the maintainer for a report that concerns them.

**Two more stamped version strings.** The roadmap heading (`### Delivered (through vX.Y.Z)`) and the status line (`**Current Status**: Pre-1.0 (vX.Y.Z)`) both still said v0.4.0 two releases later, a few screens below a badge reading 0.5.0 — nothing stamped them because nothing checked them. `scripts/release.sh` now stamps both and `verify-version` now reads both back.

Tested in both directions locally: after stamping to 0.5.1 all four extractors in `verify-version` (badge, download snippet, roadmap, status) agree with the tag; with the roadmap left at v0.5.0 and the status at v0.4.9 both checks fire and the job would exit non-zero; and with either line deleted outright `release.sh`'s own guards refuse to run. `shellcheck scripts/release.sh` clean, `bash -n` clean, `release.yml` parses.