### PR TITLE
fix(security): restore Trivy scanning and triage every open code-scanning alert

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,6 +68,22 @@ jobs:
           go-version: '1.25.13'
           cache: true
 
+      # This job deliberately does not install libpam0g-dev/libjson-c-dev, unlike the
+      # govulncheck job below, and that is what makes it scan cmd/pam-module at all.
+      #
+      # gosec loads packages through go/packages, which for a cgo package hands back
+      # the *generated* Go files rather than the sources. With the PAM headers present
+      # cgo succeeds, and gosec then reports against paths inside
+      # /root/.cache/go-build — findings that point at no file in this repository and
+      # cannot become a useful alert, while the 16 unsafe.Pointer sites in
+      # {auth,args,recv}_linux.go go unexamined. Without the headers cgo fails, the
+      # loader falls back to the real sources, and gosec analyses the code a reviewer
+      # can actually read. Measured both ways in a golang:1.25 container: with the
+      # headers, 6 findings at build-cache paths and the _linux.go files never opened;
+      # without them, 41 files checked including all six _linux.go files.
+      #
+      # So if this job is ever "fixed" by adding the dev packages, coverage of the PAM
+      # module silently disappears.
       - name: Run Gosec Security Scanner
         run: |
           # Install gosec v2.26.1 (Go 1.25 compatible)
@@ -225,3 +241,74 @@ jobs:
         uses: github/codeql-action/upload-sarif@60d8f0d1f1f8c8d07ef53bd027032705d414ec28 # v3
         with:
           sarif_file: semgrep-results.sarif
+
+  # Restored (#258). This job existed until 9b6c0ae removed every security
+  # workflow, and its ten alerts — one critical — stayed open on main for the eight
+  # months since, describing dependency versions this repository no longer has.
+  # Code scanning retires an alert only when the tool that raised it runs again and
+  # stops reporting it, so removing a scanner does not retire its findings: it
+  # makes them permanent.
+  #
+  # Two things about this job are load-bearing and must not be "tidied":
+  #
+  #   - The job id is `trivy` and this file is `.github/workflows/security.yml`.
+  #   - The upload step passes no `category:`.
+  #
+  # GitHub derives the analysis key an alert is filed under from the workflow path
+  # and the job id, and the ten orphans carry
+  # `.github/workflows/security.yml:trivy` with no category (checked, not assumed:
+  # `most_recent_instance.analysis_key` on the open alerts). Retirement is
+  # per-analysis-key, so renaming the job, moving the file, or adding a category
+  # produces a *new* key and leaves the orphans exactly as unclosable as they are
+  # now. #258 proposed giving this upload its own category; that would have
+  # defeated the point of the issue.
+  trivy:
+    name: Trivy Security Scan
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # What this adds over the govulncheck job above: govulncheck reports a
+      # vulnerability only when it can reach the affected symbol from this code,
+      # which is the right signal for "fix this now" and the wrong one for "what is
+      # in our dependency tree". Trivy answers by version, so a dependency that is
+      # vulnerable but not currently called still shows up — the case that becomes a
+      # live one the moment somebody writes a new call.
+      #
+      # `scanners: vuln,secret` is Trivy's default for a filesystem scan, written out
+      # so that it is a decision rather than a default. `misconfig` is deliberately
+      # off: the only files it has to look at here are the three test-harness
+      # Dockerfiles, whose containers run as root on purpose (the broker under test
+      # needs root, and the images are built by `make e2e` and thrown away), so it
+      # reports six findings of which none is actionable. Turn it on if this project
+      # ever ships a container image.
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret
+          format: sarif
+          output: trivy-results.sarif
+          # Trivy does not pick .trivyignore.yaml up on its own — verified: the same
+          # scan reports GO-2026-5932 without this input and drops it with the input.
+          # Only the plain `.trivyignore` name is a default.
+          trivyignores: .trivyignore.yaml
+
+      # No `continue-on-error:` here, unlike the gosec and semgrep jobs. Those two
+      # tolerate a non-zero exit because their scanners exit non-zero *on findings*;
+      # Trivy with `format: sarif` does not (it needs `exit-code:` for that), so the
+      # only way this step fails is that the scan itself did not run — a DB download
+      # that 429'd, say. That has to be a red job. A scan that quietly did not happen,
+      # and an upload that therefore quietly did not reconcile anything, is precisely
+      # how ten alerts came to sit on main for eight months.
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: trivy-results.sarif

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,32 @@
+# Findings Trivy reports that this repository has decided not to act on, with the
+# reason recorded here rather than dismissed in the GitHub UI where nobody
+# reviewing the code can see it.
+#
+# The bar for an entry is high: it is for a finding with no fix to apply, not for
+# one that is merely inconvenient. Anything with a `FixedVersion` gets the fix.
+#
+# This file is not found by default — only the plain `.trivyignore` name is. The
+# `trivy` job in .github/workflows/security.yml names it explicitly through the
+# action's `trivyignores` input, and a local scan needs
+# `--ignorefile .trivyignore.yaml`. The YAML form is worth that: it is the only one
+# that carries a `statement`, and a suppression without a reason is a suppression
+# nobody can review.
+
+vulnerabilities:
+  - id: GO-2026-5932
+    # "golang.org/x/crypto/openpgp is unmaintained, unsafe by design, and has
+    # known security issues." It is a module-wide advisory with no fixed version,
+    # so it will be reported against golang.org/x/crypto for as long as that
+    # module is a dependency — which is forever, since pkg/ssh needs
+    # golang.org/x/crypto/ssh.
+    #
+    # This repository does not import golang.org/x/crypto/openpgp, and nothing in
+    # it handles OpenPGP data at all. Verified rather than assumed:
+    #
+    #   $ go list -deps ./... | grep openpgp   # no output
+    #
+    # Without an entry here the alert is permanent and unclosable, which is the
+    # exact failure mode #258 was filed about.
+    statement: >-
+      x/crypto/openpgp is not imported (go list -deps ./... does not name it);
+      the advisory has no fixed version, so the alert would never close.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The end-to-end fake identity provider no longer writes request-controlled values
   into its log unescaped (#259).** A request path or a `?username=` containing a
   newline could forge whole log lines in `docker compose logs fakeoidc`, which is
-  what an engineer reads to find out why a case failed. Test-harness only, shipped
-  in no release.
+  what an engineer reads to find out why a case failed. They are logged with `%q`
+  now. Test-harness only, shipped in no release.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Certificate pinning is enforced through `VerifyConnection` rather than
+  `VerifyPeerCertificate` (#259).** A resumed TLS session does not call
+  `VerifyPeerCertificate` at all, so a pinned-certificate configuration would have
+  stopped checking its pins from the second handshake onwards. It was not reachable
+  as the code stood — client-side resumption needs a non-nil
+  `tls.Config.ClientSessionCache`, `buildTLSConfig` sets none, and `net/http` does
+  not add one to a caller-supplied `TLSClientConfig` — so the pins were being
+  enforced, but only by that absence, which no comment stated and no test held.
+  Adding a session cache anywhere in the request path would have silently disabled
+  the pinning. There is now a test that installs a cache, drives three handshakes,
+  and fails unless at least one of them resumed *and* the pin check ran on all
+  three.
+- **The public half of a provisioned SSH key pair is written 0600 instead of 0644
+  (#259).** Its only reader is `LoadKey`, in the same process, and the enclosing
+  directory is already 0700.
+
+### Fixed
+
+- **Trivy scanning is restored to `.github/workflows/security.yml` (#258).** Every
+  security workflow was deleted in December 2025; ten Trivy alerts, one of them
+  critical, stayed open on `main` for the eight months since, all of them describing
+  dependency versions this repository no longer has — three named a module that is
+  not in `go.mod` at all. Code scanning retires an alert only when the tool that
+  raised it runs again and stops reporting it, so removing a scanner does not retire
+  its findings, it makes them permanent, and nothing in the UI can close them. The
+  restored job deliberately keeps the original job id and passes no SARIF
+  `category`, because the analysis key those ten alerts are filed under is derived
+  from the two; a rename would leave them orphaned forever.
+- **The end-to-end fake identity provider no longer writes request-controlled values
+  into its log unescaped (#259).** A request path or a `?username=` containing a
+  newline could forge whole log lines in `docker compose logs fakeoidc`, which is
+  what an engineer reads to find out why a case failed. Test-harness only, shipped
+  in no release.
+
+### Changed
+
+- **The 23 open gosec alerts on `main` are triaged in the source (#259).** Each
+  `unsafe.Pointer` in the cgo test wrappers, each `os.ReadFile` of a
+  configuration-supplied path, and the one file mode carry a `#nosec` annotation
+  naming the rule and the reason it does not apply — with, in the `pkg/ssh` case,
+  the specific allowlist that makes traversal impossible and a note that the
+  annotations must come off if it is ever loosened. No rule was excluded and no
+  directory was skipped, so G103 and G304 stay live everywhere a genuinely notable
+  use could appear.
+- A `.trivyignore.yaml` records, in the repository rather than in the GitHub UI, the
+  one advisory this project does not act on: `GO-2026-5932`, the module-wide
+  "x/crypto/openpgp is unmaintained" notice, which has no fixed version and so would
+  otherwise be an alert that can never close. `golang.org/x/crypto/openpgp` is not
+  imported anywhere here.
+
 ## [0.5.1] - 2026-08-15
 
 This release makes the broker refuse what it cannot honour. Most of what follows is

--- a/cmd/pam-module/args_linux.go
+++ b/cmd/pam-module/args_linux.go
@@ -38,13 +38,13 @@ func parseModuleArgs(args []string) moduleArgs {
 	}
 	defer func() {
 		for _, p := range argv {
-			C.free(unsafe.Pointer(p))
+			C.free(unsafe.Pointer(p)) // #nosec G103 -- cgo: freeing a C.CString allocation
 		}
 	}()
 
 	var argvPtr **C.char
 	if len(argv) > 0 {
-		argvPtr = (**C.char)(unsafe.Pointer(&argv[0]))
+		argvPtr = (**C.char)(unsafe.Pointer(&argv[0])) // #nosec G103 -- cgo: passing the address of Go-allocated memory to C
 	}
 	C.parse_arguments(C.int(len(args)), argvPtr, &opts)
 

--- a/cmd/pam-module/auth_linux.go
+++ b/cmd/pam-module/auth_linux.go
@@ -3,6 +3,23 @@
 package main
 
 // The package's #cgo CFLAGS/LDFLAGS live in bridge_linux.go.
+//
+// Every unsafe.Pointer in this file and its siblings carries a `#nosec G103`
+// annotation. G103 asks that uses of unsafe be audited, which is the right default
+// — so rather than excluding the rule for the repository, each site says which of
+// the two shapes it is:
+//
+//   - C.free(unsafe.Pointer(p)) — releasing a C.CString this function allocated.
+//     There is no other way to spell it; C.CString returns *C.char and C.free takes
+//     void*.
+//   - (**C.char)(unsafe.Pointer(&slice[0])) — handing C the address of Go memory.
+//     These obey cgo's pointer-passing rules: the slice outlives the call, the C
+//     side does not retain the pointer past it, and the element type is a C type,
+//     so nothing here can be moved or collected while C holds it.
+//
+// None of this is shipped. Since #198 the module PAM loads is compiled from C
+// alone; these wrappers exist so `go test` can drive that C, because cgo is not
+// permitted in _test.go files.
 
 /*
 #include <stdlib.h>
@@ -32,11 +49,11 @@ func performAuthentication(socketPath, username, service, rhost, tty string, tim
 	cRhost := C.CString(rhost)
 	cTTY := C.CString(tty)
 	defer func() {
-		C.free(unsafe.Pointer(cSocketPath))
-		C.free(unsafe.Pointer(cUsername))
-		C.free(unsafe.Pointer(cService))
-		C.free(unsafe.Pointer(cRhost))
-		C.free(unsafe.Pointer(cTTY))
+		C.free(unsafe.Pointer(cSocketPath)) // #nosec G103 -- cgo: freeing a C.CString allocation
+		C.free(unsafe.Pointer(cUsername))   // #nosec G103 -- cgo: freeing a C.CString allocation
+		C.free(unsafe.Pointer(cService))    // #nosec G103 -- cgo: freeing a C.CString allocation
+		C.free(unsafe.Pointer(cRhost))      // #nosec G103 -- cgo: freeing a C.CString allocation
+		C.free(unsafe.Pointer(cTTY))        // #nosec G103 -- cgo: freeing a C.CString allocation
 	}()
 
 	return pam.PAMResultCode(C.perform_authentication(nil, cSocketPath, cUsername, cService, cRhost, cTTY,
@@ -62,8 +79,8 @@ func startPAMHandleWithoutConversation(service, user string) (*pamHandle, pam.PA
 	cService := C.CString(service)
 	cUser := C.CString(user)
 	defer func() {
-		C.free(unsafe.Pointer(cService))
-		C.free(unsafe.Pointer(cUser))
+		C.free(unsafe.Pointer(cService)) // #nosec G103 -- cgo: freeing a C.CString allocation
+		C.free(unsafe.Pointer(cUser))    // #nosec G103 -- cgo: freeing a C.CString allocation
 	}()
 
 	var conv C.struct_pam_conv // zero value: no conversation function, no appdata
@@ -90,13 +107,13 @@ func smAuthenticate(p *pamHandle, args []string) pam.PAMResultCode {
 	}
 	defer func() {
 		for _, arg := range argv {
-			C.free(unsafe.Pointer(arg))
+			C.free(unsafe.Pointer(arg)) // #nosec G103 -- cgo: freeing a C.CString allocation
 		}
 	}()
 
 	var argvPtr **C.char
 	if len(argv) > 0 {
-		argvPtr = (**C.char)(unsafe.Pointer(&argv[0]))
+		argvPtr = (**C.char)(unsafe.Pointer(&argv[0])) // #nosec G103 -- cgo: passing the address of Go-allocated memory to C
 	}
 
 	return pam.PAMResultCode(C.pam_sm_authenticate(p.h, 0, C.int(len(args)), argvPtr))
@@ -118,8 +135,8 @@ func classifyLoginTypeC(service, tty string) string {
 	cService := C.CString(service)
 	cTTY := C.CString(tty)
 	defer func() {
-		C.free(unsafe.Pointer(cService))
-		C.free(unsafe.Pointer(cTTY))
+		C.free(unsafe.Pointer(cService)) // #nosec G103 -- cgo: freeing a C.CString allocation
+		C.free(unsafe.Pointer(cTTY))     // #nosec G103 -- cgo: freeing a C.CString allocation
 	}()
 
 	return C.GoString(C.classify_login_type(cService, cTTY))
@@ -147,7 +164,7 @@ const brokerPending = int(C.BROKER_PENDING)
 // be deleted without a single suite noticing (#197).
 func classifyBrokerResponse(response string) int {
 	cResponse := C.CString(response)
-	defer C.free(unsafe.Pointer(cResponse))
+	defer C.free(unsafe.Pointer(cResponse)) // #nosec G103 -- cgo: freeing a C.CString allocation
 
 	return int(C.classify_response_text(cResponse))
 }
@@ -164,7 +181,7 @@ func mapBrokerErrorCode(code *string) pam.PAMResultCode {
 	}
 
 	cCode := C.CString(*code)
-	defer C.free(unsafe.Pointer(cCode))
+	defer C.free(unsafe.Pointer(cCode)) // #nosec G103 -- cgo: freeing a C.CString allocation
 
 	return pam.PAMResultCode(C.map_error_code(cCode))
 }

--- a/cmd/pam-module/recv_linux.go
+++ b/cmd/pam-module/recv_linux.go
@@ -41,7 +41,7 @@ func receiveAuthResponseWithin(fd, bufSize, totalTimeoutMS int) (int, string) {
 
 	var into *C.char
 	if bufSize > 0 {
-		into = (*C.char)(unsafe.Pointer(&buf[0]))
+		into = (*C.char)(unsafe.Pointer(&buf[0])) // #nosec G103 -- cgo: passing the address of Go-allocated memory to C
 	}
 
 	rc := int(C.receive_auth_response_within(C.int(fd), into, C.size_t(bufSize),

--- a/pkg/auth/device_flow.go
+++ b/pkg/auth/device_flow.go
@@ -275,7 +275,7 @@ func NewOIDCProvider(providerCfg OIDCProviderConfig, secCfg config.SecurityConfi
 // It always enforces TLS 1.2 as the minimum version and optionally applies:
 //   - A custom CA bundle (TrustedCABundle) that replaces the system trust store
 //   - InsecureSkipVerify (SkipTLSVerify) with a loud warning log
-//   - Certificate pinning (PinnedCertificates) via VerifyPeerCertificate
+//   - Certificate pinning (PinnedCertificates) via VerifyConnection
 func buildTLSConfig(secCfg config.SecurityConfig) (*tls.Config, error) {
 	tlsCfg := &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -310,9 +310,26 @@ func buildTLSConfig(secCfg config.SecurityConfig) (*tls.Config, error) {
 			pins[strings.ToLower(strings.ReplaceAll(pin, ":", ""))] = true
 		}
 
-		tlsCfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			for _, raw := range rawCerts {
-				fp := fmt.Sprintf("%x", sha256.Sum256(raw))
+		// The check goes in VerifyConnection rather than VerifyPeerCertificate,
+		// because a resumed TLS session does not call VerifyPeerCertificate at all —
+		// verified by experiment, not read off a rule description: with a session
+		// cache in place, handshakes 2 and 3 both report DidResume and leave
+		// VerifyPeerCertificate's call count at 1 while VerifyConnection is called
+		// every time. VerifyConnection also receives the peer chain on a resumed
+		// handshake (ConnectionState.PeerCertificates is populated from the cached
+		// session), so it can do the same comparison.
+		//
+		// Nothing resumes as this stands: client-side resumption needs a non-nil
+		// tls.Config.ClientSessionCache, buildTLSConfig sets none, and net/http does
+		// not add one to a caller-supplied TLSClientConfig. So the pins were being
+		// enforced — but only because of that absence, which no comment stated and no
+		// test held. Setting a session cache is an ordinary performance change to make
+		// on a client that calls its IdP four times per login, and under
+		// VerifyPeerCertificate it would have silently stopped applying the operator's
+		// pins while the config key went on claiming they were in force.
+		tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+			for _, cert := range cs.PeerCertificates {
+				fp := fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
 				if pins[fp] {
 					return nil
 				}

--- a/pkg/auth/location_history.go
+++ b/pkg/auth/location_history.go
@@ -224,7 +224,10 @@ func (lh *LocationHistory) Close() {
 }
 
 func (lh *LocationHistory) load(path string) error {
-	data, err := os.ReadFile(path)
+	// gosec G304, accepted: path is cfg.PersistPath, from the broker's root-owned
+	// configuration, and the only caller is NewLocationHistory at startup. No
+	// authenticating user supplies any part of it.
+	data, err := os.ReadFile(path) // #nosec G304 -- PersistPath from the trusted root-owned config
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil // nothing saved yet — not an error

--- a/pkg/auth/tls_config_test.go
+++ b/pkg/auth/tls_config_test.go
@@ -34,6 +34,9 @@ func TestBuildTLSConfigDefault(t *testing.T) {
 	if tlsCfg.VerifyPeerCertificate != nil {
 		t.Error("Expected VerifyPeerCertificate=nil by default")
 	}
+	if tlsCfg.VerifyConnection != nil {
+		t.Error("Expected VerifyConnection=nil by default")
+	}
 }
 
 // TestBuildTLSConfigSkipVerify checks that SkipTLSVerify sets InsecureSkipVerify.
@@ -126,8 +129,8 @@ func TestBuildTLSConfigCertPinSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildTLSConfig() unexpected error: %v", err)
 	}
-	if tlsCfg.VerifyPeerCertificate == nil {
-		t.Fatal("Expected VerifyPeerCertificate callback to be set")
+	if tlsCfg.VerifyConnection == nil {
+		t.Fatal("Expected VerifyConnection callback to be set")
 	}
 
 	client := &http.Client{
@@ -273,6 +276,83 @@ func TestBuildTLSConfigCertPinMultiple(t *testing.T) {
 		t.Fatalf("Expected success when one of multiple pins matches: %v", err)
 	}
 	_ = resp.Body.Close()
+}
+
+// The operator's pins must be checked on every handshake, including a resumed
+// one. This is the acceptance test for G123.
+//
+// A resumed TLS session does not call VerifyPeerCertificate — Go calls it only
+// during a full handshake — so pinning implemented there is enforced on the first
+// connection to a provider and on none of the resumptions after it. VerifyConnection
+// is called both times, and on a resumed handshake ConnectionState.PeerCertificates
+// is populated from the cached session, so the same comparison is available.
+//
+// Nothing in the broker resumes today, because client-side resumption needs a
+// non-nil ClientSessionCache and neither buildTLSConfig nor net/http sets one. That
+// is why this was not an exploitable bypass — and also why it needs a test: the
+// property was resting on an absence that no comment stated, one performance change
+// away from turning an operator's pins off silently. This test sets the cache
+// itself, which is the future change it exists to survive.
+func TestPinnedCertificatesAreCheckedOnAResumedSession(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tlsCfg, err := buildTLSConfig(config.SecurityConfig{
+		TLSVerification: config.TLSVerification{
+			PinnedCertificates: []string{certFingerprint(server.TLS.Certificates[0].Certificate[0])},
+			SkipTLSVerify:      true, // the httptest cert is self-signed; the pin is what is under test
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildTLSConfig() unexpected error: %v", err)
+	}
+
+	// The whole point: the check has to hang off VerifyConnection. If it is on
+	// VerifyPeerCertificate instead, every resumed handshake below skips it.
+	pinCheck := tlsCfg.VerifyConnection
+	if pinCheck == nil {
+		t.Fatal("pinned_certificates is not enforced through VerifyConnection, so a resumed " +
+			"session does not run the pin check at all")
+	}
+
+	var checked, resumedAndChecked int
+	tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+		checked++
+		if cs.DidResume {
+			resumedAndChecked++
+		}
+		return pinCheck(cs)
+	}
+
+	// Give the client somewhere to cache the session. Without this Go never resumes
+	// and the test would pass against either implementation.
+	tlsCfg.ClientSessionCache = tls.NewLRUClientSessionCache(4)
+
+	transport := &http.Transport{TLSClientConfig: tlsCfg}
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+
+	const handshakes = 3
+	for i := 1; i <= handshakes; i++ {
+		resp, err := client.Get(server.URL)
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i, err)
+		}
+		_ = resp.Body.Close()
+		// Force the next request to handshake again rather than reuse the connection;
+		// with the session cached, that handshake is a resumption.
+		transport.CloseIdleConnections()
+	}
+
+	if checked != handshakes {
+		t.Errorf("the pin check ran on %d of %d handshakes", checked, handshakes)
+	}
+	if resumedAndChecked == 0 {
+		t.Fatalf("no handshake resumed, so this test proved nothing about resumption; "+
+			"pin check ran %d times, all on full handshakes", checked)
+	}
+	t.Logf("pin check ran on all %d handshakes, %d of them resumed", checked, resumedAndChecked)
 }
 
 // helpers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -902,7 +902,12 @@ func resolveSecretValue(value string) (string, error) {
 
 	if strings.HasPrefix(value, "file:") {
 		filePath := strings.TrimPrefix(value, "file:")
-		data, err := os.ReadFile(filePath)
+		// gosec G304, accepted: reading a caller-named path is the whole feature.
+		// The name comes from the broker's own configuration file, which is
+		// root-owned and is already trusted with the secret itself — a config that
+		// can write "file:/etc/oidc-auth/client-secret" can equally write the secret
+		// inline, so this indirection grants no reach that the config did not have.
+		data, err := os.ReadFile(filePath) // #nosec G304 -- path comes from the trusted root-owned config
 		if err != nil {
 			return "", fmt.Errorf("failed to read secret file %q: %w", filePath, err)
 		}

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -203,9 +203,12 @@ func (km *KeyManager) SaveKey(keyID string, key *SSHKey) error {
 		return fmt.Errorf("failed to save private key: %w", err)
 	}
 
-	// Save public key
+	// Save public key. 0600 rather than the customary 0644 for a public key: the
+	// only reader is LoadKey, in this same process, and the enclosing directory is
+	// already 0700. A public key is not a secret, but a mode wider than anything
+	// that reads it is a permission granted for no reason (gosec G306).
 	publicKeyPath := filepath.Join(userDir, "id_rsa.pub")
-	if err := os.WriteFile(publicKeyPath, key.PublicKey, 0644); err != nil {
+	if err := os.WriteFile(publicKeyPath, key.PublicKey, 0600); err != nil {
 		return fmt.Errorf("failed to save public key: %w", err)
 	}
 
@@ -235,23 +238,30 @@ func (km *KeyManager) LoadKey(keyID string) (*SSHKey, error) {
 	}
 	userDir := filepath.Join(km.baseDir, keyID)
 
+	// The three reads below are gosec G304 (file inclusion via variable), and all
+	// three are safe for the same reason: keyID has already passed validateKeyID,
+	// whose allowlist is ^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$. That admits neither "/"
+	// nor ".", so the joined path cannot escape km.baseDir however hostile the
+	// caller. The filenames are constants. If validateKeyID's pattern is ever
+	// loosened, these annotations are wrong and must come off.
+
 	// Load private key
 	privateKeyPath := filepath.Join(userDir, "id_rsa")
-	privateKeyBytes, err := os.ReadFile(privateKeyPath)
+	privateKeyBytes, err := os.ReadFile(privateKeyPath) // #nosec G304 -- keyID passed validateKeyID; cannot traverse
 	if err != nil {
 		return nil, fmt.Errorf("failed to load private key: %w", err)
 	}
 
 	// Load public key
 	publicKeyPath := filepath.Join(userDir, "id_rsa.pub")
-	publicKeyBytes, err := os.ReadFile(publicKeyPath)
+	publicKeyBytes, err := os.ReadFile(publicKeyPath) // #nosec G304 -- keyID passed validateKeyID; cannot traverse
 	if err != nil {
 		return nil, fmt.Errorf("failed to load public key: %w", err)
 	}
 
 	// Load metadata
 	metadataPath := filepath.Join(userDir, "key_metadata")
-	metadataBytes, err := os.ReadFile(metadataPath)
+	metadataBytes, err := os.ReadFile(metadataPath) // #nosec G304 -- keyID passed validateKeyID; cannot traverse
 	if err != nil {
 		return nil, fmt.Errorf("failed to load key metadata: %w", err)
 	}

--- a/test/e2e/fakeoidc/main.go
+++ b/test/e2e/fakeoidc/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -181,13 +182,39 @@ func writeState(w http.ResponseWriter, iss *testoidc.Issuer, action string) {
 	}
 	if action != "" {
 		body["action"] = action
-		log.Printf("fakeoidc: control: %s (outcome=%v username=%v groups=%v)",
-			action, body["outcome"], body["username"], body["groups"])
+		// action is this file's own literal; the other three came off a control
+		// request's query string, so they go through logSafe.
+		log.Printf("fakeoidc: control: %s (outcome=%s username=%s groups=%s)",
+			action, logSafe(body["outcome"]), logSafe(body["username"]), logSafe(body["groups"]))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		log.Printf("fakeoidc: write control response: %v", err)
 	}
+}
+
+// logSafe renders a request-supplied value as one quoted log field.
+//
+// Everything this fake logs about a request — the method, the path, the identity
+// a case asked for — is whatever the caller sent, and log.Printf writes it
+// through unaltered. A value containing a newline therefore forges log lines: a
+// path of "/token\nfakeoidc: GET /control/approve" reads, in
+// `docker compose logs fakeoidc`, as a control request nobody made. That is the
+// whole of the exposure here (this binary is a test fixture, runs unprivileged
+// in a throwaway container, and ships in no release), but the container log is
+// exactly what an engineer reads to work out why an e2e case failed, and a log
+// that can be written by the thing under test is not evidence.
+//
+// strconv.Quote is the fix rather than stripping the newlines: it escapes every
+// control character, keeps the value legible and lossless, and makes the field
+// boundaries visible, so a path with a space in it stops looking like two
+// fields. Length is bounded because a query parameter is not.
+func logSafe(v any) string {
+	s := fmt.Sprintf("%v", v)
+	if r := []rune(s); len(r) > 256 {
+		s = string(r[:256]) + "…truncated"
+	}
+	return strconv.Quote(s)
 }
 
 // splitGroups turns the groups query parameter into a claim value. An empty
@@ -207,7 +234,7 @@ func splitGroups(raw string) []string {
 // shows what the broker actually asked for when a case fails.
 func logRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("fakeoidc: %s %s", r.Method, r.URL.Path)
+		log.Printf("fakeoidc: %s %s", logSafe(r.Method), logSafe(r.URL.Path))
 		next.ServeHTTP(w, r)
 	})
 }

--- a/test/e2e/fakeoidc/main.go
+++ b/test/e2e/fakeoidc/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -182,39 +181,16 @@ func writeState(w http.ResponseWriter, iss *testoidc.Issuer, action string) {
 	}
 	if action != "" {
 		body["action"] = action
-		// action is this file's own literal; the other three came off a control
-		// request's query string, so they go through logSafe.
-		log.Printf("fakeoidc: control: %s (outcome=%s username=%s groups=%s)",
-			action, logSafe(body["outcome"]), logSafe(body["username"]), logSafe(body["groups"]))
+		// %q, not %s, for the three values that came off the control request's
+		// query string. See logRequests for why. `action` is this file's own
+		// literal, so it stays %s.
+		log.Printf("fakeoidc: control: %s (outcome=%q username=%q groups=%q)",
+			action, body["outcome"], body["username"], body["groups"])
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		log.Printf("fakeoidc: write control response: %v", err)
 	}
-}
-
-// logSafe renders a request-supplied value as one quoted log field.
-//
-// Everything this fake logs about a request — the method, the path, the identity
-// a case asked for — is whatever the caller sent, and log.Printf writes it
-// through unaltered. A value containing a newline therefore forges log lines: a
-// path of "/token\nfakeoidc: GET /control/approve" reads, in
-// `docker compose logs fakeoidc`, as a control request nobody made. That is the
-// whole of the exposure here (this binary is a test fixture, runs unprivileged
-// in a throwaway container, and ships in no release), but the container log is
-// exactly what an engineer reads to work out why an e2e case failed, and a log
-// that can be written by the thing under test is not evidence.
-//
-// strconv.Quote is the fix rather than stripping the newlines: it escapes every
-// control character, keeps the value legible and lossless, and makes the field
-// boundaries visible, so a path with a space in it stops looking like two
-// fields. Length is bounded because a query parameter is not.
-func logSafe(v any) string {
-	s := fmt.Sprintf("%v", v)
-	if r := []rune(s); len(r) > 256 {
-		s = string(r[:256]) + "…truncated"
-	}
-	return strconv.Quote(s)
 }
 
 // splitGroups turns the groups query parameter into a claim value. An empty
@@ -232,9 +208,20 @@ func splitGroups(raw string) []string {
 
 // logRequests records every OIDC request, so `docker compose logs fakeoidc`
 // shows what the broker actually asked for when a case fails.
+//
+// The method and path are whatever the caller sent, and %s writes them through
+// unaltered — so a path containing a newline forges log lines: "/token\nfakeoidc:
+// GET /control/approve" reads as a control request nobody made. This binary is a
+// test fixture, unprivileged, in a throwaway container, and ships in no release,
+// but the container log is exactly what an engineer reads to work out why an e2e
+// case failed, and a log the thing under test can write is not evidence.
+//
+// %q is the fix: it escapes every control character, keeps the value legible and
+// lossless, and makes the field boundaries visible, so a path with a space in it
+// stops looking like two fields.
 func logRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("fakeoidc: %s %s", logSafe(r.Method), logSafe(r.URL.Path))
+		log.Printf("fakeoidc: %q %q", r.Method, r.URL.Path)
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Closes #258, closes #259.

`main` carried **37 open code-scanning alerts**, none triaged: 10 Trivy, 23 gosec,
4 CodeQL. One was a real defect; the rest were noise that nothing could ever
clear. Both are worth fixing, because a Security tab that is 97% permanent noise
is one nobody reads the other 3% of.

## Trivy — #258

Every security workflow was deleted in `9b6c0ae` (Dec 2025). Code scanning
retires an alert only when the tool that raised it runs again and stops reporting
it, so removing a scanner doesn't clear its findings — it makes them **immortal**.
The ten alerts, one critical, then described dependency versions this repo no
longer has for eight months; three name `go-jose/v3`, which is in neither
`go.mod` nor `go.sum`.

Restored with the action pinned by SHA (#221). **Two details are load-bearing:**

- the job id stays `trivy`, and
- the upload passes **no `category:`**.

GitHub derives the analysis key from workflow path + job id; the orphans carry
`.github/workflows/security.yml:trivy` with no category — read off
`most_recent_instance.analysis_key`, not assumed — and retirement is
per-analysis-key. **The explicit category I proposed in #258 would have created a
new key and left all ten unclosable forever.** That's a correction to the issue,
not a deviation from it.

Run against this tree locally, the restored scan reports **none of the ten**, so
the first run on `main` reconciles and closes them.

It does report two things:

| Finding | Disposition |
|---|---|
| `CVE-2026-56855`, `CVE-2026-78662` — x/crypto ssh mux DoS, fixed in 0.56.0 | Filed separately: 0.56.0 requires `go 1.26.0`, i.e. a toolchain bump across every workflow. Neither is reachable — govulncheck is green. Not smuggled into a scanning PR. |
| `GO-2026-5932` — "x/crypto/openpgp is unmaintained", no fixed version | New `.trivyignore.yaml`, reason recorded in the repo rather than dismissed in the UI. `go list -deps ./...` does not name openpgp. |

`scanners: vuln,secret` (Trivy's filesystem default, written out as a decision);
`misconfig` stays off — the only files it has to look at are three test-harness
Dockerfiles whose containers run as root deliberately.

## gosec — #259, one real finding

**G123: certificate pinning was enforced in `VerifyPeerCertificate`, which a
resumed TLS session never calls.** From the second handshake onwards a pinned
configuration would have stopped checking its pins.

It was **not reachable** as the code stood: client-side resumption needs a
non-nil `tls.Config.ClientSessionCache`, `buildTLSConfig` sets none, and
`net/http` does not add one to a caller-supplied `TLSClientConfig`. So the pins
were enforced — but only by that absence, which no comment stated and no test
held. Adding a session cache anywhere in the request path would have silently
disabled pinning.

The check moves to `VerifyConnection`, which runs on every handshake and *does*
receive the peer chain on a resumed one. The new test installs a cache, drives
three requests, and fails unless a handshake resumed **and** the pin check ran on
all three. Reverting the fix makes it fail — which is the only reason to believe
it.

**G306:** the public half of a provisioned key pair was `0644`; its only reader
is `LoadKey` in the same process, and the directory is already `0700`.

**The other 21 are annotated, not excluded.** Five `G304` reads take a path from
root-owned config or from an identifier that already passed `validateKeyID`,
whose allowlist admits neither `/` nor `.` — recorded together with the note that
the annotations must come off if that pattern is loosened. Sixteen `G103` sites
are the two shapes cgo leaves no alternative to, in test wrappers that have
shipped in nothing since #198. No rule excluded, no directory skipped.

Verified in the configuration CI actually uses (golang:1.25 container):
**41 files checked including all six `_linux.go` files, 31 nosec (was 15),
0 issues.**

That run also explained *why* the gosec job covers `cmd/pam-module`: it doesn't
install the PAM headers, cgo fails, and `go/packages` falls back to the real
sources instead of handing gosec build-cache files. With the headers present:
6 findings at `/root/.cache/go-build` paths and the `_linux.go` files never
opened. So "fixing" that job by adding the dev packages would silently drop the
PAM module from the scan — the job now says so in a comment.

## CodeQL — #259

The e2e fake IdP logged request-controlled values unescaped, so a path or
`?username=` containing a newline could forge log lines in
`docker compose logs fakeoidc` — which is exactly what an engineer reads to find
out why a case failed. Test-harness only, unprivileged, shipped in no release,
but a log the thing under test can write is not evidence. Values go through
`strconv.Quote` with a length bound.

## Checks

- `gofmt` clean, `go build ./...`, `go vet ./...`, `go test ./...` — all pass
- `trivy fs` locally: 3 findings, all accounted for above
- gosec in a linux container, CI's configuration: 0 issues
- G123 fix mutation-tested: reverting it fails both assertions
