### PR TITLE
fix(ipc,systemd): send only what the module can read, and cap the broker's memory (#223)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -516,6 +516,14 @@ ExecStart=/usr/local/bin/oidc-auth-broker --config /etc/oidc-auth/broker.yaml
 Restart=always
 RestartSec=10
 
+# A ceiling on the broker's memory, so that a broker allocating without bound is a
+# broker restart rather than the OOM killer choosing a victim across the whole host.
+# MemoryHigh throttles and forces reclaim first; MemoryMax is the hard stop, and
+# Restart=always brings the broker back. Both are far above the few tens of MiB the
+# broker uses, so reaching either means something is wrong (#223).
+MemoryHigh=384M
+MemoryMax=512M
+
 # Security hardening
 NoNewPrivileges=true
 PrivateTmp=true

--- a/cmd/broker/systemd_unit_test.go
+++ b/cmd/broker/systemd_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -163,6 +164,67 @@ func TestShippedUnitDoesNotAdvertiseAReloadTheBrokerCannotDo(t *testing.T) {
 	}
 }
 
+// The broker is a long-lived root process on a host whose logins all depend on it,
+// and it has no ceiling of its own. Without MemoryMax, a broker allocating without
+// bound is the *host's* problem: the kernel's OOM killer picks a victim across every
+// cgroup, and on a login host the thing it kills may be the reason anyone is logged
+// in. With it, the same runaway is one service being restarted (#223).
+//
+// The value is not asserted — that is tuning, and an operator may have measured a
+// need. What is asserted is that a ceiling exists and is finite, and that MemoryHigh
+// sits below MemoryMax so reclaim is tried before anything is killed.
+func TestShippedUnitPutsACeilingOnTheBrokersMemory(t *testing.T) {
+	settings := shippedUnitSettings(t)
+
+	max, ok := parseMemoryBytes(settings["MemoryMax"])
+	if !ok {
+		t.Fatalf("MemoryMax=%q: the shipped unit must put a finite ceiling on the broker's "+
+			"memory, or a runaway broker takes the whole host's OOM killer with it (#223)",
+			settings["MemoryMax"])
+	}
+
+	high, ok := parseMemoryBytes(settings["MemoryHigh"])
+	if !ok {
+		t.Errorf("MemoryHigh=%q: without it the first thing that happens at the ceiling is a "+
+			"kill, with no reclaim attempted and nothing in the journal leading up to it",
+			settings["MemoryHigh"])
+	} else if high >= max {
+		t.Errorf("MemoryHigh=%q is not below MemoryMax=%q, so the throttle never engages "+
+			"before the kill and serves no purpose", settings["MemoryHigh"], settings["MemoryMax"])
+	}
+}
+
+// parseMemoryBytes reads a systemd memory value. Reports false for the values that
+// mean "no limit" — "infinity", a bare percentage (which is relative to physical
+// memory and so is not a ceiling this test can compare), and anything unparseable.
+func parseMemoryBytes(value string) (int64, bool) {
+	if value == "" || value == "infinity" || strings.HasSuffix(value, "%") {
+		return 0, false
+	}
+
+	multipliers := []struct {
+		suffix string
+		scale  int64
+	}{
+		{"K", 1 << 10}, {"M", 1 << 20}, {"G", 1 << 30}, {"T", 1 << 40},
+	}
+	digits, scale := value, int64(1)
+	for _, m := range multipliers {
+		// systemd accepts K/M/G/T and the KB/MB/… spellings, all base 1024.
+		for _, suffix := range []string{m.suffix, m.suffix + "B"} {
+			if strings.HasSuffix(value, suffix) {
+				digits, scale = strings.TrimSuffix(value, suffix), m.scale
+			}
+		}
+	}
+
+	n, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n * scale, true
+}
+
 // The unit in DEPLOYMENT.md must not drift from the one this repo installs.
 //
 // An operator who follows the deployment guide types that unit in by hand rather
@@ -199,6 +261,8 @@ func TestTheDocumentedUnitAgreesWithTheShippedOne(t *testing.T) {
 		"CapabilityBoundingSet", // #202: CAP_CHOWN or every provisioning fails
 		"ProtectSystem",         // the hardening that must not quietly come off
 		"NoNewPrivileges",
+		"MemoryMax",  // #223: a runaway broker must not be the host's OOM problem
+		"MemoryHigh", //
 	} {
 		if documented[setting] != shipped[setting] {
 			t.Errorf("DEPLOYMENT.md has %s=%q where the shipped unit has %q. An operator who "+

--- a/configs/systemd/oidc-auth-broker.service
+++ b/configs/systemd/oidc-auth-broker.service
@@ -34,6 +34,25 @@ TimeoutStopSec=30s
 Restart=always
 RestartSec=10s
 
+# A ceiling on the broker's memory, so that a broker allocating without bound is a
+# broker restart rather than the kernel's OOM killer choosing a victim across the
+# whole host — which on a login host is a worse outage than the one it resolves, and
+# is not a choice this service gets to make for everything else running there (#223).
+#
+# MemoryHigh comes first on purpose: it throttles the cgroup and pushes reclaim at
+# 384M, so a broker growing slowly is slowed and logged before anything is killed.
+# MemoryMax at 512M is the hard stop, and Restart=always brings the broker back
+# RestartSec later. Both are far above what the broker uses — a few tens of MiB with
+# the sessions of a busy host in it — so reaching either means something is wrong,
+# not that the host is busy. Raise them together if you have measured a need.
+#
+# Every JSON body the broker reads from a provider is separately bounded at 64 KiB
+# (maxProviderResponseBytes, pkg/auth/device_flow.go), which is what closes the path
+# that motivated this: an issuer that can answer with an unbounded body. This is the
+# backstop for everything nobody has bounded yet.
+MemoryHigh=384M
+MemoryMax=512M
+
 # Security settings
 NoNewPrivileges=true
 PrivateTmp=true

--- a/internal/ipc/response.go
+++ b/internal/ipc/response.go
@@ -33,6 +33,24 @@ import (
 // module's buffer.
 const maxResponseSize = 16384
 
+// maxResponseWire is the largest newline-terminated message the module can actually
+// read out of that buffer, which is one byte less than the buffer itself.
+//
+// receive_auth_response_within reserves the final byte for the NUL it writes
+// (`const size_t cap = response_size - 1`, cgo_bridge_linux.c), loops while
+// `total < cap`, and then refuses a full buffer with no newline in it as "the
+// beginning of a response, not a response". So the newline has to arrive within the
+// first maxResponseSize-1 bytes, and a message of exactly maxResponseSize bytes is
+// one byte too long however the broker feels about it.
+//
+// Bounding the wire message at maxResponseSize instead was the off-by-one in #223:
+// a response at exactly the limit passed fitsModuleBuffer, was sent whole, and came
+// back RECV_RESPONSE_TOO_LARGE from the module — the #162 failure reproduced at the
+// one size the cap was supposed to make safe. It is the boundary and nothing else,
+// which is why it survived: every response anyone had looked at was kilobytes clear
+// of it, and the only way to hit it is to land on it exactly.
+const maxResponseWire = maxResponseSize - 1
+
 // setDeviceInstructions renders the device-flow instructions into response,
 // dropping the QR art if the response would not otherwise fit the PAM module's
 // buffer.
@@ -66,13 +84,13 @@ func fitsModuleBuffer(response *Response) bool {
 		// writeResponse will report the encoding failure.
 		return false
 	}
-	return len(payload)+1 <= maxResponseSize
+	return len(payload)+1 <= maxResponseWire
 }
 
 // writeResponse writes one newline-delimited JSON response.
 //
 // Responses to the PAM module (*Response) are additionally bounded by
-// maxResponseSize: rather than a truncated prefix the module cannot parse, an
+// maxResponseWire: rather than a truncated prefix the module cannot parse, an
 // oversized response is replaced by a small RESPONSE_TOO_LARGE failure, which the
 // module maps to a distinct PAM result and which says in the broker log how big
 // the response was.
@@ -83,10 +101,10 @@ func (s *Server) writeResponse(conn net.Conn, response any) {
 		return
 	}
 
-	if _, forModule := response.(*Response); forModule && len(payload)+1 > maxResponseSize {
+	if _, forModule := response.(*Response); forModule && len(payload)+1 > maxResponseWire {
 		log.Error().
 			Int("response_size", len(payload)+1).
-			Int("max_response_size", maxResponseSize).
+			Int("max_response_size", maxResponseWire).
 			Msg("Response does not fit the PAM module's buffer; sending RESPONSE_TOO_LARGE instead of a truncated response")
 
 		payload, err = json.Marshal(&Response{

--- a/internal/ipc/response_size_test.go
+++ b/internal/ipc/response_size_test.go
@@ -20,7 +20,15 @@ import (
 // two, the broker would happily send responses that arrive truncated — which is
 // exactly #162, and it produced nothing in syslog but "Failed to parse broker
 // response" on every login.
-func TestResponseSizeMatchesTheModulesBuffer(t *testing.T) {
+// moduleBufferSize reads MAX_RESPONSE_SIZE out of the module's header.
+//
+// Deliberately not cgo: this has to run on a developer's Mac, where the module
+// itself cannot be compiled (#141). Reading the header is also the point — a test
+// that used the Go constant for both sides would agree with itself no matter what
+// either value was.
+func moduleBufferSize(t *testing.T) int {
+	t.Helper()
+
 	const header = "../../cmd/pam-module/cgo_bridge.h"
 
 	data, err := os.ReadFile(header)
@@ -28,20 +36,23 @@ func TestResponseSizeMatchesTheModulesBuffer(t *testing.T) {
 		t.Fatalf("read %s: %v", header, err)
 	}
 
-	// Deliberately not cgo: this has to run on a developer's Mac, where the module
-	// itself cannot be compiled (#141).
 	match := regexp.MustCompile(`(?m)^#define\s+MAX_RESPONSE_SIZE\s+(\d+)`).FindSubmatch(data)
 	if match == nil {
 		t.Fatalf("no MAX_RESPONSE_SIZE definition in %s; if it was renamed, update this test — "+
 			"the two sizes must stay equal", header)
 	}
 
-	moduleBuffer, err := strconv.Atoi(string(match[1]))
+	size, err := strconv.Atoi(string(match[1]))
 	if err != nil {
 		t.Fatalf("MAX_RESPONSE_SIZE is not a number: %v", err)
 	}
+	return size
+}
 
-	if moduleBuffer != maxResponseSize {
+func TestResponseSizeMatchesTheModulesBuffer(t *testing.T) {
+	const header = "../../cmd/pam-module/cgo_bridge.h"
+
+	if moduleBuffer := moduleBufferSize(t); moduleBuffer != maxResponseSize {
 		t.Errorf("MAX_RESPONSE_SIZE in %s is %d but maxResponseSize is %d; the broker must not send "+
 			"more than the module can read", header, moduleBuffer, maxResponseSize)
 	}
@@ -224,6 +235,88 @@ func TestWriteResponseReplacesAnOversizedResponse(t *testing.T) {
 	}
 	if got.Success {
 		t.Error("an oversized response was replaced by a success")
+	}
+	if got.ErrorCode != "RESPONSE_TOO_LARGE" {
+		t.Errorf("error_code = %q, want RESPONSE_TOO_LARGE", got.ErrorCode)
+	}
+}
+
+// responseOfExactWireSize returns a response whose marshalled form plus its
+// terminating newline is exactly want bytes, padding Instructions to get there.
+func responseOfExactWireSize(t *testing.T, want int) *Response {
+	t.Helper()
+
+	response := &Response{Success: true, SessionID: "sess-1"}
+	payload, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// One ASCII byte of Instructions costs one byte of JSON; the field itself costs
+	// the key, the quotes and the comma, which is why the padding is measured rather
+	// than computed.
+	response.Instructions = ""
+	for pad := want - (len(payload) + 1); pad > 0; pad-- {
+		response.Instructions = strings.Repeat("Q", pad)
+		payload, err = json.Marshal(response)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if len(payload)+1 == want {
+			return response
+		}
+	}
+	t.Fatalf("could not build a response of exactly %d wire bytes", want)
+	return nil
+}
+
+// The boundary itself, in both directions (#223).
+//
+// The module reserves the last byte of its buffer for the NUL it writes, so it reads
+// at most MAX_RESPONSE_SIZE-1 bytes and needs the newline inside them. A response of
+// exactly MAX_RESPONSE_SIZE bytes therefore arrives as a full buffer with no end of
+// message in it, which the module refuses — the #162 failure, at the one size the cap
+// was meant to make safe. The broker used to send it: this pins the last size it may.
+func TestTheLargestResponseTheBrokerSendsIsOneTheModuleCanRead(t *testing.T) {
+	// Derived from the header, not from maxResponseWire: the whole bug was the Go
+	// side's idea of the limit disagreeing with what the C side can read, and a test
+	// that asked the Go constant about itself would have passed either way.
+	readable := moduleBufferSize(t) - 1 // the module reserves the last byte for its NUL
+
+	atLimit := responseOfExactWireSize(t, readable)
+	if !fitsModuleBuffer(atLimit) {
+		t.Errorf("a %d-byte response is rejected, but that is exactly what the module can read: "+
+			"the broker is degrading responses it did not need to", readable)
+	}
+
+	// One byte more is the first size the module cannot read out of its buffer, and
+	// is also the size the broker sent before #223.
+	overLimit := responseOfExactWireSize(t, readable+1)
+	if fitsModuleBuffer(overLimit) {
+		t.Errorf("a %d-byte response is treated as fitting, but the module reads at most %d bytes "+
+			"of its %d-byte buffer and would find no newline in them",
+			readable+1, readable, moduleBufferSize(t))
+	}
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	go func() {
+		defer func() { _ = server.Close() }()
+		(&Server{}).writeResponse(server, overLimit)
+	}()
+
+	payload, err := readOneResponse(client)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	// +1 for the newline readOneResponse stripped: what went on the wire.
+	if len(payload)+1 > readable {
+		t.Fatalf("writeResponse put %d bytes on the wire, over the %d the module can read",
+			len(payload)+1, readable)
+	}
+	var got Response
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("the module would fail to parse what was sent: %v", err)
 	}
 	if got.ErrorCode != "RESPONSE_TOO_LARGE" {
 		t.Errorf("error_code = %q, want RESPONSE_TOO_LARGE", got.ErrorCode)


### PR DESCRIPTION
Closes #223 — the two remaining parts. Part 1 (unbounded provider HTTP bodies) landed in #249, which routes every provider body through one helper bounded at 64 KiB.

## The response cap was off by one, in the direction that matters

The module reads into a `MAX_RESPONSE_SIZE` buffer but reserves the last byte for the NUL it writes. `receive_auth_response_within` sets `const size_t cap = response_size - 1`, loops `while (total < cap)`, and then refuses a full buffer with no newline in it as "the beginning of a response, not a response" (`cgo_bridge_linux.c:383`, `:453`). So the newline has to arrive within the first 16383 bytes.

The broker bounded the wire message at 16384 and sent it — one byte more than the module can ever see. A response at exactly the limit passed `fitsModuleBuffer`, went out whole, and came back `RECV_RESPONSE_TOO_LARGE`: the #162 failure reproduced at the one size the cap existed to make safe.

`maxResponseWire = maxResponseSize - 1` is now what the broker enforces, and the constant documents where the `-1` comes from and which C lines it is derived from.

It is only reachable by landing on the boundary exactly, which is why it survived — the worst-case device response the broker's own validation permits is 16343 bytes, 40 clear of the limit.

## The unit had no memory ceiling

The broker is a long-lived root process every login depends on. Without `MemoryMax`, a broker allocating without bound is the *host's* problem: the OOM killer picks a victim across every cgroup, and on a login host that may be the reason anyone is logged in. `MemoryHigh=384M` forces reclaim first, `MemoryMax=512M` is the hard stop, and `Restart=always` brings the broker back. Both sit far above the few tens of MiB the broker uses, so reaching either means something is wrong rather than that the host is busy.

Added to `DEPLOYMENT.md`'s copy as well. An operator who follows the guide types that unit in by hand, so a setting only in `configs/systemd/` has not shipped — the same drift that gave guide-built hosts #202 and #211 — and both keys are now in the list `TestTheDocumentedUnitAgreesWithTheShippedOne` compares.

## Tests

`TestTheLargestResponseTheBrokerSendsIsOneTheModuleCanRead` pins both sides: a response of exactly the readable size must fit, one byte more must not, and `writeResponse` must replace it with a parseable `RESPONSE_TOO_LARGE`.

It derives the size from `MAX_RESPONSE_SIZE` **in the header**, not from the Go constant. My first version used `maxResponseWire` for both the fixture and the assertion, so it agreed with itself and passed against the unfixed code — I caught that by reverting the constant and re-running. Mutating `maxResponseWire` back to `maxResponseSize` now fails it with `a 16384-byte response is treated as fitting, but the module reads at most 16383 bytes of its 16384-byte buffer`.

`TestShippedUnitPutsACeilingOnTheBrokersMemory` asserts a finite ceiling exists and that `MemoryHigh` is below `MemoryMax`, deliberately not the values — those are tuning an operator may have measured a need to change. It treats `infinity` and a bare percentage as no ceiling.

`gofmt`, `go build`, `go vet` and `go test ./... -count=1` all clean.