### PR TITLE
chore(ci): enforce main's checks on admins, protect v* tags (#214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,54 @@ jobs:
           fi
           echo "release.yml's build job is gated on the CI workflow."
 
+      # main's required status checks are named by display name, and the names live
+      # in GitHub's database (recorded in scripts/repo-settings.sh, #214). Renaming a
+      # job here therefore breaks the protection rather than following it: the old
+      # context is never reported again, so every pull request waits on a check that
+      # can no longer arrive and nothing merges until somebody thinks to look at the
+      # branch settings. Catch the rename in the pull request that makes it.
+      #
+      # Only this direction is an error. A new job that nobody added to the required
+      # list is a judgment call — perhaps deliberately advisory — and repo-settings.sh
+      # says which jobs are excluded and why.
+      - name: Check main's required checks all name a real job
+        run: |
+          yq -r '.jobs | to_entries | .[] | .value.name // .key' \
+            .github/workflows/ci.yml .github/workflows/security.yml | sort -u > /tmp/job-names
+
+          # The REQUIRED_CHECKS array in the settings script, one bare name per line.
+          awk '/^REQUIRED_CHECKS=\(/{f=1;next} /^\)/{f=0} f' scripts/repo-settings.sh \
+            | sed -e 's/#.*//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+                  -e 's/^"//' -e 's/"$//' \
+            | grep -v '^$' > /tmp/required-checks
+
+          if [ ! -s /tmp/required-checks ]; then
+            echo "::error::could not read REQUIRED_CHECKS out of scripts/repo-settings.sh"
+            exit 1
+          fi
+
+          fail=0
+          while IFS= read -r ctx; do
+            if grep -qxF "$ctx" /tmp/job-names; then
+              continue
+            fi
+            # A matrix job's check is named "<job name> (<matrix value>)" — e.g.
+            # "CodeQL Analysis (go)" from a job named "CodeQL Analysis".
+            base=$(printf '%s' "$ctx" | sed -E 's/ \([^()]*\)$//')
+            if [ "$base" != "$ctx" ] && grep -qxF "$base" /tmp/job-names; then
+              continue
+            fi
+            echo "::error::required check '${ctx}' names no job in ci.yml or security.yml. Renaming a job breaks main's branch protection — update scripts/repo-settings.sh and run 'scripts/repo-settings.sh apply'."
+            fail=1
+          done < /tmp/required-checks
+
+          if [ "$fail" -ne 0 ]; then
+            echo "job names found:"
+            cat /tmp/job-names
+            exit 1
+          fi
+          echo "All $(wc -l < /tmp/required-checks | tr -d ' ') required checks name a real job."
+
       # The installer and uninstaller decide, in shell, whether a host stays
       # loggable-in: #207 was an uninstaller that reduced /etc/pam.d/sshd to
       # `auth requisite pam_deny.so` and reported success. This exercises that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The public half of a provisioned SSH key pair is written 0600 instead of 0644
   (#259).** Its only reader is `LoadKey`, in the same process, and the enclosing
   directory is already 0700.
+- **`main` now enforces its required checks on administrators, and `v*` tags cannot
+  be created, moved or deleted below the admin role (#214).** Releases were being
+  pushed straight to `main`, and git said so out loud — v0.5.1's push reported
+  "Bypassed rule violations for refs/heads/main: 4 of 4 required status checks are
+  expected" — so each release was built, signed and published from a commit no test
+  had ever run against. The required set also grew from four jobs to thirteen: the
+  end-to-end suite, both PAM-module builds and every security scanner ran on each
+  pull request and none of them could block a merge. Separately, a `v*` tag push
+  *is* a publish (it builds, signs with a Sigstore certificate naming this
+  repository, and attaches provenance), and nothing restricted who could start one;
+  write access, or a token scoped to write and not admin, was enough to obtain
+  genuinely signed artifacts from an arbitrary commit.
 
 ### Fixed
 
@@ -53,6 +65,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   annotations must come off if it is ever loosened. No rule was excluded and no
   directory was skipped, so G103 and G304 stay live everywhere a genuinely notable
   use could appear.
+- **`scripts/release.sh` runs in two phases, with a pull request in between
+  (#214).** Phase 1 stamps the docs and opens `release/vX.Y.Z`; phase 2, after that
+  PR is rebase-merged, checks that `main` carries the release commit and then
+  creates and pushes the tag. Both halves are forced by the protections above: the
+  release commit has to arrive through a PR now, and because a rebase-merge rewrites
+  the commit, a tag created before the merge would point at something no branch
+  contains.
+- **The protections on `main` and on `v*` tags are recorded in
+  `scripts/repo-settings.sh` (#214).** They live in GitHub's database, so previously
+  nothing in the tree said what they were or why, an admin could widen them without
+  leaving a trace, and a fork came up with none of them. `show` prints what GitHub
+  has; `apply` is idempotent.
 - A `.trivyignore.yaml` records, in the repository rather than in the GitHub UI, the
   one advisory this project does not act on: `GO-2026-5932`, the module-wide
   "x/crypto/openpgp is unmaintained" notice, which has no fixed version and so would

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,28 +302,72 @@ This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 ### Cutting a release
 
 Use the release script — it is the single source of truth and keeps the README
-version badge and CHANGELOG in sync with the tag automatically:
+version strings and the CHANGELOG in sync with the tag automatically. It runs in
+two phases, with a pull request in between:
 
 ```bash
 # 1. Land all changes for the release on main, with entries under
 #    "## [Unreleased]" in CHANGELOG.md.
-# 2. From a clean checkout of main:
+
+# 2. From a clean checkout of main — stamps the docs and opens the release PR:
 scripts/release.sh 0.4.2        # leading 'v' optional
+
+# 3. Wait for the checks, then rebase-merge that PR.
+
+# 4. From a fresh main — tags the merged release commit and pushes the tag:
+git checkout main && git pull
+scripts/release.sh --tag 0.4.2
 ```
 
-The script stamps the README badge, rolls `## [Unreleased]` into a dated
-`## [0.4.2]` section, commits `chore(release): v0.4.2`, creates the annotated tag,
-and (after confirmation) pushes both. Pushing the tag triggers the Release
-workflow, which **verifies** the tag, README badge, and CHANGELOG agree before
-building and publishing multi-arch artifacts. A manual tag whose docs are out of
-sync will fail that check.
+Phase 1 stamps the README version badge, the `VERSION=v0.4.2` download snippet,
+the roadmap heading and the status line, rolls `## [Unreleased]` into a dated
+`## [0.4.2]` section, commits `chore(release): v0.4.2` on `release/v0.4.2`, and
+opens the pull request. Phase 2 checks that `main` really does carry that commit
+— badge, snippet, CHANGELOG heading and commit subject — then creates the
+annotated tag and pushes it.
+
+Pushing the tag is what triggers the Release workflow, which re-verifies that the
+tag, the four README strings and the CHANGELOG agree, runs the full CI suite, and
+only then builds, signs and publishes the artifacts. A manual tag whose docs are
+out of sync fails that check.
+
+**Why two phases.** `main` enforces its required checks on admins too
+(`scripts/repo-settings.sh`), so the release commit cannot be pushed straight to
+it — it goes through a pull request like every other change. That is the point:
+the old single-phase flow published releases from a commit no test had ever run
+against. And because this repository rebase-merges, the merge rewrites the
+commit: a tag created before the merge would point at a commit that is not on
+`main`, so the release would be built and signed from something no branch
+contains. Hence the tag waits for phase 2.
 
 ### Release Checklist
 
 - [ ] All changes merged to `main` with entries under `## [Unreleased]`
 - [ ] All tests pass on `main`
-- [ ] `scripts/release.sh <version>` run (stamps README + CHANGELOG, tags, pushes)
+- [ ] `scripts/release.sh <version>` run (stamps README + CHANGELOG, opens the PR)
+- [ ] Release PR checks green, **rebase**-merged, `main` pulled
+- [ ] `scripts/release.sh --tag <version>` run (tags the merged commit, pushes)
 - [ ] Release workflow green; GitHub release and artifacts published
+
+### Repository settings
+
+The protections on `main` and on `v*` tags are recorded in
+`scripts/repo-settings.sh` — what they are and why each one is there:
+
+```bash
+scripts/repo-settings.sh show     # what GitHub has right now
+scripts/repo-settings.sh apply    # make GitHub match the script (idempotent)
+```
+
+They live in GitHub's database rather than in the tree, which means nothing
+otherwise records them, an admin can widen them without leaving a trace, and a
+fork or a restored repository comes up with none of them. Change them by editing
+that script and running `apply`, not through the web UI — otherwise the file
+stops being true, which is worse than not having it.
+
+In short: `main` takes no direct pushes and requires every CI and security job,
+including of admins; `v*` tags cannot be created, moved or deleted by anyone
+below admin, because pushing one publishes signed artifacts.
 
 ## Community
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,21 +1,49 @@
 #!/usr/bin/env bash
 #
-# Cut a release: stamp the README version badge and the CHANGELOG, commit, create
-# an annotated tag, and push. Tagging this way guarantees the README/CHANGELOG in
-# the tagged commit always match the version (no manual sync drift).
+# Cut a release, in two phases:
 #
-# Usage:
-#   scripts/release.sh <version>
+#   scripts/release.sh <version>        # 1. stamp the docs, commit on a release
+#                                       #    branch, push it, open the PR
+#   scripts/release.sh --tag <version>  # 2. once that PR has merged: tag main
+#
 # Example:
-#   scripts/release.sh 0.4.2          # leading 'v' optional
+#   scripts/release.sh 0.4.2            # leading 'v' optional
+#   scripts/release.sh --tag 0.4.2
+#
+# Why two phases, when this used to be one push.
+#
+# `main` requires its status checks of everyone, admins included (#214), so the
+# release commit cannot be pushed straight to it any more — it goes through a PR
+# like every other change. That is the point: the previous flow published a
+# release from a commit no test had ever run against, and the v0.5.1 push said so
+# out loud ("Bypassed rule violations for refs/heads/main: 4 of 4 required status
+# checks are expected").
+#
+# The tag then has to wait for the merge, and not for bureaucratic reasons: this
+# repository rebase-merges, which rewrites the commit. A tag created in phase 1
+# would point at a commit that is not on main, so the release workflow would
+# build, sign and publish something no branch contains — and `git describe` on
+# main would never find it. Phase 2 tags merged main after checking that main
+# really does carry the release commit for this version.
+#
+# Tagging from the stamped commit is still what keeps the README badge, the
+# download snippet and the CHANGELOG heading in agreement with the tag; phase 2
+# now verifies that rather than assuming it.
 #
 # Preconditions: clean working tree on the default branch, a "## [Unreleased]"
-# section in CHANGELOG.md with content, and push access.
+# section in CHANGELOG.md with content, push access, and `gh` authenticated.
 
 set -euo pipefail
 
+MODE="prepare"
+if [[ "${1:-}" == "--tag" ]]; then
+  MODE="tag"
+  shift
+fi
+
 if [[ $# -ne 1 ]]; then
-  echo "usage: $0 <version>   (e.g. $0 0.4.2)" >&2
+  echo "usage: $0 <version>          (e.g. $0 0.4.2)" >&2
+  echo "       $0 --tag <version>    (after the release PR has merged)" >&2
   exit 2
 fi
 
@@ -31,14 +59,95 @@ fi
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-# --- preconditions -----------------------------------------------------------
+RELEASE_BRANCH="release/${TAG}"
+
+# The branch the release is cut from, as origin reports it rather than as this
+# script assumes it.
+DEFAULT_BRANCH="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+# --- preconditions shared by both phases -------------------------------------
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "error: working tree is not clean; commit or stash first" >&2
   exit 1
 fi
 
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "$DEFAULT_BRANCH" ]]; then
+  echo "error: on branch '${BRANCH}'; releases are cut from '${DEFAULT_BRANCH}'" >&2
+  exit 1
+fi
+
 if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-  echo "error: tag ${TAG} already exists" >&2
+  echo "error: tag ${TAG} already exists locally" >&2
+  exit 1
+fi
+
+git fetch --quiet origin "${DEFAULT_BRANCH}" --tags
+
+if [[ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]]; then
+  echo "error: tag ${TAG} already exists on origin" >&2
+  exit 1
+fi
+
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/${DEFAULT_BRANCH}")" ]]; then
+  echo "error: ${DEFAULT_BRANCH} is not level with origin/${DEFAULT_BRANCH}; pull or push first" >&2
+  exit 1
+fi
+
+# --- phase 2: tag merged main -------------------------------------------------
+# Everything here is a check that the commit about to be tagged is the release
+# commit for this version. A tag on the wrong commit is not a cosmetic mistake:
+# the release workflow builds, signs and attests whatever the tag points at, and
+# the attestation then says that artifact came from this repository at that
+# commit — truthfully, about the wrong code.
+if [[ "$MODE" == "tag" ]]; then
+  if ! grep -q "badge/Version-${VER}-blue" README.md; then
+    echo "error: README's version badge does not read ${VER}; is the release PR merged?" >&2
+    exit 1
+  fi
+  if ! grep -qx "VERSION=${TAG}" README.md; then
+    echo "error: README's download snippet does not read VERSION=${TAG}" >&2
+    exit 1
+  fi
+  if ! grep -q "^## \[${VER}\] - " CHANGELOG.md; then
+    echo "error: CHANGELOG.md has no '## [${VER}] - <date>' section" >&2
+    exit 1
+  fi
+
+  SUBJECT="$(git log -1 --format=%s)"
+  if [[ "$SUBJECT" != "chore(release): ${TAG}" ]]; then
+    echo "error: HEAD is '${SUBJECT}', not 'chore(release): ${TAG}'" >&2
+    echo "       Phase 2 tags the release commit itself, so that the tag, the README" >&2
+    echo "       and the CHANGELOG cannot disagree. Rebase-merge the release PR and" >&2
+    echo "       pull, then run this again." >&2
+    exit 1
+  fi
+
+  git tag -a "${TAG}" -m "oidc-pam ${TAG}"
+  echo
+  echo "Tagged ${TAG} at $(git rev-parse --short HEAD) on ${DEFAULT_BRANCH}:"
+  git --no-pager show --stat --oneline HEAD | head -20
+  echo
+  read -r -p "Push tag ${TAG} to origin? [y/N] " ans
+  if [[ "${ans:-}" =~ ^[Yy]$ ]]; then
+    git push origin "${TAG}"
+    echo "Pushed ${TAG}. The release workflow will run the CI set, then build, sign"
+    echo "and publish the artifacts."
+  else
+    echo "Not pushed. To undo locally: git tag -d ${TAG}"
+  fi
+  exit 0
+fi
+
+# --- phase 1: stamp the docs and open the release PR -------------------------
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh is not installed; it is needed to open the release PR" >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/heads/${RELEASE_BRANCH}" >/dev/null; then
+  echo "error: branch ${RELEASE_BRANCH} already exists; delete it or finish that release" >&2
   exit 1
 fi
 
@@ -117,21 +226,47 @@ awk -v ver="$VER" -v date="$TODAY" '
   { print }
 ' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
 
-# --- commit, tag, push -------------------------------------------------------
+# --- commit on a release branch and open the PR ------------------------------
+git checkout -q -b "${RELEASE_BRANCH}"
 git add README.md CHANGELOG.md
-git commit -m "chore(release): ${TAG}"
-git tag -a "${TAG}" -m "oidc-pam ${TAG}"
+git commit -q -m "chore(release): ${TAG}"
 
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 echo
-echo "Prepared ${TAG} on branch '${BRANCH}':"
+echo "Prepared ${TAG} on branch '${RELEASE_BRANCH}':"
 git --no-pager show --stat --oneline HEAD | head -20
 echo
-read -r -p "Push commit and tag to origin? [y/N] " ans
-if [[ "${ans:-}" =~ ^[Yy]$ ]]; then
-  git push origin "${BRANCH}"
-  git push origin "${TAG}"
-  echo "Pushed ${TAG}. The release workflow will build artifacts and publish the GitHub release."
-else
-  echo "Not pushed. To undo locally: git tag -d ${TAG} && git reset --hard HEAD~1"
+read -r -p "Push ${RELEASE_BRANCH} and open the release PR? [y/N] " ans
+if ! [[ "${ans:-}" =~ ^[Yy]$ ]]; then
+  echo "Not pushed. To undo locally:"
+  echo "  git checkout ${DEFAULT_BRANCH} && git branch -D ${RELEASE_BRANCH}"
+  exit 0
 fi
+
+git push -q -u origin "${RELEASE_BRANCH}"
+gh pr create \
+  --base "${DEFAULT_BRANCH}" \
+  --head "${RELEASE_BRANCH}" \
+  --title "chore(release): ${TAG}" \
+  --body "$(cat <<EOF
+Stamps the README version badge, the \`VERSION=${TAG}\` download snippet, the
+roadmap heading and the status line, and rolls \`## [Unreleased]\` into
+\`## [${VER}] - ${TODAY}\`.
+
+Generated by \`scripts/release.sh ${VER}\`. No code changes.
+
+Once this is **rebase-merged** and \`${DEFAULT_BRANCH}\` is pulled:
+
+\`\`\`bash
+scripts/release.sh --tag ${VER}
+\`\`\`
+
+That tags the merged release commit and pushes the tag, which is what triggers
+the release workflow. The tag is deliberately not created before the merge: a
+rebase-merge rewrites the commit, so a tag made now would point at a commit that
+is not on \`${DEFAULT_BRANCH}\`.
+EOF
+)"
+
+echo
+echo "Next: wait for the checks, rebase-merge the PR, then:"
+echo "  git checkout ${DEFAULT_BRANCH} && git pull && scripts/release.sh --tag ${VER}"

--- a/scripts/repo-settings.sh
+++ b/scripts/repo-settings.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# The branch- and tag-protection settings for this repository, written down.
+#
+#   scripts/repo-settings.sh show    # what GitHub has right now
+#   scripts/repo-settings.sh apply   # make GitHub match this file
+#
+# Why this exists. These settings live in GitHub's database, not in the tree, so
+# nothing records what they are or why (#214). Anyone with admin can widen them
+# with two clicks and leave no trace, a restored or forked repository comes up
+# with none of them, and a reviewer reading this repository cannot tell whether
+# the release path is gated at all. `apply` is idempotent, so this file is both
+# the record and the way to restore it.
+#
+# Requires `gh` authenticated as a repository admin.
+#
+# If a setting here ever locks out something legitimate, it is a fast fix, not an
+# emergency: an admin can still delete the ruleset or the branch protection
+# through the API (permission to administer a rule is separate from exemption
+# from it), so the worst case is a rejected push and a minute of work.
+
+set -euo pipefail
+
+REPO="scttfrdmn/oidc-pam"
+BRANCH="main"
+RULESET_NAME="Protect release tags"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh is not installed" >&2
+  exit 1
+fi
+
+# --- required status checks ---------------------------------------------------
+# Every job a pull request has to clear before it can reach main. This list used
+# to be Test/Lint/Validate/Build only: the end-to-end suite, both PAM-module
+# builds and every security scanner ran on each pull request and none of them
+# could block a merge, so a red e2e run was advisory (#214).
+#
+# These are the *job* checks. The four code-scanning result checks (`CodeQL`,
+# `gosec`, `Trivy`, `Semgrep OSS`) are deliberately not here: a required check
+# that is only created when its tool uploads results blocks a merge forever on
+# the run where the upload does not happen, and the jobs that produce those
+# uploads are required already. `OpenSSF Scorecard` is excluded because its
+# companion `Scorecard` check reports `neutral` ("skipping") on pull requests,
+# and `security/snyk` because it is a third-party status that is often absent
+# altogether — either would stall merges for reasons unrelated to the change.
+REQUIRED_CHECKS=(
+  # ci.yml
+  "Test"
+  "Lint"
+  "Validate"
+  "Build"
+  "End-to-end (SSH + PAM)"   # the suite that exercises a real sshd and PAM stack
+  "PAM (cgo)"                # the module actually compiling against libpam
+  "macOS (no PAM headers)"   # the build-tag split still holding on a host with no PAM
+  # security.yml
+  "CodeQL Analysis (go)"
+  "Gosec Security Scanner"
+  "Go Vulnerability Check"
+  "Semgrep Security Scan"
+  "Trivy Security Scan"
+  "Dependency Review"
+)
+
+show() {
+  echo "== branch protection: ${BRANCH} =="
+  gh api "/repos/${REPO}/branches/${BRANCH}/protection" --jq '{
+    enforce_admins: .enforce_admins.enabled,
+    strict: .required_status_checks.strict,
+    contexts: .required_status_checks.contexts,
+    required_reviews: (.required_pull_request_reviews // null),
+    allow_force_pushes: .allow_force_pushes.enabled,
+    allow_deletions: .allow_deletions.enabled
+  }'
+  echo
+  echo "== rulesets =="
+  gh api "/repos/${REPO}/rulesets" --jq 'if length == 0 then "(none)" else .[] | {id, name, target, enforcement} end'
+}
+
+apply() {
+  # --- main ------------------------------------------------------------------
+  # enforce_admins: true is the substantive change here. Without it the settings
+  # below describe what contributors must do and what the maintainer may skip,
+  # and the maintainer was skipping it: v0.5.1 was pushed straight to main and
+  # git said so — "Bypassed rule violations for refs/heads/main: 4 of 4 required
+  # status checks are expected". A release built from a commit no test ran
+  # against is exactly the commit that most needs the tests.
+  #
+  # This is why scripts/release.sh is two-phase: with admins enforced, the
+  # release commit has to arrive through a pull request like any other.
+  #
+  # required_pull_request_reviews stays null on purpose. A pull request is
+  # required by GitHub's own rules once direct pushes are blocked, but *approval*
+  # is not required, because GitHub will not let an author approve their own pull
+  # request and this project has one maintainer: requiring a review would mean
+  # nothing could ever merge. If a second maintainer joins, set
+  # required_approving_review_count to 1 here.
+  #
+  # strict: true keeps "branch must be up to date" — the reason a PR that passed
+  # in isolation still gets re-run against current main before merging.
+  local checks_json
+  checks_json="$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s .)"
+
+  echo "== applying branch protection to ${BRANCH} =="
+  jq -n --argjson contexts "$checks_json" '{
+    required_status_checks: { strict: true, contexts: $contexts },
+    enforce_admins: true,
+    required_pull_request_reviews: null,
+    restrictions: null,
+    allow_force_pushes: false,
+    allow_deletions: false
+  }' | gh api -X PUT "/repos/${REPO}/branches/${BRANCH}/protection" --input - >/dev/null
+  echo "ok"
+
+  # --- v* tags ---------------------------------------------------------------
+  # A push of a v* tag is a publish: .github/workflows/release.yml builds from
+  # it, signs the artifacts with a Sigstore certificate naming this repository,
+  # attaches SLSA provenance, and creates the GitHub release (#180). Nothing
+  # restricted who could start that. Anyone with write access — a future
+  # collaborator, or a token scoped to write and not admin — could push a v*
+  # tag at any commit and get genuinely signed artifacts out of it, whose
+  # signature would verify.
+  #
+  # `update` and `deletion` matter as much as `creation`: a moved tag would make
+  # the signature and the provenance describe code that is no longer there, and
+  # a deleted-and-recreated tag is a moved tag with extra steps.
+  #
+  # The bypass is the admin repository role, so releasing still works for a
+  # maintainer. That is a real limitation and not a loophole to be embarrassed
+  # about: it stops the write-access and stolen-write-token cases, not an admin.
+  # Closing the admin case means moving tag creation into a workflow, which is a
+  # different piece of work.
+  echo "== applying tag ruleset: ${RULESET_NAME} =="
+  local body existing
+  body="$(jq -n --arg name "$RULESET_NAME" '{
+    name: $name,
+    target: "tag",
+    enforcement: "active",
+    bypass_actors: [
+      { actor_id: 5, actor_type: "RepositoryRole", bypass_mode: "always" }
+    ],
+    conditions: { ref_name: { include: ["refs/tags/v*"], exclude: [] } },
+    rules: [
+      { type: "creation" },
+      { type: "update" },
+      { type: "deletion" }
+    ]
+  }')"
+
+  existing="$(gh api "/repos/${REPO}/rulesets" --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id" || true)"
+  if [[ -n "$existing" ]]; then
+    printf '%s' "$body" | gh api -X PUT "/repos/${REPO}/rulesets/${existing}" --input - >/dev/null
+    echo "ok (updated ruleset ${existing})"
+  else
+    printf '%s' "$body" | gh api -X POST "/repos/${REPO}/rulesets" --input - >/dev/null
+    echo "ok (created)"
+  fi
+
+  echo
+  show
+}
+
+case "${1:-}" in
+  show) show ;;
+  apply) apply ;;
+  *)
+    echo "usage: $0 show|apply" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Closes the code half of #214 items 2–4. The settings themselves get applied after
this merges, because item 3 cannot be flipped on its own — `enforce_admins: true`
breaks the current release flow.

### What was wrong

`scripts/release.sh` pushed the release commit straight to `main`, and v0.5.1's
push reported it:

```
Bypassed rule violations for refs/heads/main:
  4 of 4 required status checks are expected
```

So every release was built, signed and published from a commit no test had ever
run against. And a `v*` tag push *is* a publish — it builds, signs with a
Sigstore certificate naming this repository, and attaches provenance — with
nothing restricting who could start one.

### Changes

- **`scripts/release.sh` is two-phase.** Phase 1 stamps the docs, commits on
  `release/vX.Y.Z` and opens the PR. Phase 2 (`--tag`), after that PR is
  **rebase**-merged, checks that `main` carries the release commit — badge,
  `VERSION=` snippet, CHANGELOG heading, commit subject — then creates and pushes
  the annotated tag. The tag waits for the merge for a second reason: a
  rebase-merge rewrites the commit, so a tag made in phase 1 would point at
  something no branch contains.
- **`scripts/repo-settings.sh`** is the record #214 asks for — `show` plus an
  idempotent `apply`, with each choice's reason beside it.
- **A new `Validate` step** asserts every name in `REQUIRED_CHECKS` still matches
  a job in `ci.yml`/`security.yml`. Required checks are named by display name, so
  renaming a job silently breaks the protection: the old context is never
  reported again and every PR waits forever on a check that cannot arrive.
- CONTRIBUTING's Release Process, Release Checklist and a new Repository Settings
  section; CHANGELOG entries.

### Settings that get applied after merge

`enforce_admins: true` on `main`; required contexts 4 → 13 (adding the e2e suite,
both PAM-module builds, and every security scanner); a `Protect release tags`
ruleset over `refs/tags/v*` blocking creation, update and deletion below admin.

Deliberately **not** required: the four code-scanning result checks (`CodeQL`,
`gosec`, `Trivy`, `Semgrep OSS`) — a required check created only when its tool
uploads results blocks merges forever on the run where the upload does not
happen, and the jobs producing those uploads are required already; `OpenSSF
Scorecard`, whose companion `Scorecard` check reports `neutral` on PRs; and
`security/snyk`, a third-party status that is often absent.
`required_pull_request_reviews` stays null — GitHub will not let an author
approve their own PR, and this project has one maintainer, so requiring a review
would mean nothing could ever merge.

### Verification

Two-phase `release.sh` exercised end to end in a scratch clone against a bare
origin: all four README strings and the CHANGELOG roll correctly; phase 2 refuses
from the release branch, refuses on un-merged `main`, refuses when the tag
already exists, and tags the right commit once `main` carries it. The new
Validate step passes on the current job names and fails on a deliberately
misspelled one. Both scripts are shellcheck-clean at `--severity=warning`.

This PR is also the first test of the flow it documents: it has to go through the
same gate.